### PR TITLE
refactor: decompose god-class components

### DIFF
--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -1,15 +1,11 @@
 <script setup lang="ts">
-import { Ref, onMounted, ref, watch } from "vue";
-import { Map, Layer, Config } from "../../data/map";
+import { onMounted, ref, watch } from "vue";
+import { Map, Config, Layer } from "../../data/map";
 import Input from "../atoms/Input.vue";
-import { Server } from "../../data/network/server";
-import { Team } from "../../data/team";
 import BoundingBox from "../molecules/BoundingBox.vue";
 import { BBox } from "../../data/map/bbox";
 import { useRouter } from "vue-router";
-import { logEvent } from "../../util/firebase";
 import { GameSettings } from "../../util/localStorage/settings";
-import { defaults } from "../../util/localStorage/settings";
 import MapSelect from "../organisms/MapSelect.vue";
 import BuilderSettings, {
   AdvancedSettings,
@@ -18,6 +14,9 @@ import ImageInput from "../molecules/ImageInput.vue";
 import IconButton from "../atoms/IconButton.vue";
 import plus from "pixelarticons/svg/plus.svg";
 import Collapsible from "../atoms/Collapsible.vue";
+import { useBuilderLayers } from "./composables/useBuilderLayers";
+import { useBuilderLadders } from "./composables/useBuilderLadders";
+import { useBuilderMap } from "./composables/useBuilderMap";
 
 const { onPlay, config } = defineProps<{
   onPlay: (key: string, map: Map | Config, settings: GameSettings) => void;
@@ -27,12 +26,6 @@ const router = useRouter();
 const preview = ref<HTMLDivElement>();
 
 const name = ref("");
-const terrain = ref({ data: "", visible: false });
-const mask = ref({ data: "", visible: false });
-const background = ref({ data: "", visible: false });
-const layers = ref<Array<Layer & { visible: boolean }>>([]);
-const ladders = ref<BBox[]>([]);
-const creatingLadder = ref(false);
 
 const settingsOpen = ref(false);
 const advancedSettings = ref<AdvancedSettings>({
@@ -42,6 +35,23 @@ const advancedSettings = ref<AdvancedSettings>({
   parallaxName: "",
   parallaxOffset: 0,
 });
+
+const oldScale = ref(advancedSettings.value.scale);
+
+const {
+  terrain, mask, background, layers,
+  handleAddTerrain, handleSetTerrainVisibility,
+  handleAddMask, handleSetMaskVisibility,
+  handleAddBackground, handleSetBackgroundVisibility,
+  handleAddLayer, handleRemoveLayer, handleSetLayerVisibility,
+} = useBuilderLayers(advancedSettings, preview);
+
+const { ladders, creatingLadder, handleCreateLadder } =
+  useBuilderLadders(advancedSettings, preview);
+
+const { handleBuild, handleTest, loadMap } = useBuilderMap(
+  name, terrain, mask, background, layers, ladders, advancedSettings, oldScale
+);
 
 onMounted(async () => {
   if (config) {
@@ -58,7 +68,6 @@ watch(
   }
 );
 
-const oldScale = ref(advancedSettings.value.scale);
 watch(
   () => advancedSettings.value.scale,
   (scale) => {
@@ -68,128 +77,6 @@ watch(
     oldScale.value = scale;
   }
 );
-
-const addImageFactory =
-  (ref: Ref, visible = true) =>
-  (_: File, data: string) => {
-    ref.value = { data, visible };
-
-    if (advancedSettings.value.bbox.isEmpty()) {
-      var image = new Image();
-      image.src = data;
-
-      image.onload = () => {
-        advancedSettings.value.bbox = BBox.create(image.width, image.height);
-      };
-    }
-  };
-
-const handleAddTerrain = addImageFactory(terrain);
-const handleSetTerrainVisibility = (visible: boolean) =>
-  (terrain.value.visible = visible);
-const handleAddMask = addImageFactory(mask, false);
-const handleSetMaskVisibility = (visible: boolean) =>
-  (mask.value.visible = visible);
-
-const handleAddBackground = addImageFactory(background);
-const handleSetBackgroundVisibility = (visible: boolean) =>
-  (background.value.visible = visible);
-
-const handleBuild = async () => {
-  const map = await Map.fromConfig({
-    terrain: { data: terrain.value.data, mask: mask.value.data },
-    background: background.value.data
-      ? { data: background.value.data }
-      : undefined,
-    layers: layers.value
-      .filter((layer) => !!layer.data)
-      .map((layer) => ({ ...layer })),
-    bbox: advancedSettings.value.bbox,
-    parallax: {
-      name: advancedSettings.value.parallaxName,
-      offset: advancedSettings.value.parallaxOffset,
-    },
-    scale: advancedSettings.value.scale,
-    ladders: ladders.value,
-  });
-
-  const url = URL.createObjectURL(await map.toBlob());
-  setTimeout(() => window.URL.revokeObjectURL(url), 1000);
-
-  const link = document.createElement("a");
-  link.download = `${name.value || "map"}.png`;
-  link.href = url;
-  link.click();
-
-  logEvent("build_map");
-};
-
-const handleTest = async () => {
-  const config: Config = {
-    terrain: { data: terrain.value.data, mask: mask.value.data },
-    background: background.value.data
-      ? { data: background.value.data }
-      : undefined,
-    layers: layers.value
-      .filter((layer) => !!layer.data)
-      .map((layer) => ({ ...layer })),
-    bbox: advancedSettings.value.bbox,
-    parallax: {
-      name: advancedSettings.value.parallaxName,
-      offset: advancedSettings.value.parallaxOffset,
-    },
-    scale: advancedSettings.value.scale,
-    ladders: ladders.value,
-  };
-
-  const server = new Server();
-  server.addPlayer("Test player", Team.random());
-  onPlay("0000", config, { ...defaults().gameSettings, teamSize: 1 });
-};
-
-const loadMap = (config: Config, map: string) => {
-  oldScale.value = config.scale;
-  terrain.value = { data: config.terrain.data as string, visible: true };
-  background.value = {
-    data: (config.background?.data as string) || "",
-    visible: true,
-  };
-  layers.value = config.layers.map((layer) => ({ ...layer, visible: true }));
-  advancedSettings.value = {
-    bbox: BBox.fromJS(config.bbox) || BBox.create(0, 0),
-    scale: config.scale,
-    customMask: !!config.terrain.mask,
-    parallaxName: config.parallax.name,
-    parallaxOffset: config.parallax.offset,
-  };
-  name.value = map;
-  ladders.value =
-    (config.ladders
-      ?.map((bbox) => BBox.fromJS(bbox))
-      .filter(Boolean) as BBox[]) || [];
-
-  if (config.terrain.mask) {
-    mask.value = { data: config.terrain.mask as string, visible: false };
-  } else {
-    mask.value = { data: "", visible: false };
-  }
-};
-
-const handleAddLayer = () =>
-  layers.value.push({
-    data: "",
-    x: Math.round(preview.value!.scrollLeft / advancedSettings.value.scale),
-    y: Math.round(preview.value!.scrollTop / advancedSettings.value.scale),
-    visible: true,
-  });
-
-const handleRemoveLayer = (index: number) => {
-  layers.value = layers.value.filter((_, i) => i !== index);
-};
-
-const handleSetLayerVisibility = (visible: boolean, index: number) => {
-  layers.value[index].visible = visible;
-};
 
 const handleMouseDown = (event: MouseEvent, layer: Layer) => {
   let x = layer.x;
@@ -218,55 +105,6 @@ const handleMouseDown = (event: MouseEvent, layer: Layer) => {
 
 const handleBBoxChange = (newBBox: BBox) => {
   advancedSettings.value.bbox = newBBox;
-};
-
-const handleCreateLadder = (event: MouseEvent) => {
-  if (!creatingLadder.value) {
-    return;
-  }
-
-  event.preventDefault();
-  const position = preview.value!.getBoundingClientRect();
-  const x = Math.round(
-    (position.left - preview.value!.scrollLeft) / advancedSettings.value.scale
-  );
-  const y = Math.round(
-    (position.top - preview.value!.scrollTop) / advancedSettings.value.scale
-  );
-  const startX = Math.round(event.pageX / advancedSettings.value.scale) - x;
-  const startY = Math.round(event.pageY / advancedSettings.value.scale) - y;
-
-  ladders.value.push(
-    BBox.fromJS({
-      left: startX,
-      top: startY,
-      right: startX,
-      bottom: startY,
-    })!
-  );
-
-  const handleMouseMove = (moveEvent: MouseEvent) => {
-    ladders.value[ladders.value.length - 1].right = Math.max(
-      startX,
-      Math.round(moveEvent.pageX / advancedSettings.value.scale) - x
-    );
-    ladders.value[ladders.value.length - 1].bottom = Math.max(
-      startY,
-      Math.round(moveEvent.pageY / advancedSettings.value.scale) - y
-    );
-  };
-
-  const handleMouseUp = () => {
-    document.onselectstart = null;
-    document.removeEventListener("mousemove", handleMouseMove);
-    document.removeEventListener("mouseup", handleMouseUp);
-    creatingLadder.value = false;
-  };
-
-  event.preventDefault();
-  document.onselectstart = () => false;
-  document.addEventListener("mousemove", handleMouseMove);
-  document.addEventListener("mouseup", handleMouseUp);
 };
 </script>
 
@@ -349,7 +187,7 @@ const handleCreateLadder = (event: MouseEvent) => {
       >
         Build
       </button>
-      <button class="primary" title="Build and test" @click="handleTest">
+      <button class="primary" title="Build and test" @click="() => handleTest(onPlay)">
         Test
       </button>
       <button class="secondary" @click="() => router.replace('/')">Back</button>

--- a/src/components/pages/Host.vue
+++ b/src/components/pages/Host.vue
@@ -2,25 +2,21 @@
 import { onMounted, ref, watch } from "vue";
 import { get, set } from "../../util/localStorage";
 import { GameSettings, defaults } from "../../util/localStorage/settings";
-import { Server } from "../../data/network/server";
-import { PEER_ID_PREFIX } from "../../data/network/constants";
 import { MessageType } from "../../data/network/types";
-import Peer from "peerjs";
-import { Team } from "../../data/team";
 import { Config, Map } from "../../data/map";
-import { getManager, getServer } from "../../data/context";
-import { Player } from "../../data/network/player";
+import { getServer } from "../../data/context";
 import debounce from "lodash.debounce";
 import { useRouter } from "vue-router";
 import { logEvent } from "../../util/firebase";
 import TeamDisplay from "../organisms/TeamDisplay.vue";
 import TeamDialog from "../organisms/TeamDialog.vue";
-import { IPlayer } from "../types";
 import GameSettingsComponent from "../organisms/GameSettings.vue";
 import MapSelect from "../organisms/MapSelect.vue";
 import { COLORS } from "../../data/network/constants";
 import IconButton from "../atoms/IconButton.vue";
 import plus from "pixelarticons/svg/plus.svg";
+import { useHostServer } from "./composables/useHostServer";
+import { useHostPlayers } from "./composables/useHostPlayers";
 
 const { onPlay } = defineProps<{
   onPlay: (key: string, map: Map | Config, settings: GameSettings) => void;
@@ -31,8 +27,6 @@ const router = useRouter();
 const settings = defaults(get("Settings"));
 
 const team = ref(settings.team);
-const serverStarting = ref(false);
-const localPlayers = ref<string[]>([]);
 
 const mapContainer: { map: Map | null; name: string } = {
   map: null,
@@ -43,11 +37,8 @@ const gameSettings = ref({
   ...settings.gameSettings,
 });
 
-const key = ref("");
-const players = ref<Player[]>([]);
-const promise = ref<Promise<void>>();
-
-const editingPlayer = ref<IPlayer>();
+const { key, serverStarting, promise, createServer, destroyServer } =
+  useHostServer(gameSettings);
 
 watch(
   () => gameSettings.value.teamSize,
@@ -57,41 +48,6 @@ watch(
     server.players.forEach((player) => player.team.setSize(newSize));
   }
 );
-
-const createServer = () =>
-  new Promise<void>((resolve) => {
-    getManager()?.destroy();
-
-    key.value = Math.floor(Math.random() * 10000)
-      .toString()
-      .padStart(4, "0");
-
-    const peer = new Peer(PEER_ID_PREFIX + key.value);
-
-    peer.on("error", () => {
-      createServer().then(resolve);
-    });
-
-    peer.once("open", () => {
-      peer.off("error");
-
-      const server = new Server(peer);
-      server.teamSize = gameSettings.value.teamSize;
-
-      const player = server.addPlayer(settings.name, team.value);
-      localPlayers.value.push(player.color);
-
-      server.listen(updateLobby);
-      resolve();
-    });
-  });
-
-onMounted(async () => {
-  promise.value = createServer();
-
-  await promise.value;
-  updateLobby();
-});
 
 const updateLobby = debounce(() => {
   const server = getServer();
@@ -118,16 +74,33 @@ const updateLobby = debounce(() => {
   }
 }, 200);
 
+const {
+  players,
+  localPlayers,
+  editingPlayer,
+  handleAddLocalPlayer,
+  handleKick,
+  handleEditPlayer,
+  handleClose,
+  handleSave,
+} = useHostPlayers(updateLobby, gameSettings);
+
+onMounted(async () => {
+  promise.value = createServer(settings.name, team.value, (server) => {
+    const player = server.addPlayer(settings.name, team.value);
+    localPlayers.value.push(player.color);
+    server.listen(updateLobby);
+  });
+
+  await promise.value;
+  updateLobby();
+});
+
 const handleBack = () => {
   if (serverStarting.value) {
     return;
   }
-
-  const server = getServer();
-  if (server) {
-    server.destroy();
-  }
-
+  destroyServer();
   router.replace("/");
 };
 
@@ -151,51 +124,6 @@ const handleStart = async () => {
     players: getServer()!.players.length,
     map: mapContainer.name,
   });
-};
-
-const handleAddLocalPlayer = () => {
-  const team = Team.random(gameSettings.value.teamSize);
-  const player = getServer()!.addPlayer(
-    `${settings.name} (${players.value?.length})`,
-    team
-  );
-  localPlayers.value.push(player.color);
-
-  updateLobby();
-};
-
-const handleKick = (index: number) => {
-  const server = getServer()!;
-  const player = server.players[index];
-  const localPlayerIndex = localPlayers.value.findIndex(
-    (localPlayer) => localPlayer === player.color
-  );
-
-  if (localPlayerIndex !== -1) {
-    localPlayers.value.splice(localPlayerIndex, 1);
-  }
-
-  server.kick(server.players[index]);
-  updateLobby();
-};
-
-const handleEditPlayer = (player: IPlayer) => {
-  editingPlayer.value = player;
-};
-
-const handleClose = () => {
-  editingPlayer.value = undefined;
-  updateLobby();
-};
-
-const handleSave = (name: string, characters: string[]) => {
-  (editingPlayer.value as Player).rename(
-    name,
-    Team.fromJson(characters, gameSettings.value.teamSize)
-  );
-
-  editingPlayer.value = undefined;
-  updateLobby();
 };
 
 const handleSaveSettings = (settings: GameSettings) => {
@@ -226,7 +154,7 @@ const handleSelectMap = async (config: Config, name: string) => {
         <IconButton
           v-if="players.length < COLORS.length"
           title="Add local player"
-          :onClick="handleAddLocalPlayer"
+          :onClick="() => handleAddLocalPlayer(settings.name)"
           :icon="plus"
         />
       </h2>

--- a/src/components/pages/composables/useBuilderLadders.ts
+++ b/src/components/pages/composables/useBuilderLadders.ts
@@ -1,0 +1,70 @@
+import { Ref, ref } from "vue";
+import { BBox } from "../../../data/map/bbox";
+import type { AdvancedSettings } from "../../organisms/BuilderSettings.vue";
+
+export function useBuilderLadders(
+  advancedSettings: Ref<AdvancedSettings>,
+  preview: Ref<HTMLDivElement | undefined>
+) {
+  const ladders = ref<BBox[]>([]);
+  const creatingLadder = ref(false);
+
+  const handleCreateLadder = (event: MouseEvent) => {
+    if (!creatingLadder.value) {
+      return;
+    }
+
+    event.preventDefault();
+    const position = preview.value!.getBoundingClientRect();
+    const x = Math.round(
+      (position.left - preview.value!.scrollLeft) /
+        advancedSettings.value.scale
+    );
+    const y = Math.round(
+      (position.top - preview.value!.scrollTop) /
+        advancedSettings.value.scale
+    );
+    const startX =
+      Math.round(event.pageX / advancedSettings.value.scale) - x;
+    const startY =
+      Math.round(event.pageY / advancedSettings.value.scale) - y;
+
+    ladders.value.push(
+      BBox.fromJS({
+        left: startX,
+        top: startY,
+        right: startX,
+        bottom: startY,
+      })!
+    );
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      ladders.value[ladders.value.length - 1].right = Math.max(
+        startX,
+        Math.round(moveEvent.pageX / advancedSettings.value.scale) - x
+      );
+      ladders.value[ladders.value.length - 1].bottom = Math.max(
+        startY,
+        Math.round(moveEvent.pageY / advancedSettings.value.scale) - y
+      );
+    };
+
+    const handleMouseUp = () => {
+      document.onselectstart = null;
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      creatingLadder.value = false;
+    };
+
+    event.preventDefault();
+    document.onselectstart = () => false;
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+  };
+
+  return {
+    ladders,
+    creatingLadder,
+    handleCreateLadder,
+  };
+}

--- a/src/components/pages/composables/useBuilderLayers.ts
+++ b/src/components/pages/composables/useBuilderLayers.ts
@@ -18,7 +18,7 @@ export function useBuilderLayers(
       target.value = { data, visible };
 
       if (advancedSettings.value.bbox.isEmpty()) {
-        var image = new Image();
+        const image = new Image();
         image.src = data;
 
         image.onload = () => {

--- a/src/components/pages/composables/useBuilderLayers.ts
+++ b/src/components/pages/composables/useBuilderLayers.ts
@@ -1,0 +1,78 @@
+import { Ref, ref } from "vue";
+import { Layer } from "../../../data/map";
+import { BBox } from "../../../data/map/bbox";
+import type { AdvancedSettings } from "../../organisms/BuilderSettings.vue";
+
+export function useBuilderLayers(
+  advancedSettings: Ref<AdvancedSettings>,
+  preview: Ref<HTMLDivElement | undefined>
+) {
+  const terrain = ref({ data: "", visible: false });
+  const mask = ref({ data: "", visible: false });
+  const background = ref({ data: "", visible: false });
+  const layers = ref<Array<Layer & { visible: boolean }>>([]);
+
+  const addImageFactory =
+    (target: Ref<{ data: string; visible: boolean }>, visible = true) =>
+    (_: File, data: string) => {
+      target.value = { data, visible };
+
+      if (advancedSettings.value.bbox.isEmpty()) {
+        var image = new Image();
+        image.src = data;
+
+        image.onload = () => {
+          advancedSettings.value.bbox = BBox.create(
+            image.width,
+            image.height
+          );
+        };
+      }
+    };
+
+  const handleAddTerrain = addImageFactory(terrain);
+  const handleSetTerrainVisibility = (visible: boolean) =>
+    (terrain.value.visible = visible);
+  const handleAddMask = addImageFactory(mask, false);
+  const handleSetMaskVisibility = (visible: boolean) =>
+    (mask.value.visible = visible);
+  const handleAddBackground = addImageFactory(background);
+  const handleSetBackgroundVisibility = (visible: boolean) =>
+    (background.value.visible = visible);
+
+  const handleAddLayer = () =>
+    layers.value.push({
+      data: "",
+      x: Math.round(
+        preview.value!.scrollLeft / advancedSettings.value.scale
+      ),
+      y: Math.round(
+        preview.value!.scrollTop / advancedSettings.value.scale
+      ),
+      visible: true,
+    });
+
+  const handleRemoveLayer = (index: number) => {
+    layers.value = layers.value.filter((_, i) => i !== index);
+  };
+
+  const handleSetLayerVisibility = (visible: boolean, index: number) => {
+    layers.value[index].visible = visible;
+  };
+
+  return {
+    terrain,
+    mask,
+    background,
+    layers,
+    handleAddTerrain,
+    handleSetTerrainVisibility,
+    handleAddMask,
+    handleSetMaskVisibility,
+    handleAddBackground,
+    handleSetBackgroundVisibility,
+    handleAddLayer,
+    handleRemoveLayer,
+    handleSetLayerVisibility,
+  };
+}

--- a/src/components/pages/composables/useBuilderMap.ts
+++ b/src/components/pages/composables/useBuilderMap.ts
@@ -1,0 +1,97 @@
+import { Ref } from "vue";
+import { Config, Layer, Map } from "../../../data/map";
+import { BBox } from "../../../data/map/bbox";
+import { Server } from "../../../data/network/server";
+import { Team } from "../../../data/team";
+import { logEvent } from "../../../util/firebase";
+import { defaults, GameSettings } from "../../../util/localStorage/settings";
+import type { AdvancedSettings } from "../../organisms/BuilderSettings.vue";
+
+export function useBuilderMap(
+  name: Ref<string>,
+  terrain: Ref<{ data: string; visible: boolean }>,
+  mask: Ref<{ data: string; visible: boolean }>,
+  background: Ref<{ data: string; visible: boolean }>,
+  layers: Ref<Array<Layer & { visible: boolean }>>,
+  ladders: Ref<BBox[]>,
+  advancedSettings: Ref<AdvancedSettings>,
+  oldScale: Ref<number>
+) {
+  const buildConfig = (): Config => ({
+    terrain: { data: terrain.value.data, mask: mask.value.data },
+    background: background.value.data
+      ? { data: background.value.data }
+      : undefined,
+    layers: layers.value
+      .filter((layer) => !!layer.data)
+      .map((layer) => ({ ...layer })),
+    bbox: advancedSettings.value.bbox,
+    parallax: {
+      name: advancedSettings.value.parallaxName,
+      offset: advancedSettings.value.parallaxOffset,
+    },
+    scale: advancedSettings.value.scale,
+    ladders: ladders.value,
+  });
+
+  const handleBuild = async () => {
+    const map = await Map.fromConfig(buildConfig());
+
+    const url = URL.createObjectURL(await map.toBlob());
+    setTimeout(() => window.URL.revokeObjectURL(url), 1000);
+
+    const link = document.createElement("a");
+    link.download = `${name.value || "map"}.png`;
+    link.href = url;
+    link.click();
+
+    logEvent("build_map");
+  };
+
+  const handleTest = async (
+    onPlay: (key: string, map: Map | Config, settings: GameSettings) => void
+  ) => {
+    const config = buildConfig();
+
+    const server = new Server();
+    server.addPlayer("Test player", Team.random());
+    onPlay("0000", config, { ...defaults().gameSettings, teamSize: 1 });
+  };
+
+  const loadMap = (config: Config, mapName: string) => {
+    oldScale.value = config.scale;
+    terrain.value = { data: config.terrain.data as string, visible: true };
+    background.value = {
+      data: (config.background?.data as string) || "",
+      visible: true,
+    };
+    layers.value = config.layers.map((layer) => ({
+      ...layer,
+      visible: true,
+    }));
+    advancedSettings.value = {
+      bbox: BBox.fromJS(config.bbox) || BBox.create(0, 0),
+      scale: config.scale,
+      customMask: !!config.terrain.mask,
+      parallaxName: config.parallax.name,
+      parallaxOffset: config.parallax.offset,
+    };
+    name.value = mapName;
+    ladders.value =
+      (config.ladders
+        ?.map((bbox) => BBox.fromJS(bbox))
+        .filter(Boolean) as BBox[]) || [];
+
+    if (config.terrain.mask) {
+      mask.value = { data: config.terrain.mask as string, visible: false };
+    } else {
+      mask.value = { data: "", visible: false };
+    }
+  };
+
+  return {
+    handleBuild,
+    handleTest,
+    loadMap,
+  };
+}

--- a/src/components/pages/composables/useHostPlayers.ts
+++ b/src/components/pages/composables/useHostPlayers.ts
@@ -1,0 +1,70 @@
+import { ref } from "vue";
+import { Player } from "../../../data/network/player";
+import { Team } from "../../../data/team";
+import { getServer } from "../../../data/context";
+import { GameSettings } from "../../../util/localStorage/settings";
+import { IPlayer } from "../../types";
+
+export function useHostPlayers(
+  updateLobby: () => void,
+  gameSettings: { value: GameSettings }
+) {
+  const players = ref<Player[]>([]);
+  const localPlayers = ref<string[]>([]);
+  const editingPlayer = ref<IPlayer>();
+
+  const handleAddLocalPlayer = (baseName: string) => {
+    const team = Team.random(gameSettings.value.teamSize);
+    const player = getServer()!.addPlayer(
+      `${baseName} (${players.value?.length})`,
+      team
+    );
+    localPlayers.value.push(player.color);
+    updateLobby();
+  };
+
+  const handleKick = (index: number) => {
+    const server = getServer()!;
+    const player = server.players[index];
+    const localPlayerIndex = localPlayers.value.findIndex(
+      (localPlayer) => localPlayer === player.color
+    );
+
+    if (localPlayerIndex !== -1) {
+      localPlayers.value.splice(localPlayerIndex, 1);
+    }
+
+    server.kick(server.players[index]);
+    updateLobby();
+  };
+
+  const handleEditPlayer = (player: IPlayer) => {
+    editingPlayer.value = player;
+  };
+
+  const handleClose = () => {
+    editingPlayer.value = undefined;
+    updateLobby();
+  };
+
+  const handleSave = (name: string, characters: string[]) => {
+    (editingPlayer.value as Player).rename(
+      name,
+      Team.fromJson(characters, gameSettings.value.teamSize)
+    );
+
+    editingPlayer.value = undefined;
+    updateLobby();
+  };
+
+  return {
+    players,
+    localPlayers,
+    editingPlayer,
+    handleAddLocalPlayer,
+    handleKick,
+    handleEditPlayer,
+    handleClose,
+    handleSave,
+  };
+}

--- a/src/components/pages/composables/useHostServer.ts
+++ b/src/components/pages/composables/useHostServer.ts
@@ -3,7 +3,7 @@ import Peer from "peerjs";
 import { Server } from "../../../data/network/server";
 import { PEER_ID_PREFIX } from "../../../data/network/constants";
 import { getManager, getServer } from "../../../data/context";
-import { Team } from "../../../data/team";
+import type { Team } from "../../../data/team";
 import { GameSettings } from "../../../util/localStorage/settings";
 
 export function useHostServer(gameSettings: { value: GameSettings }) {

--- a/src/components/pages/composables/useHostServer.ts
+++ b/src/components/pages/composables/useHostServer.ts
@@ -1,0 +1,57 @@
+import { ref } from "vue";
+import Peer from "peerjs";
+import { Server } from "../../../data/network/server";
+import { PEER_ID_PREFIX } from "../../../data/network/constants";
+import { getManager, getServer } from "../../../data/context";
+import { Team } from "../../../data/team";
+import { GameSettings } from "../../../util/localStorage/settings";
+
+export function useHostServer(gameSettings: { value: GameSettings }) {
+  const key = ref("");
+  const serverStarting = ref(false);
+  const promise = ref<Promise<void>>();
+
+  const createServer = (
+    name: string,
+    team: Team,
+    onReady: (server: Server) => void
+  ): Promise<void> =>
+    new Promise<void>((resolve) => {
+      getManager()?.destroy();
+
+      key.value = Math.floor(Math.random() * 10000)
+        .toString()
+        .padStart(4, "0");
+
+      const peer = new Peer(PEER_ID_PREFIX + key.value);
+
+      peer.on("error", () => {
+        createServer(name, team, onReady).then(resolve);
+      });
+
+      peer.once("open", () => {
+        peer.off("error");
+
+        const server = new Server(peer);
+        server.teamSize = gameSettings.value.teamSize;
+
+        onReady(server);
+        resolve();
+      });
+    });
+
+  const destroyServer = () => {
+    const server = getServer();
+    if (server) {
+      server.destroy();
+    }
+  };
+
+  return {
+    key,
+    serverStarting,
+    promise,
+    createServer,
+    destroyServer,
+  };
+}

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -28,29 +28,25 @@ import {
 } from "../../graphics/particles/factory/character";
 import { ControllableSound } from "../../sound/controllableSound";
 import { Sound } from "../../sound";
-import { Wings } from "./wings";
 import { SmokePuff } from "../../graphics/smokePuff";
 import { COLORS } from "../network/constants";
-import { BBox } from "../map/bbox";
 import { getLevel, getManager, getServer } from "../context";
 import { CharacterHealth } from "./characterHealth";
+import { CharacterMovement } from "./characterMovement";
 
 // Start bouncing when impact is greater than this value
 const BOUNCE_TRIGGER = 3.8;
 const SMOKE_TRIGGER = 2;
-const MAX_LADDER_MOUNT_SPEED = 1;
-
 const WALK_DURATION = 20;
 const MELEE_DURATION = 50;
 const PAGE_READ_DURATION = 60;
 const CLIMB_DURATION = 10;
-const JUMP_GRACE_TIME = 3;
 
 const MELEE_POWER = 20;
 
 const MAX_NAME_LENGTH = 30;
 
-enum AnimationState {
+export enum AnimationState {
   Idle = "elf_idle",
   Walk = "elf_walk",
   Jump = "elf_jump",
@@ -189,10 +185,8 @@ export class Character extends Container implements HurtableEntity, Syncable {
   private lastActiveTime = 0;
   private spellSource: any | null = null;
   private lookDirection = 1;
-  private wings?: Wings;
   private namePlateName: string;
-  private wasUp = false;
-  private lastGroundedTime = 0;
+  public readonly movement: CharacterMovement;
 
   private animator: Animator<AnimationState>;
 
@@ -209,10 +203,11 @@ export class Character extends Container implements HurtableEntity, Syncable {
         ? characterName.slice(0, MAX_NAME_LENGTH - 3) + "..."
         : characterName;
 
+    this.movement = new CharacterMovement(this);
     this.body = new Body(getLevel().terrain.characterMask, {
       mask: rectangle6x16,
       onCollide: this.onCollide,
-      ladderTest: this.ladderTest,
+      ladderTest: this.movement.ladderTest,
     });
     this.body.move(x, y);
     this.position.set(x * 6, y * 6);
@@ -372,7 +367,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
         this.position.set(x * 6, y * 6);
 
         if (this.body.grounded) {
-          this.lastGroundedTime = this.time;
+          this.movement.lastGroundedTime = this.time;
         }
 
         if (
@@ -426,142 +421,36 @@ export class Character extends Container implements HurtableEntity, Syncable {
     );
   }
 
-  ladderTest = (x: number, y: number) => {
-    if (!getManager().isTrusted(this)) {
-      return false;
-    }
-
-    for (let ladder of getLevel().terrain.ladders) {
-      if (
-        x + 6 >= ladder.left &&
-        x <= ladder.right &&
-        y + 16 > ladder.top &&
-        y < ladder.bottom
-      ) {
-        return true;
-      }
-    }
-
-    return false;
-  };
-
   control(controller: Controller) {
-    let foundLadder: BBox | null = null;
-    if (
-      this.body.grounded ||
-      this.body.onLadder ||
-      (this.body.yVelocity > 0 && this.body.yVelocity < MAX_LADDER_MOUNT_SPEED)
-    ) {
-      const [x, y] = this.body.precisePosition;
-      for (let ladder of getLevel().terrain.ladders) {
-        if (
-          x + 6 >= ladder.left &&
-          x <= ladder.right &&
-          y + 16 > ladder.top &&
-          y < ladder.bottom &&
-          ladder.top < (foundLadder?.top || Infinity)
-        ) {
-          foundLadder = ladder;
-        }
-      }
-    }
-
-    if (this.body.onLadder) {
-      this.setSpellSource(null, false);
-    }
-
-    const isUp = controller.isKeyDown(Key.Up) || controller.isKeyDown(Key.W);
-    if (!this.wings && foundLadder && isUp) {
-      this.body.mountLadder();
-    }
-
-    if (this.body.onLadder) {
-      if (!foundLadder) {
-        if (getManager().isTrusted(this)) {
-          this.body.unmountLadder();
-        }
-        return;
-      }
-
-      if (isUp) {
-        if (this.body.precisePosition[1] + 8 > foundLadder.top) {
-          this.body.setLadderDirection(-1);
-          this.animator.animate(AnimationState.Climb);
-        } else {
-          if (!this.wasUp) {
-            this.body.unmountLadder();
-            this.body.jump();
-            this.animator.animate(AnimationState.Jump);
-          }
-
-          this.body.setLadderDirection(0);
-        }
-      } else if (
-        controller.isKeyDown(Key.Down) ||
-        controller.isKeyDown(Key.D)
-      ) {
-        this.body.setLadderDirection(1);
-        this.animator.animate(AnimationState.Climb);
-      } else {
-        this.body.setLadderDirection(0);
-      }
-
-      this.wasUp = isUp;
-      return;
-    }
-
-    if (!isUp) {
-      return;
-    }
-
-    if (this.time - this.lastGroundedTime < JUMP_GRACE_TIME && !this.wings) {
-      if (this.body.jump()) {
-        this.animator.animate(AnimationState.Jump);
-      }
-    }
-
-    if (this.wings) {
-      this.wings.flap(this.time);
-      this.animator.animate(AnimationState.Float);
-
-      if (this.wings.power <= 0) {
-        this.removeWings();
-      }
-    }
+    this.movement.control(controller);
   }
 
   controlContinuous(dt: number, controller: Controller) {
-    if (this.animator.isBlocking) {
-      return;
-    }
+    this.movement.controlContinuous(dt, controller);
+  }
 
+  /** Trigger an animation by state name. Used by helpers. */
+  animate(state: keyof typeof AnimationState): void {
+    this.animator.animate(AnimationState[state]);
+  }
+
+  /** Check if current animation is blocking input. Used by CharacterMovement. */
+  isAnimationBlocking(): boolean {
+    return !!this.animator.isBlocking;
+  }
+
+  /** Update look direction from controller mouse position. Used by CharacterMovement. */
+  updateLookDirection(controller: Controller): void {
     this.lookDirection = Math.sign(
       controller.getMouse()[0] - this.getCenter()[0]
     );
     this.sprite.scale.x = 2 * this.lookDirection;
+  }
 
-    if (controller.isKeyDown(Key.Left) || controller.isKeyDown(Key.A)) {
-      this.body.walk(-1);
-
-      if (this.body.grounded) {
-        this.animator.animate(AnimationState.Walk);
-
-        if (this.sprite.animationSpeed * this.lookDirection < 0) {
-          this.sprite.animationSpeed *= this.lookDirection;
-        }
-      }
-    }
-
-    if (controller.isKeyDown(Key.Right) || controller.isKeyDown(Key.D)) {
-      this.body.walk(1);
-
-      if (this.body.grounded) {
-        this.animator.animate(AnimationState.Walk);
-
-        if (this.sprite.animationSpeed * this.lookDirection < 0) {
-          this.sprite.animationSpeed *= this.lookDirection;
-        }
-      }
+  /** Sync animation speed direction with look direction. Used by CharacterMovement. */
+  syncAnimationDirection(): void {
+    if (this.sprite.animationSpeed * this.lookDirection < 0) {
+      this.sprite.animationSpeed *= this.lookDirection;
     }
   }
 
@@ -659,25 +548,15 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   giveWings() {
-    this.body.unmountLadder();
-
-    this.wings = new Wings(this);
-    this.addChildAt(this.wings, 0);
+    this.movement.giveWings();
   }
 
   removeWings() {
-    if (!this.wings) {
-      return;
-    }
-
-    this.wings.stop();
-    this.removeChild(this.wings);
-    this.wings = undefined;
+    this.movement.removeWings();
   }
 
   endTurn() {
-    this.removeWings();
-    this.body.setLadderDirection(0);
+    this.movement.endTurn();
   }
 
   melee() {

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -456,6 +456,16 @@ export class Character extends Container implements HurtableEntity, Syncable {
     }
   }
 
+  /** Check if current animation matches a given state. Used by CharacterCombat. */
+  isInAnimationState(state: keyof typeof AnimationState): boolean {
+    return this.animator.animationState === AnimationState[state];
+  }
+
+  /** Set the default animation state. Used by CharacterCombat. */
+  setDefaultAnimation(state: keyof typeof AnimationState): void {
+    this.animator.setDefaultAnimation(AnimationState[state]);
+  }
+
   damage(source: DamageSource, damage: number, force?: Force) {
     this.health.damage(source, damage, force);
   }
@@ -517,7 +527,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   melee() {
-    this.animator.animate(AnimationState.Swing);
+    this.combat.melee();
   }
 
   get hp() {

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -32,6 +32,7 @@ import { SmokePuff } from "../../graphics/smokePuff";
 import { COLORS } from "../network/constants";
 import { getLevel, getManager, getServer } from "../context";
 import { CharacterHealth } from "./characterHealth";
+import { CharacterCombat } from "./characterCombat";
 import { CharacterMovement } from "./characterMovement";
 
 // Start bouncing when impact is greater than this value
@@ -183,9 +184,9 @@ export class Character extends Container implements HurtableEntity, Syncable {
 
   public time = 0;
   private lastActiveTime = 0;
-  private spellSource: any | null = null;
   private lookDirection = 1;
   private namePlateName: string;
+  public readonly combat: CharacterCombat;
   public readonly movement: CharacterMovement;
 
   private animator: Animator<AnimationState>;
@@ -203,6 +204,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
         ? characterName.slice(0, MAX_NAME_LENGTH - 3) + "..."
         : characterName;
 
+    this.combat = new CharacterCombat(this);
     this.movement = new CharacterMovement(this);
     this.body = new Body(getLevel().terrain.characterMask, {
       mask: rectangle6x16,
@@ -286,7 +288,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
           if (
             (getManager().getActiveCharacter() !== this ||
               !this.player.controller.isKeyDown()) &&
-            !this.spellSource
+            !this.combat.isCasting()
           ) {
             this.animator.animate(AnimationState.ReadDone);
           }
@@ -459,60 +461,15 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   setSpellSource(source: any, toggle = true) {
-    if (toggle) {
-      if (this.body.onLadder) {
-        return;
-      }
-
-      this.spellSource = source;
-
-      if (
-        this.animator.animationState !== AnimationState.SpellIdle &&
-        !this.player.controller.isKeyDown(Key.Left) &&
-        !this.player.controller.isKeyDown(Key.Right) &&
-        !this.player.controller.isKeyDown(Key.A) &&
-        !this.player.controller.isKeyDown(Key.D)
-      ) {
-        this.animator.animate(AnimationState.Spell);
-      }
-
-      this.animator.setDefaultAnimation(AnimationState.Spell);
-    } else if (!source || source === this.spellSource) {
-      this.spellSource = null;
-
-      let defaultAnimation;
-      if (
-        getManager().getActiveCharacter() === this &&
-        this.player.controller.isKeyDown(Key.Inventory)
-      ) {
-        defaultAnimation = AnimationState.Read;
-      } else {
-        defaultAnimation = AnimationState.Idle;
-      }
-
-      if (this.animator.animationState === AnimationState.SpellIdle) {
-        this.animator.animate(AnimationState.SpellDone);
-      } else if (this.animator.animationState === AnimationState.Spell) {
-        this.animator.animate(defaultAnimation);
-      }
-
-      this.animator.setDefaultAnimation(defaultAnimation);
-    }
+    this.combat.setSpellSource(source, toggle);
   }
 
   isCasting() {
-    return !!this.spellSource;
+    return this.combat.isCasting();
   }
 
   openSpellBook() {
-    if (
-      !this.spellSource &&
-      this.animator.animationState !== AnimationState.Read &&
-      this.animator.animationState !== AnimationState.ReadIdle
-    ) {
-      this.animator.animate(AnimationState.Read);
-      this.animator.setDefaultAnimation(AnimationState.Read);
-    }
+    this.combat.openSpellBook();
   }
 
   serialize() {

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -175,7 +175,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
   private static readonly maxInactiveTime = 3;
 
   public readonly body: Body;
-  public readonly health: CharacterHealth;
+  private readonly health: CharacterHealth;
   public id = -1;
   public readonly priority = Priority.Low;
   public readonly type = EntityType.Character;

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -12,7 +12,6 @@ import { Player } from "../network/player";
 import { Force, TargetList } from "../damage/targetList";
 import { EntityType, HurtableEntity, Priority, Syncable } from "./types";
 import { GenericDamage } from "../damage/genericDamage";
-import { ExplosiveDamage } from "../damage/explosiveDamage";
 import { DamageSource } from "../damage/types";
 import { ParticleEmitter } from "../../graphics/particles/types";
 import {
@@ -27,8 +26,6 @@ import {
   createBackgroundParticles,
   createWandParticles,
 } from "../../graphics/particles/factory/character";
-import { createCharacterGibs } from "./gib/characterGibs";
-import { Explosion } from "../../graphics/explosion";
 import { ControllableSound } from "../../sound/controllableSound";
 import { Sound } from "../../sound";
 import { Wings } from "./wings";
@@ -36,6 +33,7 @@ import { SmokePuff } from "../../graphics/smokePuff";
 import { COLORS } from "../network/constants";
 import { BBox } from "../map/bbox";
 import { getLevel, getManager, getServer } from "../context";
+import { CharacterHealth } from "./characterHealth";
 
 // Start bouncing when impact is greater than this value
 const BOUNCE_TRIGGER = 3.8;
@@ -174,12 +172,10 @@ const ANIMATION_CONFIG: Record<
 };
 
 export class Character extends Container implements HurtableEntity, Syncable {
-  private static readonly invulnerableTime = 1;
-  private static readonly damageNumberTime = 90;
   private static readonly maxInactiveTime = 3;
-  private static readonly damageAttributionTime = 120;
 
   public readonly body: Body;
+  public readonly health: CharacterHealth;
   public id = -1;
   public readonly priority = Priority.Low;
   public readonly type = EntityType.Character;
@@ -189,11 +185,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
   private particles?: ParticleEmitter;
   private foregroundParticles?: ParticleEmitter;
 
-  private _hp = 100;
-  private lastReportedHp = this._hp;
-  private time = 0;
-  private lastDamageTime = -1;
-  private _lastDamageDealer: Player | null = null;
+  public time = 0;
   private lastActiveTime = 0;
   private spellSource: any | null = null;
   private lookDirection = 1;
@@ -327,7 +319,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
     sprite2.alpha = 0.5;
 
     this.namePlate = new BitmapText({
-      text: `${this.namePlateName} ${this._hp}`,
+      text: `${this.namePlateName} 100`,
       style: {
         fontFamily: "Eternal",
         fontSize: 32,
@@ -336,6 +328,8 @@ export class Character extends Container implements HurtableEntity, Syncable {
     this.namePlate.tint = this.player.color;
     this.namePlate.anchor.set(0.5);
     this.namePlate.position.set(18, -40);
+
+    this.health = new CharacterHealth(this, this.namePlate, this.namePlateName);
 
     this.addChild(this.sprite, this.namePlate);
   }
@@ -363,20 +357,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
       this.body.active = 1;
     }
 
-    if (
-      this.lastReportedHp !== this._hp &&
-      this.time > this.lastDamageTime + Character.damageNumberTime
-    ) {
-      getLevel().numberContainer.damage(
-        this.lastReportedHp - this._hp,
-        ...this.getCenter()
-      );
-      this.namePlate.text = `${this.namePlateName} ${Math.max(
-        0,
-        Math.ceil(this._hp)
-      )}`;
-      this.lastReportedHp = this._hp;
-    }
+    this.health.reportDamageNumbers();
 
     if (this.body.active) {
       this.lastActiveTime = this.time;
@@ -585,28 +566,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   damage(source: DamageSource, damage: number, force?: Force) {
-    if (
-      this.lastDamageTime !== -1 &&
-      this.time <= this.lastDamageTime + Character.invulnerableTime
-    ) {
-      return;
-    }
-
-    this.player.stats.registerDamage(source, this, damage, force);
-
-    this.hp -= damage;
-    this.lastDamageTime = this.time;
-    this._lastDamageDealer = source.cause;
-    this.body.unmountLadder();
-
-    getLevel().bloodEmitter.burst(this, damage, source);
-    if (damage > 0) {
-      ControllableSound.fromEntity(this, Sound.Splat);
-    }
-
-    if (force) {
-      this.body.addAngularVelocity(force.power, force.direction);
-    }
+    this.health.damage(source, damage, force);
   }
 
   setSpellSource(source: any, toggle = true) {
@@ -695,58 +655,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   die() {
-    if (this._hp !== this.lastReportedHp) {
-      getLevel().numberContainer.damage(
-        this.lastReportedHp - this._hp,
-        ...this.getCenter()
-      );
-      this.namePlate.text = `${this.namePlateName} ${Math.max(
-        0,
-        Math.ceil(this._hp)
-      )}`;
-      this.lastReportedHp = this._hp;
-    }
-
-    getLevel().terrain.characterMask.subtract(
-      this.body.mask,
-      ...this.body.position
-    );
-
-    this.player.removeCharacter(this);
-
-    const [x, y] = this.getCenter();
-    new Explosion(x, y);
-    getLevel().shake();
-
-    const gibs = createCharacterGibs(...this.body.precisePosition);
-    gibs.forEach((gib) =>
-      gib.body.addVelocity((Math.random() - 0.5) * 8, -2 - Math.random() * 3)
-    );
-    getLevel().add(...gibs);
-    getLevel().bloodEmitter.burst(this, 100);
-
-    getLevel().terrain.draw((ctx) => {
-      const splat = AssetsContainer.instance.assets!["atlas"].textures[
-        "gibs_splat"
-      ] as Texture;
-
-      ctx.drawImage(
-        splat.source.resource,
-        splat.frame.left,
-        splat.frame.top,
-        splat.frame.width,
-        splat.frame.height,
-        x / 6 - splat.frame.width / 2,
-        y / 6 - splat.frame.height / 2 + 5,
-        splat.frame.width,
-        splat.frame.height
-      );
-    });
-
-    getServer()?.damage(
-      new ExplosiveDamage(x / 6, y / 6, 16, 1, 1),
-      this.player
-    );
+    this.health.die();
   }
 
   giveWings() {
@@ -776,23 +685,11 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   get hp() {
-    return this._hp;
+    return this.health.hp;
   }
 
   set hp(hp: number) {
-    const oldHp = this._hp;
-    const diff = hp - oldHp;
-    if (diff > 0) {
-      getLevel().numberContainer.heal(diff, ...this.getCenter());
-      this.lastReportedHp += diff;
-      this.namePlate.text = `${this.namePlateName} ${Math.max(
-        0,
-        Math.ceil(this.lastReportedHp)
-      )}`;
-    }
-
-    this._hp = hp;
-    this.body.active = 1;
+    this.health.hp = hp;
   }
 
   get direction() {
@@ -800,10 +697,6 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   get lastDamageDealer() {
-    if (this.time > this.lastDamageTime + Character.damageAttributionTime) {
-      return null;
-    }
-
-    return this._lastDamageDealer;
+    return this.health.lastDamageDealer;
   }
 }

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -182,7 +182,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
   private particles?: ParticleEmitter;
   private foregroundParticles?: ParticleEmitter;
 
-  public time = 0;
+  private _time = 0;
   private lastActiveTime = 0;
   private lookDirection = 1;
   private namePlateName: string;
@@ -349,15 +349,15 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   tick(dt: number) {
-    this.time += dt;
-    if (this.time > this.lastActiveTime + Character.maxInactiveTime) {
+    this._time += dt;
+    if (this._time > this.lastActiveTime + Character.maxInactiveTime) {
       this.body.active = 1;
     }
 
     this.health.reportDamageNumbers();
 
     if (this.body.active) {
-      this.lastActiveTime = this.time;
+      this.lastActiveTime = this._time;
 
       getLevel().terrain.characterMask.subtract(
         this.body.mask,
@@ -369,7 +369,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
         this.position.set(x * 6, y * 6);
 
         if (this.body.grounded) {
-          this.movement.lastGroundedTime = this.time;
+          this.movement.lastGroundedTime = this._time;
         }
 
         if (
@@ -536,6 +536,10 @@ export class Character extends Container implements HurtableEntity, Syncable {
 
   set hp(hp: number) {
     this.health.hp = hp;
+  }
+
+  get time() {
+    return this._time;
   }
 
   get direction() {

--- a/src/data/entity/characterCombat.ts
+++ b/src/data/entity/characterCombat.ts
@@ -1,0 +1,70 @@
+import { Key } from "../controller/controller";
+import { getManager } from "../context";
+import type { Character } from "./character";
+
+export class CharacterCombat {
+  private spellSource: any | null = null;
+
+  constructor(private character: Character) {}
+
+  setSpellSource(source: any, toggle = true): void {
+    if (toggle) {
+      if (this.character.body.onLadder) {
+        return;
+      }
+
+      this.spellSource = source;
+
+      if (
+        !this.character.isInAnimationState("SpellIdle") &&
+        !this.character.player.controller.isKeyDown(Key.Left) &&
+        !this.character.player.controller.isKeyDown(Key.Right) &&
+        !this.character.player.controller.isKeyDown(Key.A) &&
+        !this.character.player.controller.isKeyDown(Key.D)
+      ) {
+        this.character.animate("Spell");
+      }
+
+      this.character.setDefaultAnimation("Spell");
+    } else if (!source || source === this.spellSource) {
+      this.spellSource = null;
+
+      let defaultAnimation: "Read" | "Idle";
+      if (
+        getManager().getActiveCharacter() === this.character &&
+        this.character.player.controller.isKeyDown(Key.Inventory)
+      ) {
+        defaultAnimation = "Read";
+      } else {
+        defaultAnimation = "Idle";
+      }
+
+      if (this.character.isInAnimationState("SpellIdle")) {
+        this.character.animate("SpellDone");
+      } else if (this.character.isInAnimationState("Spell")) {
+        this.character.animate(defaultAnimation);
+      }
+
+      this.character.setDefaultAnimation(defaultAnimation);
+    }
+  }
+
+  isCasting(): boolean {
+    return !!this.spellSource;
+  }
+
+  openSpellBook(): void {
+    if (
+      !this.spellSource &&
+      !this.character.isInAnimationState("Read") &&
+      !this.character.isInAnimationState("ReadIdle")
+    ) {
+      this.character.animate("Read");
+      this.character.setDefaultAnimation("Read");
+    }
+  }
+
+  melee(): void {
+    this.character.animate("Swing");
+  }
+}

--- a/src/data/entity/characterHealth.ts
+++ b/src/data/entity/characterHealth.ts
@@ -1,0 +1,172 @@
+import { BitmapText } from "pixi.js";
+import { Player } from "../network/player";
+import { DamageSource } from "../damage/types";
+import { Force } from "../damage/targetList";
+import { ControllableSound } from "../../sound/controllableSound";
+import { Sound } from "../../sound";
+import { getLevel, getServer } from "../context";
+import { GenericDamage } from "../damage/genericDamage";
+import { TargetList } from "../damage/targetList";
+import { ExplosiveDamage } from "../damage/explosiveDamage";
+import { AssetsContainer } from "../../util/assets/assetsContainer";
+import { Texture } from "pixi.js";
+import { Explosion } from "../../graphics/explosion";
+import { createCharacterGibs } from "./gib/characterGibs";
+import type { Character } from "./character";
+
+export class CharacterHealth {
+  private static readonly invulnerableTime = 1;
+  private static readonly damageNumberTime = 90;
+  private static readonly damageAttributionTime = 120;
+
+  private _hp = 100;
+  private lastReportedHp = this._hp;
+  private lastDamageTime = -1;
+  private _lastDamageDealer: Player | null = null;
+
+  constructor(
+    private character: Character,
+    private namePlate: BitmapText,
+    private namePlateName: string
+  ) {}
+
+  get hp(): number {
+    return this._hp;
+  }
+
+  set hp(hp: number) {
+    const oldHp = this._hp;
+    const diff = hp - oldHp;
+    if (diff > 0) {
+      getLevel().numberContainer.heal(diff, ...this.character.getCenter());
+      this.lastReportedHp += diff;
+      this.namePlate.text = `${this.namePlateName} ${Math.max(
+        0,
+        Math.ceil(this.lastReportedHp)
+      )}`;
+    }
+
+    this._hp = hp;
+    this.character.body.active = 1;
+  }
+
+  get lastDamageDealer(): Player | null {
+    if (
+      this.character.time >
+      this.lastDamageTime + CharacterHealth.damageAttributionTime
+    ) {
+      return null;
+    }
+
+    return this._lastDamageDealer;
+  }
+
+  reportDamageNumbers(): void {
+    if (
+      this.lastReportedHp !== this._hp &&
+      this.character.time >
+        this.lastDamageTime + CharacterHealth.damageNumberTime
+    ) {
+      getLevel().numberContainer.damage(
+        this.lastReportedHp - this._hp,
+        ...this.character.getCenter()
+      );
+      this.namePlate.text = `${this.namePlateName} ${Math.max(
+        0,
+        Math.ceil(this._hp)
+      )}`;
+      this.lastReportedHp = this._hp;
+    }
+  }
+
+  damage(source: DamageSource, damage: number, force?: Force): void {
+    if (
+      this.lastDamageTime !== -1 &&
+      this.character.time <=
+        this.lastDamageTime + CharacterHealth.invulnerableTime
+    ) {
+      return;
+    }
+
+    this.character.player.stats.registerDamage(
+      source,
+      this.character,
+      damage,
+      force
+    );
+
+    this.hp -= damage;
+    this.lastDamageTime = this.character.time;
+    this._lastDamageDealer = source.cause;
+    this.character.body.unmountLadder();
+
+    getLevel().bloodEmitter.burst(this.character, damage, source);
+    if (damage > 0) {
+      ControllableSound.fromEntity(this.character, Sound.Splat);
+    }
+
+    if (force) {
+      this.character.body.addAngularVelocity(force.power, force.direction);
+    }
+  }
+
+  die(): void {
+    if (this._hp !== this.lastReportedHp) {
+      getLevel().numberContainer.damage(
+        this.lastReportedHp - this._hp,
+        ...this.character.getCenter()
+      );
+      this.namePlate.text = `${this.namePlateName} ${Math.max(
+        0,
+        Math.ceil(this._hp)
+      )}`;
+      this.lastReportedHp = this._hp;
+    }
+
+    getLevel().terrain.characterMask.subtract(
+      this.character.body.mask,
+      ...this.character.body.position
+    );
+
+    this.character.player.removeCharacter(this.character);
+
+    const [x, y] = this.character.getCenter();
+    new Explosion(x, y);
+    getLevel().shake();
+
+    const gibs = createCharacterGibs(
+      ...this.character.body.precisePosition
+    );
+    gibs.forEach((gib) =>
+      gib.body.addVelocity(
+        (Math.random() - 0.5) * 8,
+        -2 - Math.random() * 3
+      )
+    );
+    getLevel().add(...gibs);
+    getLevel().bloodEmitter.burst(this.character, 100);
+
+    getLevel().terrain.draw((ctx) => {
+      const splat = AssetsContainer.instance.assets!["atlas"].textures[
+        "gibs_splat"
+      ] as Texture;
+
+      ctx.drawImage(
+        splat.source.resource,
+        splat.frame.left,
+        splat.frame.top,
+        splat.frame.width,
+        splat.frame.height,
+        x / 6 - splat.frame.width / 2,
+        y / 6 - splat.frame.height / 2 + 5,
+        splat.frame.width,
+        splat.frame.height
+      );
+    });
+
+    getServer()?.damage(
+      new ExplosiveDamage(x / 6, y / 6, 16, 1, 1),
+      this.character.player
+    );
+  }
+}

--- a/src/data/entity/characterHealth.ts
+++ b/src/data/entity/characterHealth.ts
@@ -5,8 +5,6 @@ import { Force } from "../damage/targetList";
 import { ControllableSound } from "../../sound/controllableSound";
 import { Sound } from "../../sound";
 import { getLevel, getServer } from "../context";
-import { GenericDamage } from "../damage/genericDamage";
-import { TargetList } from "../damage/targetList";
 import { ExplosiveDamage } from "../damage/explosiveDamage";
 import { AssetsContainer } from "../../util/assets/assetsContainer";
 import { Texture } from "pixi.js";

--- a/src/data/entity/characterMovement.ts
+++ b/src/data/entity/characterMovement.ts
@@ -1,0 +1,181 @@
+import { Controller, Key } from "../controller/controller";
+import { BBox } from "../map/bbox";
+import { Wings } from "./wings";
+import { getLevel, getManager } from "../context";
+import type { Character } from "./character";
+
+const MAX_LADDER_MOUNT_SPEED = 1;
+const JUMP_GRACE_TIME = 3;
+
+export class CharacterMovement {
+  private wasUp = false;
+  public lastGroundedTime = 0;
+  private wings?: Wings;
+
+  constructor(private character: Character) {}
+
+  ladderTest = (x: number, y: number): boolean => {
+    if (!getManager().isTrusted(this.character)) {
+      return false;
+    }
+
+    for (let ladder of getLevel().terrain.ladders) {
+      if (
+        x + 6 >= ladder.left &&
+        x <= ladder.right &&
+        y + 16 > ladder.top &&
+        y < ladder.bottom
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  control(controller: Controller): void {
+    let foundLadder: BBox | null = null;
+    if (
+      this.character.body.grounded ||
+      this.character.body.onLadder ||
+      (this.character.body.yVelocity > 0 &&
+        this.character.body.yVelocity < MAX_LADDER_MOUNT_SPEED)
+    ) {
+      const [x, y] = this.character.body.precisePosition;
+      for (let ladder of getLevel().terrain.ladders) {
+        if (
+          x + 6 >= ladder.left &&
+          x <= ladder.right &&
+          y + 16 > ladder.top &&
+          y < ladder.bottom &&
+          ladder.top < (foundLadder?.top || Infinity)
+        ) {
+          foundLadder = ladder;
+        }
+      }
+    }
+
+    if (this.character.body.onLadder) {
+      this.character.setSpellSource(null, false);
+    }
+
+    const isUp =
+      controller.isKeyDown(Key.Up) || controller.isKeyDown(Key.W);
+    if (!this.wings && foundLadder && isUp) {
+      this.character.body.mountLadder();
+    }
+
+    if (this.character.body.onLadder) {
+      if (!foundLadder) {
+        if (getManager().isTrusted(this.character)) {
+          this.character.body.unmountLadder();
+        }
+        return;
+      }
+
+      if (isUp) {
+        if (
+          this.character.body.precisePosition[1] + 8 >
+          foundLadder.top
+        ) {
+          this.character.body.setLadderDirection(-1);
+          this.character.animate("Climb");
+        } else {
+          if (!this.wasUp) {
+            this.character.body.unmountLadder();
+            this.character.body.jump();
+            this.character.animate("Jump");
+          }
+
+          this.character.body.setLadderDirection(0);
+        }
+      } else if (
+        controller.isKeyDown(Key.Down) ||
+        controller.isKeyDown(Key.D)
+      ) {
+        this.character.body.setLadderDirection(1);
+        this.character.animate("Climb");
+      } else {
+        this.character.body.setLadderDirection(0);
+      }
+
+      this.wasUp = isUp;
+      return;
+    }
+
+    if (!isUp) {
+      return;
+    }
+
+    if (
+      this.character.time - this.lastGroundedTime < JUMP_GRACE_TIME &&
+      !this.wings
+    ) {
+      if (this.character.body.jump()) {
+        this.character.animate("Jump");
+      }
+    }
+
+    if (this.wings) {
+      this.wings.flap(this.character.time);
+      this.character.animate("Float");
+
+      if (this.wings.power <= 0) {
+        this.removeWings();
+      }
+    }
+  }
+
+  controlContinuous(dt: number, controller: Controller): void {
+    if (this.character.isAnimationBlocking()) {
+      return;
+    }
+
+    this.character.updateLookDirection(controller);
+
+    if (
+      controller.isKeyDown(Key.Left) ||
+      controller.isKeyDown(Key.A)
+    ) {
+      this.character.body.walk(-1);
+
+      if (this.character.body.grounded) {
+        this.character.animate("Walk");
+        this.character.syncAnimationDirection();
+      }
+    }
+
+    if (
+      controller.isKeyDown(Key.Right) ||
+      controller.isKeyDown(Key.D)
+    ) {
+      this.character.body.walk(1);
+
+      if (this.character.body.grounded) {
+        this.character.animate("Walk");
+        this.character.syncAnimationDirection();
+      }
+    }
+  }
+
+  giveWings(): void {
+    this.character.body.unmountLadder();
+    this.wings = new Wings(this.character);
+    this.character.addChildAt(this.wings, 0);
+  }
+
+  removeWings(): void {
+    if (!this.wings) {
+      return;
+    }
+
+    this.wings.stop();
+    this.character.removeChild(this.wings);
+    this.wings = undefined;
+  }
+
+  endTurn(): void {
+    this.removeWings();
+    this.character.body.setLadderDirection(0);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "lib": ["esnext", "dom", "dom.iterable"],
     "allowImportingTsExtensions": true,
     "noEmit": true,
-    "types": ["earcut", "fluent-ffmpeg", "lodash", "lodash.debounce"]
+    "types": ["earcut", "fluent-ffmpeg", "lodash", "lodash.debounce", "vitest/globals"]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
## Summary

- **Character.ts** (809 → 548 lines): Extract `CharacterHealth`, `CharacterMovement`, `CharacterCombat` helper classes into `src/data/entity/`
- **Builder.vue** (682 → 520 lines): Extract `useBuilderLayers`, `useBuilderLadders`, `useBuilderMap` composables into `src/components/pages/composables/`
- **Host.vue** (297 → 227 lines): Extract `useHostServer`, `useHostPlayers` composables into `src/components/pages/composables/`

Pure refactor — zero behavior changes. All 157 tests pass. Each extracted unit has a single clear responsibility and is independently testable.

## Test plan

- [x] All 157 existing tests pass
- [x] Type check passes (no new errors)
- [ ] Manual smoke test: Host, Join, Builder pages work without runtime errors
- [ ] Manual smoke test: gameplay still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)