### PR TITLE
Add 106 tests for utilities, collision, damage, and entity types

### DIFF
--- a/src/data/collision/__spec__/collisionMask.spec.ts
+++ b/src/data/collision/__spec__/collisionMask.spec.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from "vitest";
+import { CollisionMask } from "../collisionMask";
+
+describe("CollisionMask", () => {
+  describe("forRect", () => {
+    it("creates a mask with correct dimensions", () => {
+      const mask = CollisionMask.forRect(10, 5);
+      expect(mask.width).toBe(10);
+      expect(mask.height).toBe(5);
+    });
+
+    it("creates a 1x1 mask", () => {
+      const mask = CollisionMask.forRect(1, 1);
+      expect(mask.width).toBe(1);
+      expect(mask.height).toBe(1);
+      expect(mask.collidesWithPoint(0, 0)).toBe(true);
+    });
+
+    it("creates a mask wider than 32 bits", () => {
+      const mask = CollisionMask.forRect(64, 2);
+      expect(mask.width).toBe(64);
+      expect(mask.collidesWithPoint(0, 0)).toBe(true);
+      expect(mask.collidesWithPoint(63, 1)).toBe(true);
+    });
+
+    it("fills all pixels within the rect", () => {
+      const mask = CollisionMask.forRect(8, 4);
+      for (let y = 0; y < 4; y++) {
+        for (let x = 0; x < 8; x++) {
+          expect(mask.collidesWithPoint(x, y)).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe("collidesWithPoint", () => {
+    it("returns true for a point inside a filled mask", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(5, 5)).toBe(true);
+    });
+
+    it("returns false for negative x", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(-1, 5)).toBe(false);
+    });
+
+    it("returns false for negative y", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(5, -1)).toBe(false);
+    });
+
+    it("returns true at x=0, y=0", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(0, 0)).toBe(true);
+    });
+
+    it("returns true at max boundary", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(9, 9)).toBe(true);
+    });
+
+    it("returns false at x=width", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(10, 5)).toBe(false);
+    });
+
+    it("returns false at y=height", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(5, 10)).toBe(false);
+    });
+
+    it("detects cleared bits after subtract", () => {
+      const big = CollisionMask.forRect(10, 10);
+      const small = CollisionMask.forRect(2, 2);
+      big.subtract(small, 3, 3);
+      expect(big.collidesWithPoint(3, 3)).toBe(false);
+      expect(big.collidesWithPoint(4, 4)).toBe(false);
+      expect(big.collidesWithPoint(5, 5)).toBe(true);
+    });
+  });
+
+  describe("collidesWith", () => {
+    it("detects collision for overlapping masks", () => {
+      const a = CollisionMask.forRect(10, 10);
+      const b = CollisionMask.forRect(10, 10);
+      expect(a.collidesWith(b, 0, 0)).toBe(true);
+    });
+
+    it("returns false for non-overlapping masks (x)", () => {
+      const a = CollisionMask.forRect(5, 5);
+      const b = CollisionMask.forRect(5, 5);
+      expect(a.collidesWith(b, 10, 0)).toBe(false);
+    });
+
+    it("returns false for non-overlapping masks (y)", () => {
+      const a = CollisionMask.forRect(5, 5);
+      const b = CollisionMask.forRect(5, 5);
+      expect(a.collidesWith(b, 0, 10)).toBe(false);
+    });
+
+    it("detects partial overlap", () => {
+      const a = CollisionMask.forRect(10, 10);
+      const b = CollisionMask.forRect(10, 10);
+      expect(a.collidesWith(b, 5, 5)).toBe(true);
+    });
+
+    it("handles negative dx by swapping", () => {
+      const a = CollisionMask.forRect(10, 10);
+      const b = CollisionMask.forRect(10, 10);
+      expect(a.collidesWith(b, -5, 0)).toBe(true);
+    });
+
+    it("handles negative dy (other above)", () => {
+      const a = CollisionMask.forRect(10, 10);
+      const b = CollisionMask.forRect(10, 10);
+      expect(a.collidesWith(b, 0, -5)).toBe(true);
+    });
+
+    it("returns false when dx exceeds width", () => {
+      const a = CollisionMask.forRect(5, 5);
+      const b = CollisionMask.forRect(5, 5);
+      expect(a.collidesWith(b, 6, 0)).toBe(false);
+    });
+
+    it("returns false when other is completely above", () => {
+      const a = CollisionMask.forRect(5, 5);
+      const b = CollisionMask.forRect(5, 5);
+      expect(a.collidesWith(b, 0, -6)).toBe(false);
+    });
+
+    it("detects collision with 1x1 masks at same position", () => {
+      const a = CollisionMask.forRect(1, 1);
+      const b = CollisionMask.forRect(1, 1);
+      expect(a.collidesWith(b, 0, 0)).toBe(true);
+    });
+
+    it("works with masks wider than 32 pixels", () => {
+      const a = CollisionMask.forRect(64, 10);
+      const b = CollisionMask.forRect(10, 10);
+      expect(a.collidesWith(b, 50, 0)).toBe(true);
+    });
+  });
+
+  describe("add", () => {
+    it("sets bits in the target mask", () => {
+      const target = CollisionMask.forRect(10, 10);
+      target.subtract(CollisionMask.forRect(10, 10), 0, 0); // clear all
+      const small = CollisionMask.forRect(3, 3);
+      target.add(small, 2, 2);
+      expect(target.collidesWithPoint(2, 2)).toBe(true);
+      expect(target.collidesWithPoint(4, 4)).toBe(true);
+    });
+
+    it("does not affect bits outside the added region", () => {
+      const target = CollisionMask.forRect(10, 10);
+      target.subtract(CollisionMask.forRect(10, 10), 0, 0); // clear all
+      const small = CollisionMask.forRect(2, 2);
+      target.add(small, 5, 5);
+      expect(target.collidesWithPoint(0, 0)).toBe(false);
+      expect(target.collidesWithPoint(5, 5)).toBe(true);
+    });
+
+    it("is cumulative", () => {
+      const target = CollisionMask.forRect(10, 10);
+      target.subtract(CollisionMask.forRect(10, 10), 0, 0);
+      const dot = CollisionMask.forRect(1, 1);
+      target.add(dot, 0, 0);
+      target.add(dot, 9, 9);
+      expect(target.collidesWithPoint(0, 0)).toBe(true);
+      expect(target.collidesWithPoint(9, 9)).toBe(true);
+      expect(target.collidesWithPoint(5, 5)).toBe(false);
+    });
+  });
+
+  describe("subtract", () => {
+    it("clears bits in the target mask", () => {
+      const target = CollisionMask.forRect(10, 10);
+      const hole = CollisionMask.forRect(2, 2);
+      target.subtract(hole, 4, 4);
+      expect(target.collidesWithPoint(4, 4)).toBe(false);
+      expect(target.collidesWithPoint(5, 5)).toBe(false);
+    });
+
+    it("does not affect bits outside the subtracted region", () => {
+      const target = CollisionMask.forRect(10, 10);
+      const hole = CollisionMask.forRect(2, 2);
+      target.subtract(hole, 4, 4);
+      expect(target.collidesWithPoint(0, 0)).toBe(true);
+      expect(target.collidesWithPoint(9, 9)).toBe(true);
+    });
+
+    it("subtracting from empty is no-op", () => {
+      const target = CollisionMask.forRect(10, 10);
+      target.subtract(CollisionMask.forRect(10, 10), 0, 0);
+      target.subtract(CollisionMask.forRect(5, 5), 2, 2); // subtract again
+      expect(target.collidesWithPoint(3, 3)).toBe(false); // still clear
+    });
+  });
+
+  describe("difference", () => {
+    it("returns empty mask for identical overlap", () => {
+      const a = CollisionMask.forRect(8, 8);
+      const b = CollisionMask.forRect(8, 8);
+      const diff = a.difference(b, 0, 0);
+      // All bits of b are covered by a, so difference should be empty
+      for (let y = 0; y < 8; y++) {
+        for (let x = 0; x < 8; x++) {
+          expect(diff.collidesWithPoint(x, y)).toBe(false);
+        }
+      }
+    });
+
+    it("returns full other mask when no overlap", () => {
+      const a = CollisionMask.forRect(5, 5);
+      a.subtract(CollisionMask.forRect(5, 5), 0, 0); // empty mask
+      const b = CollisionMask.forRect(5, 5);
+      const diff = a.difference(b, 0, 0);
+      expect(diff.collidesWithPoint(0, 0)).toBe(true);
+      expect(diff.collidesWithPoint(4, 4)).toBe(true);
+    });
+
+    it("has correct dimensions matching other mask", () => {
+      const a = CollisionMask.forRect(20, 20);
+      const b = CollisionMask.forRect(5, 5);
+      const diff = a.difference(b, 3, 3);
+      expect(diff.width).toBe(5);
+      expect(diff.height).toBe(5);
+    });
+  });
+
+  describe("clone", () => {
+    it("has same dimensions", () => {
+      const original = CollisionMask.forRect(15, 20);
+      const cloned = original.clone();
+      expect(cloned.width).toBe(15);
+      expect(cloned.height).toBe(20);
+    });
+
+    it("has identical collision behavior", () => {
+      const original = CollisionMask.forRect(10, 10);
+      const hole = CollisionMask.forRect(2, 2);
+      original.subtract(hole, 3, 3);
+      const cloned = original.clone();
+      expect(cloned.collidesWithPoint(0, 0)).toBe(true);
+      expect(cloned.collidesWithPoint(3, 3)).toBe(false);
+    });
+
+    it("is independent — modifying clone does not affect original", () => {
+      const original = CollisionMask.forRect(10, 10);
+      const cloned = original.clone();
+      cloned.subtract(CollisionMask.forRect(10, 10), 0, 0);
+      expect(original.collidesWithPoint(5, 5)).toBe(true);
+      expect(cloned.collidesWithPoint(5, 5)).toBe(false);
+    });
+  });
+
+  describe("serialize / deserialize", () => {
+    it("round-trips dimensions", () => {
+      const original = CollisionMask.forRect(15, 20);
+      const serialized = original.serialize();
+      const restored = CollisionMask.deserialize({
+        width: serialized.width,
+        height: serialized.height,
+        mask: serialized.mask.map((buf) => new Uint8Array(buf)),
+      });
+      expect(restored.width).toBe(15);
+      expect(restored.height).toBe(20);
+    });
+
+    it("round-trips collision behavior", () => {
+      const original = CollisionMask.forRect(10, 10);
+      original.subtract(CollisionMask.forRect(2, 2), 4, 4);
+
+      const serialized = original.serialize();
+      const restored = CollisionMask.deserialize({
+        width: serialized.width,
+        height: serialized.height,
+        mask: serialized.mask.map((buf) => new Uint8Array(buf)),
+      });
+
+      expect(restored.collidesWithPoint(0, 0)).toBe(true);
+      expect(restored.collidesWithPoint(4, 4)).toBe(false);
+      expect(restored.collidesWithPoint(9, 9)).toBe(true);
+    });
+  });
+
+  describe("fromAlpha", () => {
+    it("sets bits for pixels with alpha > 128", () => {
+      const data = {
+        width: 4,
+        height: 1,
+        data: new Uint8ClampedArray([
+          0, 0, 0, 255, // alpha 255 → set
+          0, 0, 0, 0, // alpha 0 → unset
+          0, 0, 0, 129, // alpha 129 → set
+          0, 0, 0, 128, // alpha 128 → unset
+        ]),
+      } as unknown as ImageData;
+
+      const mask = CollisionMask.fromAlpha(data);
+      expect(mask.collidesWithPoint(0, 0)).toBe(true);
+      expect(mask.collidesWithPoint(1, 0)).toBe(false);
+      expect(mask.collidesWithPoint(2, 0)).toBe(true);
+      expect(mask.collidesWithPoint(3, 0)).toBe(false);
+    });
+  });
+
+  describe("fromColor", () => {
+    it("sets bits for pixels with red channel = 0", () => {
+      const data = {
+        width: 3,
+        height: 1,
+        data: new Uint8ClampedArray([
+          0, 255, 255, 255, // red 0 → set
+          255, 0, 0, 255, // red 255 → unset
+          0, 0, 0, 0, // red 0 → set
+        ]),
+      } as unknown as ImageData;
+
+      const mask = CollisionMask.fromColor(data);
+      expect(mask.collidesWithPoint(0, 0)).toBe(true);
+      expect(mask.collidesWithPoint(1, 0)).toBe(false);
+      expect(mask.collidesWithPoint(2, 0)).toBe(true);
+    });
+  });
+});

--- a/src/data/collision/__spec__/collisionMask.spec.ts
+++ b/src/data/collision/__spec__/collisionMask.spec.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { CollisionMask } from "../collisionMask";
 
 describe("CollisionMask", () => {

--- a/src/data/damage/__spec__/genericDamage.spec.ts
+++ b/src/data/damage/__spec__/genericDamage.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { GenericDamage } from "../genericDamage";
+import { TargetList } from "../targetList";
+import { DamageSourceType } from "../types";
+import { HurtableEntity, TickingEntity } from "../../entity/types";
+
+function createMockEntity(id: number): HurtableEntity {
+  return {
+    id,
+    hp: 100,
+    getCenter: () => [0, 0] as [number, number],
+    damage: vi.fn(),
+    die: vi.fn(),
+    body: {} as any,
+  } as unknown as HurtableEntity;
+}
+
+describe("GenericDamage", () => {
+  it("has type Generic", () => {
+    const damage = new GenericDamage(new TargetList());
+    expect(damage.type).toBe(DamageSourceType.Generic);
+  });
+
+  it("has null cause by default", () => {
+    const damage = new GenericDamage(new TargetList());
+    expect(damage.cause).toBeNull();
+  });
+
+  describe("getTargets", () => {
+    it("returns the TargetList passed to constructor", () => {
+      const targets = new TargetList();
+      const damage = new GenericDamage(targets);
+      expect(damage.getTargets()).toBe(targets);
+    });
+  });
+
+  describe("damage", () => {
+    it("delegates to TargetList.damage with itself as source", () => {
+      const entity = createMockEntity(1);
+      const entityMap = new Map<number, TickingEntity>([
+        [1, entity as unknown as TickingEntity],
+      ]);
+
+      const targets = new TargetList();
+      targets.add(entity, 25);
+
+      const damage = new GenericDamage(targets);
+
+      // Call damage with explicit entityMap (avoids needing mock context)
+      targets.damage(damage, entityMap);
+      expect(entity.damage).toHaveBeenCalledWith(damage, 25, undefined);
+    });
+  });
+
+  describe("serialize / deserialize", () => {
+    it("round-trips an empty TargetList", () => {
+      const original = new GenericDamage(new TargetList());
+      const serialized = original.serialize();
+      const restored = GenericDamage.deserialize(serialized);
+      expect(restored.getTargets().hasEntities()).toBe(false);
+    });
+
+    it("round-trips a TargetList with targets", () => {
+      const entity = createMockEntity(5);
+      const targets = new TargetList();
+      targets.add(entity, 30);
+
+      const original = new GenericDamage(targets);
+      const serialized = original.serialize();
+      const restored = GenericDamage.deserialize(serialized);
+
+      expect(restored.getTargets().hasEntities()).toBe(true);
+      expect(restored.serialize()).toEqual(serialized);
+    });
+
+    it("round-trips a TargetList with force", () => {
+      const entity = createMockEntity(3);
+      const targets = new TargetList();
+      targets.add(entity, 20, { power: 5, direction: 1.5 });
+
+      const original = new GenericDamage(targets);
+      const serialized = original.serialize();
+      const restored = GenericDamage.deserialize(serialized);
+
+      expect(restored.serialize()).toEqual(serialized);
+    });
+  });
+});

--- a/src/data/damage/__spec__/impactDamage.spec.ts
+++ b/src/data/damage/__spec__/impactDamage.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ImpactDamage } from "../impactDamage";
+import { TargetList } from "../targetList";
+import { DamageSourceType } from "../types";
+import { HurtableEntity } from "../../entity/types";
+import {
+  installMockContext,
+  clearMockContext,
+  MockLevel,
+} from "../../__spec__/mockContext";
+import { CollisionMask } from "../../collision/collisionMask";
+
+function createMockEntity(
+  id: number,
+  center: [number, number]
+): HurtableEntity {
+  return {
+    id,
+    hp: 100,
+    getCenter: () => center,
+    damage: vi.fn(),
+    die: vi.fn(),
+    body: { mask: CollisionMask.forRect(3, 3) },
+  } as unknown as HurtableEntity;
+}
+
+describe("ImpactDamage", () => {
+  it("has type Impact", () => {
+    const damage = new ImpactDamage(10, 20, 0, 5);
+    expect(damage.type).toBe(DamageSourceType.Impact);
+  });
+
+  it("has null cause by default", () => {
+    const damage = new ImpactDamage(10, 20, 0, 5);
+    expect(damage.cause).toBeNull();
+  });
+
+  it("stores position", () => {
+    const damage = new ImpactDamage(15, 25, 0, 5);
+    expect(damage.x).toBe(15);
+    expect(damage.y).toBe(25);
+  });
+
+  describe("serialize / deserialize", () => {
+    it("serializes position", () => {
+      const damage = new ImpactDamage(10, 20, Math.PI, 5);
+      const serialized = damage.serialize();
+      expect(serialized[0]).toBe(10);
+      expect(serialized[1]).toBe(20);
+    });
+
+    it("preserves position through deserialization", () => {
+      const original = new ImpactDamage(15, 25, 0, 0);
+      const serialized = original.serialize();
+      const restored = ImpactDamage.deserialize(serialized);
+      expect(restored.x).toBe(15);
+      expect(restored.y).toBe(25);
+    });
+
+    it("round-trips with pre-computed targets", () => {
+      const entity = createMockEntity(1, [60, 60]);
+      const targets = new TargetList();
+      targets.add(entity, 10, { power: 1, direction: 0 });
+
+      const original = new ImpactDamage(10, 20, 0, 5, targets);
+      const serialized = original.serialize();
+      const restored = ImpactDamage.deserialize(serialized);
+
+      expect(restored.getTargets().hasEntities()).toBe(true);
+    });
+  });
+
+  describe("getTargets", () => {
+    let level: MockLevel;
+
+    beforeEach(() => {
+      const mocks = installMockContext();
+      level = mocks.level;
+    });
+
+    afterEach(() => {
+      clearMockContext();
+    });
+
+    it("calls withNearbyEntities with correct search area", () => {
+      level.withNearbyEntities.mockImplementation(() => {});
+
+      const damage = new ImpactDamage(10, 20, 0, 15);
+      damage.getTargets();
+
+      expect(level.withNearbyEntities).toHaveBeenCalledWith(
+        (10 + 3) * 6, // x offset
+        (20 + 8) * 6, // y offset
+        16 * 6, // range
+        expect.any(Function)
+      );
+    });
+
+    it("ignores non-hurtable entities", () => {
+      const nonHurtable = { position: { x: 60, y: 60 } };
+
+      level.withNearbyEntities.mockImplementation(
+        (x: number, y: number, range: number, fn: Function) => {
+          fn(nonHurtable, 10);
+        }
+      );
+
+      const damage = new ImpactDamage(10, 20, 0, 15);
+      const targets = damage.getTargets();
+      expect(targets.hasEntities()).toBe(false);
+    });
+
+    it("caches targets on subsequent calls", () => {
+      level.withNearbyEntities.mockImplementation(() => {});
+
+      const damage = new ImpactDamage(10, 20, 0, 15);
+      const targets1 = damage.getTargets();
+      const targets2 = damage.getTargets();
+      expect(targets1).toBe(targets2);
+      expect(level.withNearbyEntities).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses pre-computed targets when provided", () => {
+      const targets = new TargetList();
+      const damage = new ImpactDamage(10, 20, 0, 15, targets);
+      expect(damage.getTargets()).toBe(targets);
+      expect(level.withNearbyEntities).not.toHaveBeenCalled();
+    });
+
+    it("uses pre-computed targets with correct power and direction", () => {
+      const entity = createMockEntity(1, [60, 60]);
+      const direction = Math.PI / 4;
+      const power = 20;
+
+      const targets = new TargetList();
+      targets.add(entity, power, {
+        power: power / 10,
+        direction,
+      });
+
+      const damage = new ImpactDamage(10, 20, direction, power, targets);
+      const result = damage.getTargets();
+      const serialized = result.serialize();
+
+      expect(serialized[0][1]).toBe(power);
+      expect(serialized[0][2]).toBe(power / 10);
+      expect(serialized[0][3]).toBe(direction);
+    });
+  });
+});

--- a/src/data/entity/__spec__/types.spec.ts
+++ b/src/data/entity/__spec__/types.spec.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import {
   isHurtableEntity,
   isSpawnableEntity,

--- a/src/data/entity/__spec__/types.spec.ts
+++ b/src/data/entity/__spec__/types.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  isHurtableEntity,
+  isSpawnableEntity,
+  isSyncableEntity,
+  isItem,
+} from "../types";
+
+describe("entity type guards", () => {
+  describe("isHurtableEntity", () => {
+    it("returns true for objects with getCenter", () => {
+      expect(isHurtableEntity({ getCenter: () => [0, 0] })).toBe(true);
+    });
+
+    it("returns false for objects without getCenter", () => {
+      expect(isHurtableEntity({ hp: 100 })).toBe(false);
+    });
+
+    it("returns false for empty objects", () => {
+      expect(isHurtableEntity({})).toBe(false);
+    });
+  });
+
+  describe("isSpawnableEntity", () => {
+    it("returns true for objects with serializeCreate", () => {
+      const entity = { serializeCreate: () => [] };
+      expect(isSpawnableEntity(entity as any)).toBe(true);
+    });
+
+    it("returns false for objects without serializeCreate", () => {
+      expect(isSpawnableEntity({ id: 1 } as any)).toBe(false);
+    });
+  });
+
+  describe("isSyncableEntity", () => {
+    it("returns true for objects with priority", () => {
+      expect(isSyncableEntity({ priority: 0 } as any)).toBe(true);
+    });
+
+    it("returns false for objects without priority", () => {
+      expect(isSyncableEntity({ id: 1 } as any)).toBe(false);
+    });
+  });
+
+  describe("isItem", () => {
+    it("returns true for objects with activate", () => {
+      expect(isItem({ activate: () => {} } as any)).toBe(true);
+    });
+
+    it("returns false for objects without activate", () => {
+      expect(isItem({ hp: 100 } as any)).toBe(false);
+    });
+  });
+});

--- a/src/util/__spec__/array.spec.ts
+++ b/src/util/__spec__/array.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getRandom } from "../array";
+
+describe("array", () => {
+  describe("getRandom", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("returns first element when Math.random returns 0", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      expect(getRandom([10, 20, 30])).toBe(10);
+    });
+
+    it("returns last element when Math.random returns 0.999", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.999);
+      expect(getRandom([10, 20, 30])).toBe(30);
+    });
+
+    it("returns the only element of a single-element array", () => {
+      expect(getRandom([42])).toBe(42);
+    });
+  });
+});

--- a/src/util/__spec__/data.spec.ts
+++ b/src/util/__spec__/data.spec.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { base64ToBytes, bytesToBase64 } from "../data";
 
 describe("data", () => {

--- a/src/util/__spec__/data.spec.ts
+++ b/src/util/__spec__/data.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { base64ToBytes, bytesToBase64 } from "../data";
+
+describe("data", () => {
+  describe("base64ToBytes", () => {
+    it("decodes a known base64 string", () => {
+      // "SGVsbG8=" is base64 for "Hello"
+      const bytes = base64ToBytes("SGVsbG8=");
+      expect(Array.from(bytes)).toEqual([72, 101, 108, 108, 111]);
+    });
+
+    it("handles empty string", () => {
+      const bytes = base64ToBytes("");
+      expect(bytes.length).toBe(0);
+    });
+  });
+
+  describe("bytesToBase64", () => {
+    it("encodes a known byte array", () => {
+      const bytes = new Uint8Array([72, 101, 108, 108, 111]);
+      expect(bytesToBase64(bytes.buffer)).toBe("SGVsbG8=");
+    });
+  });
+
+  describe("round-trip", () => {
+    it("preserves data through encode then decode", () => {
+      const original = new Uint8Array([0, 1, 127, 128, 255]);
+      const encoded = bytesToBase64(original.buffer);
+      const decoded = base64ToBytes(encoded);
+      expect(Array.from(decoded)).toEqual(Array.from(original));
+    });
+
+    it("preserves large data", () => {
+      const original = new Uint8Array(256);
+      for (let i = 0; i < 256; i++) original[i] = i;
+      const encoded = bytesToBase64(original.buffer);
+      const decoded = base64ToBytes(encoded);
+      expect(Array.from(decoded)).toEqual(Array.from(original));
+    });
+  });
+});

--- a/src/util/__spec__/math.spec.ts
+++ b/src/util/__spec__/math.spec.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import {
   mod,
   dot,

--- a/src/util/__spec__/math.spec.ts
+++ b/src/util/__spec__/math.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import {
+  mod,
+  dot,
+  getRayDistance,
+  getSquareDistance,
+  getDistance,
+  getAngle,
+  map,
+  angleDiff,
+} from "../math";
+
+describe("math", () => {
+  describe("mod", () => {
+    it("returns value within range for positive input", () => {
+      expect(mod(3, 5)).toBe(3);
+    });
+
+    it("wraps negative values correctly", () => {
+      expect(mod(-1, 5)).toBe(4);
+      expect(mod(-6, 5)).toBe(4);
+    });
+
+    it("returns 0 when value equals modulo", () => {
+      expect(mod(5, 5)).toBe(0);
+    });
+
+    it("wraps large values", () => {
+      expect(mod(13, 5)).toBe(3);
+    });
+  });
+
+  describe("dot", () => {
+    it("returns 0 for orthogonal vectors", () => {
+      expect(dot(1, 0, 0, 1)).toBe(0);
+    });
+
+    it("returns product for parallel vectors", () => {
+      expect(dot(3, 0, 4, 0)).toBe(12);
+    });
+
+    it("computes correctly for arbitrary vectors", () => {
+      expect(dot(2, 3, 4, 5)).toBe(2 * 4 + 3 * 5);
+    });
+  });
+
+  describe("getRayDistance", () => {
+    it("returns distance for point behind the ray origin", () => {
+      // Ray at (10, 0) pointing right, point at (0, 5)
+      // v1 = (10-0, 0-5) = (10, -5), v2 = (1, 0), dot = 10 > 0 → not infinity
+      const dist = getRayDistance(10, 0, 0, 0, 5);
+      expect(dist).toBeCloseTo(5, 5);
+    });
+
+    it("returns POSITIVE_INFINITY for point in front of the ray", () => {
+      // Ray at origin pointing right, point at (5, 0) is ahead
+      expect(getRayDistance(0, 0, 0, 5, 0)).toBe(Number.POSITIVE_INFINITY);
+    });
+
+    it("returns 0 for point directly on the ray line behind origin", () => {
+      // Ray at (10, 0) pointing right, point at (0, 0)
+      const dist = getRayDistance(10, 0, 0, 0, 0);
+      expect(dist).toBeCloseTo(0, 5);
+    });
+
+    it("works with angled rays", () => {
+      // Ray at (0, 10) pointing up (negative y), point at (5, 20)
+      // v1 = (0-5, 10-20) = (-5, -10), v2 = (cos(-PI/2), sin(-PI/2)) = (0, -1)
+      // dot = 0 + 10 = 10 > 0
+      const dist = getRayDistance(0, 10, -Math.PI / 2, 5, 20);
+      expect(dist).toBeCloseTo(5, 5);
+    });
+  });
+
+  describe("getSquareDistance", () => {
+    it("returns 0 for same point", () => {
+      expect(getSquareDistance(3, 4, 3, 4)).toBe(0);
+    });
+
+    it("returns squared distance for 3-4-5 triangle", () => {
+      expect(getSquareDistance(0, 0, 3, 4)).toBe(25);
+    });
+  });
+
+  describe("getDistance", () => {
+    it("returns 0 for same point", () => {
+      expect(getDistance(0, 0, 0, 0)).toBe(0);
+    });
+
+    it("returns 5 for 3-4-5 triangle", () => {
+      expect(getDistance(0, 0, 3, 4)).toBe(5);
+    });
+
+    it("handles negative coordinates", () => {
+      expect(getDistance(-3, -4, 0, 0)).toBe(5);
+    });
+  });
+
+  describe("getAngle", () => {
+    it("returns 0 for point directly to the right", () => {
+      expect(getAngle(0, 0, 1, 0)).toBe(0);
+    });
+
+    it("returns PI/2 for point directly below", () => {
+      expect(getAngle(0, 0, 0, 1)).toBeCloseTo(Math.PI / 2, 5);
+    });
+
+    it("returns PI for point directly to the left", () => {
+      expect(getAngle(0, 0, -1, 0)).toBeCloseTo(Math.PI, 5);
+    });
+
+    it("returns -PI/2 for point directly above", () => {
+      expect(getAngle(0, 0, 0, -1)).toBeCloseTo(-Math.PI / 2, 5);
+    });
+  });
+
+  describe("map", () => {
+    it("returns from when t=0", () => {
+      expect(map(10, 20, 0)).toBe(10);
+    });
+
+    it("returns to when t=1", () => {
+      expect(map(10, 20, 1)).toBe(20);
+    });
+
+    it("returns midpoint when t=0.5", () => {
+      expect(map(10, 20, 0.5)).toBe(15);
+    });
+
+    it("extrapolates beyond range", () => {
+      expect(map(10, 20, 2)).toBe(30);
+    });
+  });
+
+  describe("angleDiff", () => {
+    it("returns 0 for same angle", () => {
+      expect(angleDiff(1, 1)).toBeCloseTo(0, 5);
+    });
+
+    it("returns positive for clockwise difference", () => {
+      expect(angleDiff(0, Math.PI / 2)).toBeCloseTo(Math.PI / 2, 5);
+    });
+
+    it("wraps across PI boundary correctly", () => {
+      // From just below PI to just above -PI should be a small positive step
+      const diff = angleDiff(Math.PI - 0.1, -Math.PI + 0.1);
+      expect(diff).toBeCloseTo(0.2, 5);
+    });
+
+    it("returns negative for counter-clockwise difference", () => {
+      expect(angleDiff(Math.PI / 2, 0)).toBeCloseTo(-Math.PI / 2, 5);
+    });
+  });
+});

--- a/src/util/__spec__/time.spec.ts
+++ b/src/util/__spec__/time.spec.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { minutesToMs, secondsToMs } from "../time";
 
 describe("time", () => {

--- a/src/util/__spec__/time.spec.ts
+++ b/src/util/__spec__/time.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { minutesToMs, secondsToMs } from "../time";
+
+describe("time", () => {
+  describe("minutesToMs", () => {
+    it("converts 1 minute to 60000ms", () => {
+      expect(minutesToMs(1)).toBe(60000);
+    });
+
+    it("converts 0 minutes to 0ms", () => {
+      expect(minutesToMs(0)).toBe(0);
+    });
+
+    it("handles fractional minutes", () => {
+      expect(minutesToMs(0.5)).toBe(30000);
+    });
+  });
+
+  describe("secondsToMs", () => {
+    it("converts 1 second to 1000ms", () => {
+      expect(secondsToMs(1)).toBe(1000);
+    });
+
+    it("converts 0 seconds to 0ms", () => {
+      expect(secondsToMs(0)).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 8 new test files with 106 tests, increasing total from 51 to 157 (3x)
- Covers pure utility functions (math, data, time, array), CollisionMask operations, entity type guards, and remaining damage types (GenericDamage, ImpactDamage)
- Full suite runs in under 2 seconds

## New test files

| File | Tests | Coverage |
|------|-------|----------|
| `math.spec.ts` | 28 | mod, dot, getRayDistance, getDistance, getAngle, map, angleDiff |
| `collisionMask.spec.ts` | 38 | forRect, collidesWithPoint, collidesWith, add/subtract/difference, clone, serialize, fromAlpha/fromColor |
| `impactDamage.spec.ts` | 11 | search area, caching, serialization, pre-computed targets |
| `types.spec.ts` | 9 | isHurtableEntity, isSpawnableEntity, isSyncableEntity, isItem |
| `genericDamage.spec.ts` | 7 | delegation, serialize/deserialize round-trips |
| `data.spec.ts` | 5 | base64ToBytes, bytesToBase64, round-trips |
| `time.spec.ts` | 5 | minutesToMs, secondsToMs |
| `array.spec.ts` | 3 | getRandom with mocked Math.random |

## Test plan

- [x] All 157 tests pass (`yarn test`)
- [x] Execution under 2 seconds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)