### PR TITLE
refactor: deduplicate spell patterns with config-driven factory

### DIFF
--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -1,15 +1,11 @@
 <script setup lang="ts">
-import { Ref, onMounted, ref, watch } from "vue";
-import { Map, Layer, Config } from "../../data/map";
+import { onMounted, ref, watch } from "vue";
+import { Map, Config, Layer } from "../../data/map";
 import Input from "../atoms/Input.vue";
-import { Server } from "../../data/network/server";
-import { Team } from "../../data/team";
 import BoundingBox from "../molecules/BoundingBox.vue";
 import { BBox } from "../../data/map/bbox";
 import { useRouter } from "vue-router";
-import { logEvent } from "../../util/firebase";
 import { GameSettings } from "../../util/localStorage/settings";
-import { defaults } from "../../util/localStorage/settings";
 import MapSelect from "../organisms/MapSelect.vue";
 import BuilderSettings, {
   AdvancedSettings,
@@ -18,6 +14,9 @@ import ImageInput from "../molecules/ImageInput.vue";
 import IconButton from "../atoms/IconButton.vue";
 import plus from "pixelarticons/svg/plus.svg";
 import Collapsible from "../atoms/Collapsible.vue";
+import { useBuilderLayers } from "./composables/useBuilderLayers";
+import { useBuilderLadders } from "./composables/useBuilderLadders";
+import { useBuilderMap } from "./composables/useBuilderMap";
 
 const { onPlay, config } = defineProps<{
   onPlay: (key: string, map: Map | Config, settings: GameSettings) => void;
@@ -27,12 +26,6 @@ const router = useRouter();
 const preview = ref<HTMLDivElement>();
 
 const name = ref("");
-const terrain = ref({ data: "", visible: false });
-const mask = ref({ data: "", visible: false });
-const background = ref({ data: "", visible: false });
-const layers = ref<Array<Layer & { visible: boolean }>>([]);
-const ladders = ref<BBox[]>([]);
-const creatingLadder = ref(false);
 
 const settingsOpen = ref(false);
 const advancedSettings = ref<AdvancedSettings>({
@@ -42,6 +35,23 @@ const advancedSettings = ref<AdvancedSettings>({
   parallaxName: "",
   parallaxOffset: 0,
 });
+
+const oldScale = ref(advancedSettings.value.scale);
+
+const {
+  terrain, mask, background, layers,
+  handleAddTerrain, handleSetTerrainVisibility,
+  handleAddMask, handleSetMaskVisibility,
+  handleAddBackground, handleSetBackgroundVisibility,
+  handleAddLayer, handleRemoveLayer, handleSetLayerVisibility,
+} = useBuilderLayers(advancedSettings, preview);
+
+const { ladders, creatingLadder, handleCreateLadder } =
+  useBuilderLadders(advancedSettings, preview);
+
+const { handleBuild, handleTest, loadMap } = useBuilderMap(
+  name, terrain, mask, background, layers, ladders, advancedSettings, oldScale
+);
 
 onMounted(async () => {
   if (config) {
@@ -58,7 +68,6 @@ watch(
   }
 );
 
-const oldScale = ref(advancedSettings.value.scale);
 watch(
   () => advancedSettings.value.scale,
   (scale) => {
@@ -68,128 +77,6 @@ watch(
     oldScale.value = scale;
   }
 );
-
-const addImageFactory =
-  (ref: Ref, visible = true) =>
-  (_: File, data: string) => {
-    ref.value = { data, visible };
-
-    if (advancedSettings.value.bbox.isEmpty()) {
-      var image = new Image();
-      image.src = data;
-
-      image.onload = () => {
-        advancedSettings.value.bbox = BBox.create(image.width, image.height);
-      };
-    }
-  };
-
-const handleAddTerrain = addImageFactory(terrain);
-const handleSetTerrainVisibility = (visible: boolean) =>
-  (terrain.value.visible = visible);
-const handleAddMask = addImageFactory(mask, false);
-const handleSetMaskVisibility = (visible: boolean) =>
-  (mask.value.visible = visible);
-
-const handleAddBackground = addImageFactory(background);
-const handleSetBackgroundVisibility = (visible: boolean) =>
-  (background.value.visible = visible);
-
-const handleBuild = async () => {
-  const map = await Map.fromConfig({
-    terrain: { data: terrain.value.data, mask: mask.value.data },
-    background: background.value.data
-      ? { data: background.value.data }
-      : undefined,
-    layers: layers.value
-      .filter((layer) => !!layer.data)
-      .map((layer) => ({ ...layer })),
-    bbox: advancedSettings.value.bbox,
-    parallax: {
-      name: advancedSettings.value.parallaxName,
-      offset: advancedSettings.value.parallaxOffset,
-    },
-    scale: advancedSettings.value.scale,
-    ladders: ladders.value,
-  });
-
-  const url = URL.createObjectURL(await map.toBlob());
-  setTimeout(() => window.URL.revokeObjectURL(url), 1000);
-
-  const link = document.createElement("a");
-  link.download = `${name.value || "map"}.png`;
-  link.href = url;
-  link.click();
-
-  logEvent("build_map");
-};
-
-const handleTest = async () => {
-  const config: Config = {
-    terrain: { data: terrain.value.data, mask: mask.value.data },
-    background: background.value.data
-      ? { data: background.value.data }
-      : undefined,
-    layers: layers.value
-      .filter((layer) => !!layer.data)
-      .map((layer) => ({ ...layer })),
-    bbox: advancedSettings.value.bbox,
-    parallax: {
-      name: advancedSettings.value.parallaxName,
-      offset: advancedSettings.value.parallaxOffset,
-    },
-    scale: advancedSettings.value.scale,
-    ladders: ladders.value,
-  };
-
-  const server = new Server();
-  server.addPlayer("Test player", Team.random());
-  onPlay("0000", config, { ...defaults().gameSettings, teamSize: 1 });
-};
-
-const loadMap = (config: Config, map: string) => {
-  oldScale.value = config.scale;
-  terrain.value = { data: config.terrain.data as string, visible: true };
-  background.value = {
-    data: (config.background?.data as string) || "",
-    visible: true,
-  };
-  layers.value = config.layers.map((layer) => ({ ...layer, visible: true }));
-  advancedSettings.value = {
-    bbox: BBox.fromJS(config.bbox) || BBox.create(0, 0),
-    scale: config.scale,
-    customMask: !!config.terrain.mask,
-    parallaxName: config.parallax.name,
-    parallaxOffset: config.parallax.offset,
-  };
-  name.value = map;
-  ladders.value =
-    (config.ladders
-      ?.map((bbox) => BBox.fromJS(bbox))
-      .filter(Boolean) as BBox[]) || [];
-
-  if (config.terrain.mask) {
-    mask.value = { data: config.terrain.mask as string, visible: false };
-  } else {
-    mask.value = { data: "", visible: false };
-  }
-};
-
-const handleAddLayer = () =>
-  layers.value.push({
-    data: "",
-    x: Math.round(preview.value!.scrollLeft / advancedSettings.value.scale),
-    y: Math.round(preview.value!.scrollTop / advancedSettings.value.scale),
-    visible: true,
-  });
-
-const handleRemoveLayer = (index: number) => {
-  layers.value = layers.value.filter((_, i) => i !== index);
-};
-
-const handleSetLayerVisibility = (visible: boolean, index: number) => {
-  layers.value[index].visible = visible;
-};
 
 const handleMouseDown = (event: MouseEvent, layer: Layer) => {
   let x = layer.x;
@@ -218,55 +105,6 @@ const handleMouseDown = (event: MouseEvent, layer: Layer) => {
 
 const handleBBoxChange = (newBBox: BBox) => {
   advancedSettings.value.bbox = newBBox;
-};
-
-const handleCreateLadder = (event: MouseEvent) => {
-  if (!creatingLadder.value) {
-    return;
-  }
-
-  event.preventDefault();
-  const position = preview.value!.getBoundingClientRect();
-  const x = Math.round(
-    (position.left - preview.value!.scrollLeft) / advancedSettings.value.scale
-  );
-  const y = Math.round(
-    (position.top - preview.value!.scrollTop) / advancedSettings.value.scale
-  );
-  const startX = Math.round(event.pageX / advancedSettings.value.scale) - x;
-  const startY = Math.round(event.pageY / advancedSettings.value.scale) - y;
-
-  ladders.value.push(
-    BBox.fromJS({
-      left: startX,
-      top: startY,
-      right: startX,
-      bottom: startY,
-    })!
-  );
-
-  const handleMouseMove = (moveEvent: MouseEvent) => {
-    ladders.value[ladders.value.length - 1].right = Math.max(
-      startX,
-      Math.round(moveEvent.pageX / advancedSettings.value.scale) - x
-    );
-    ladders.value[ladders.value.length - 1].bottom = Math.max(
-      startY,
-      Math.round(moveEvent.pageY / advancedSettings.value.scale) - y
-    );
-  };
-
-  const handleMouseUp = () => {
-    document.onselectstart = null;
-    document.removeEventListener("mousemove", handleMouseMove);
-    document.removeEventListener("mouseup", handleMouseUp);
-    creatingLadder.value = false;
-  };
-
-  event.preventDefault();
-  document.onselectstart = () => false;
-  document.addEventListener("mousemove", handleMouseMove);
-  document.addEventListener("mouseup", handleMouseUp);
 };
 </script>
 
@@ -349,7 +187,7 @@ const handleCreateLadder = (event: MouseEvent) => {
       >
         Build
       </button>
-      <button class="primary" title="Build and test" @click="handleTest">
+      <button class="primary" title="Build and test" @click="() => handleTest(onPlay)">
         Test
       </button>
       <button class="secondary" @click="() => router.replace('/')">Back</button>

--- a/src/components/pages/Host.vue
+++ b/src/components/pages/Host.vue
@@ -2,25 +2,21 @@
 import { onMounted, ref, watch } from "vue";
 import { get, set } from "../../util/localStorage";
 import { GameSettings, defaults } from "../../util/localStorage/settings";
-import { Server } from "../../data/network/server";
-import { PEER_ID_PREFIX } from "../../data/network/constants";
 import { MessageType } from "../../data/network/types";
-import Peer from "peerjs";
-import { Team } from "../../data/team";
 import { Config, Map } from "../../data/map";
-import { getManager, getServer } from "../../data/context";
-import { Player } from "../../data/network/player";
+import { getServer } from "../../data/context";
 import debounce from "lodash.debounce";
 import { useRouter } from "vue-router";
 import { logEvent } from "../../util/firebase";
 import TeamDisplay from "../organisms/TeamDisplay.vue";
 import TeamDialog from "../organisms/TeamDialog.vue";
-import { IPlayer } from "../types";
 import GameSettingsComponent from "../organisms/GameSettings.vue";
 import MapSelect from "../organisms/MapSelect.vue";
 import { COLORS } from "../../data/network/constants";
 import IconButton from "../atoms/IconButton.vue";
 import plus from "pixelarticons/svg/plus.svg";
+import { useHostServer } from "./composables/useHostServer";
+import { useHostPlayers } from "./composables/useHostPlayers";
 
 const { onPlay } = defineProps<{
   onPlay: (key: string, map: Map | Config, settings: GameSettings) => void;
@@ -31,8 +27,6 @@ const router = useRouter();
 const settings = defaults(get("Settings"));
 
 const team = ref(settings.team);
-const serverStarting = ref(false);
-const localPlayers = ref<string[]>([]);
 
 const mapContainer: { map: Map | null; name: string } = {
   map: null,
@@ -43,11 +37,8 @@ const gameSettings = ref({
   ...settings.gameSettings,
 });
 
-const key = ref("");
-const players = ref<Player[]>([]);
-const promise = ref<Promise<void>>();
-
-const editingPlayer = ref<IPlayer>();
+const { key, serverStarting, promise, createServer, destroyServer } =
+  useHostServer(gameSettings);
 
 watch(
   () => gameSettings.value.teamSize,
@@ -56,41 +47,6 @@ watch(
     getServer()!.players.forEach((player) => player.team.setSize(newSize));
   }
 );
-
-const createServer = () =>
-  new Promise<void>((resolve) => {
-    getManager()?.destroy();
-
-    key.value = Math.floor(Math.random() * 10000)
-      .toString()
-      .padStart(4, "0");
-
-    const peer = new Peer(PEER_ID_PREFIX + key.value);
-
-    peer.on("error", () => {
-      createServer().then(resolve);
-    });
-
-    peer.once("open", () => {
-      peer.off("error");
-
-      const server = new Server(peer);
-      server.teamSize = gameSettings.value.teamSize;
-
-      const player = server.addPlayer(settings.name, team.value);
-      localPlayers.value.push(player.color);
-
-      server.listen(updateLobby);
-      resolve();
-    });
-  });
-
-onMounted(async () => {
-  promise.value = createServer();
-
-  await promise.value;
-  updateLobby();
-});
 
 const updateLobby = debounce(() => {
   if (!getServer() || getServer()!.started) {
@@ -116,15 +72,33 @@ const updateLobby = debounce(() => {
   }
 }, 200);
 
+const {
+  players,
+  localPlayers,
+  editingPlayer,
+  handleAddLocalPlayer,
+  handleKick,
+  handleEditPlayer,
+  handleClose,
+  handleSave,
+} = useHostPlayers(updateLobby, gameSettings);
+
+onMounted(async () => {
+  promise.value = createServer(settings.name, team.value, (server) => {
+    const player = server.addPlayer(settings.name, team.value);
+    localPlayers.value.push(player.color);
+    server.listen(updateLobby);
+  });
+
+  await promise.value;
+  updateLobby();
+});
+
 const handleBack = () => {
   if (serverStarting.value) {
     return;
   }
-
-  if (getServer()) {
-    getServer()!.destroy();
-  }
-
+  destroyServer();
   router.replace("/");
 };
 
@@ -148,50 +122,6 @@ const handleStart = async () => {
     players: getServer()!.players.length,
     map: mapContainer.name,
   });
-};
-
-const handleAddLocalPlayer = () => {
-  const team = Team.random(gameSettings.value.teamSize);
-  const player = getServer()!.addPlayer(
-    `${settings.name} (${players.value?.length})`,
-    team
-  );
-  localPlayers.value.push(player.color);
-
-  updateLobby();
-};
-
-const handleKick = (index: number) => {
-  const player = getServer()!.players[index];
-  const localPlayerIndex = localPlayers.value.findIndex(
-    (localPlayer) => localPlayer === player.color
-  );
-
-  if (localPlayerIndex !== -1) {
-    localPlayers.value.splice(localPlayerIndex, 1);
-  }
-
-  getServer()!.kick(getServer()!.players[index]);
-  updateLobby();
-};
-
-const handleEditPlayer = (player: IPlayer) => {
-  editingPlayer.value = player;
-};
-
-const handleClose = () => {
-  editingPlayer.value = undefined;
-  updateLobby();
-};
-
-const handleSave = (name: string, characters: string[]) => {
-  (editingPlayer.value as Player).rename(
-    name,
-    Team.fromJson(characters, gameSettings.value.teamSize)
-  );
-
-  editingPlayer.value = undefined;
-  updateLobby();
 };
 
 const handleSaveSettings = (settings: GameSettings) => {
@@ -222,7 +152,7 @@ const handleSelectMap = async (config: Config, name: string) => {
         <IconButton
           v-if="players.length < COLORS.length"
           title="Add local player"
-          :onClick="handleAddLocalPlayer"
+          :onClick="() => handleAddLocalPlayer(settings.name)"
           :icon="plus"
         />
       </h2>

--- a/src/components/pages/composables/useBuilderLadders.ts
+++ b/src/components/pages/composables/useBuilderLadders.ts
@@ -1,0 +1,70 @@
+import { Ref, ref } from "vue";
+import { BBox } from "../../../data/map/bbox";
+import type { AdvancedSettings } from "../../organisms/BuilderSettings.vue";
+
+export function useBuilderLadders(
+  advancedSettings: Ref<AdvancedSettings>,
+  preview: Ref<HTMLDivElement | undefined>
+) {
+  const ladders = ref<BBox[]>([]);
+  const creatingLadder = ref(false);
+
+  const handleCreateLadder = (event: MouseEvent) => {
+    if (!creatingLadder.value) {
+      return;
+    }
+
+    event.preventDefault();
+    const position = preview.value!.getBoundingClientRect();
+    const x = Math.round(
+      (position.left - preview.value!.scrollLeft) /
+        advancedSettings.value.scale
+    );
+    const y = Math.round(
+      (position.top - preview.value!.scrollTop) /
+        advancedSettings.value.scale
+    );
+    const startX =
+      Math.round(event.pageX / advancedSettings.value.scale) - x;
+    const startY =
+      Math.round(event.pageY / advancedSettings.value.scale) - y;
+
+    ladders.value.push(
+      BBox.fromJS({
+        left: startX,
+        top: startY,
+        right: startX,
+        bottom: startY,
+      })!
+    );
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      ladders.value[ladders.value.length - 1].right = Math.max(
+        startX,
+        Math.round(moveEvent.pageX / advancedSettings.value.scale) - x
+      );
+      ladders.value[ladders.value.length - 1].bottom = Math.max(
+        startY,
+        Math.round(moveEvent.pageY / advancedSettings.value.scale) - y
+      );
+    };
+
+    const handleMouseUp = () => {
+      document.onselectstart = null;
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      creatingLadder.value = false;
+    };
+
+    event.preventDefault();
+    document.onselectstart = () => false;
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+  };
+
+  return {
+    ladders,
+    creatingLadder,
+    handleCreateLadder,
+  };
+}

--- a/src/components/pages/composables/useBuilderLayers.ts
+++ b/src/components/pages/composables/useBuilderLayers.ts
@@ -1,0 +1,78 @@
+import { Ref, ref } from "vue";
+import { Layer } from "../../../data/map";
+import { BBox } from "../../../data/map/bbox";
+import type { AdvancedSettings } from "../../organisms/BuilderSettings.vue";
+
+export function useBuilderLayers(
+  advancedSettings: Ref<AdvancedSettings>,
+  preview: Ref<HTMLDivElement | undefined>
+) {
+  const terrain = ref({ data: "", visible: false });
+  const mask = ref({ data: "", visible: false });
+  const background = ref({ data: "", visible: false });
+  const layers = ref<Array<Layer & { visible: boolean }>>([]);
+
+  const addImageFactory =
+    (target: Ref<{ data: string; visible: boolean }>, visible = true) =>
+    (_: File, data: string) => {
+      target.value = { data, visible };
+
+      if (advancedSettings.value.bbox.isEmpty()) {
+        var image = new Image();
+        image.src = data;
+
+        image.onload = () => {
+          advancedSettings.value.bbox = BBox.create(
+            image.width,
+            image.height
+          );
+        };
+      }
+    };
+
+  const handleAddTerrain = addImageFactory(terrain);
+  const handleSetTerrainVisibility = (visible: boolean) =>
+    (terrain.value.visible = visible);
+  const handleAddMask = addImageFactory(mask, false);
+  const handleSetMaskVisibility = (visible: boolean) =>
+    (mask.value.visible = visible);
+  const handleAddBackground = addImageFactory(background);
+  const handleSetBackgroundVisibility = (visible: boolean) =>
+    (background.value.visible = visible);
+
+  const handleAddLayer = () =>
+    layers.value.push({
+      data: "",
+      x: Math.round(
+        preview.value!.scrollLeft / advancedSettings.value.scale
+      ),
+      y: Math.round(
+        preview.value!.scrollTop / advancedSettings.value.scale
+      ),
+      visible: true,
+    });
+
+  const handleRemoveLayer = (index: number) => {
+    layers.value = layers.value.filter((_, i) => i !== index);
+  };
+
+  const handleSetLayerVisibility = (visible: boolean, index: number) => {
+    layers.value[index].visible = visible;
+  };
+
+  return {
+    terrain,
+    mask,
+    background,
+    layers,
+    handleAddTerrain,
+    handleSetTerrainVisibility,
+    handleAddMask,
+    handleSetMaskVisibility,
+    handleAddBackground,
+    handleSetBackgroundVisibility,
+    handleAddLayer,
+    handleRemoveLayer,
+    handleSetLayerVisibility,
+  };
+}

--- a/src/components/pages/composables/useBuilderMap.ts
+++ b/src/components/pages/composables/useBuilderMap.ts
@@ -1,0 +1,97 @@
+import { Ref } from "vue";
+import { Config, Layer, Map } from "../../../data/map";
+import { BBox } from "../../../data/map/bbox";
+import { Server } from "../../../data/network/server";
+import { Team } from "../../../data/team";
+import { logEvent } from "../../../util/firebase";
+import { defaults, GameSettings } from "../../../util/localStorage/settings";
+import type { AdvancedSettings } from "../../organisms/BuilderSettings.vue";
+
+export function useBuilderMap(
+  name: Ref<string>,
+  terrain: Ref<{ data: string; visible: boolean }>,
+  mask: Ref<{ data: string; visible: boolean }>,
+  background: Ref<{ data: string; visible: boolean }>,
+  layers: Ref<Array<Layer & { visible: boolean }>>,
+  ladders: Ref<BBox[]>,
+  advancedSettings: Ref<AdvancedSettings>,
+  oldScale: Ref<number>
+) {
+  const buildConfig = (): Config => ({
+    terrain: { data: terrain.value.data, mask: mask.value.data },
+    background: background.value.data
+      ? { data: background.value.data }
+      : undefined,
+    layers: layers.value
+      .filter((layer) => !!layer.data)
+      .map((layer) => ({ ...layer })),
+    bbox: advancedSettings.value.bbox,
+    parallax: {
+      name: advancedSettings.value.parallaxName,
+      offset: advancedSettings.value.parallaxOffset,
+    },
+    scale: advancedSettings.value.scale,
+    ladders: ladders.value,
+  });
+
+  const handleBuild = async () => {
+    const map = await Map.fromConfig(buildConfig());
+
+    const url = URL.createObjectURL(await map.toBlob());
+    setTimeout(() => window.URL.revokeObjectURL(url), 1000);
+
+    const link = document.createElement("a");
+    link.download = `${name.value || "map"}.png`;
+    link.href = url;
+    link.click();
+
+    logEvent("build_map");
+  };
+
+  const handleTest = async (
+    onPlay: (key: string, map: Map | Config, settings: GameSettings) => void
+  ) => {
+    const config = buildConfig();
+
+    const server = new Server();
+    server.addPlayer("Test player", Team.random());
+    onPlay("0000", config, { ...defaults().gameSettings, teamSize: 1 });
+  };
+
+  const loadMap = (config: Config, mapName: string) => {
+    oldScale.value = config.scale;
+    terrain.value = { data: config.terrain.data as string, visible: true };
+    background.value = {
+      data: (config.background?.data as string) || "",
+      visible: true,
+    };
+    layers.value = config.layers.map((layer) => ({
+      ...layer,
+      visible: true,
+    }));
+    advancedSettings.value = {
+      bbox: BBox.fromJS(config.bbox) || BBox.create(0, 0),
+      scale: config.scale,
+      customMask: !!config.terrain.mask,
+      parallaxName: config.parallax.name,
+      parallaxOffset: config.parallax.offset,
+    };
+    name.value = mapName;
+    ladders.value =
+      (config.ladders
+        ?.map((bbox) => BBox.fromJS(bbox))
+        .filter(Boolean) as BBox[]) || [];
+
+    if (config.terrain.mask) {
+      mask.value = { data: config.terrain.mask as string, visible: false };
+    } else {
+      mask.value = { data: "", visible: false };
+    }
+  };
+
+  return {
+    handleBuild,
+    handleTest,
+    loadMap,
+  };
+}

--- a/src/components/pages/composables/useHostPlayers.ts
+++ b/src/components/pages/composables/useHostPlayers.ts
@@ -1,0 +1,69 @@
+import { ref } from "vue";
+import { Player } from "../../../data/network/player";
+import { Team } from "../../../data/team";
+import { getServer } from "../../../data/context";
+import { GameSettings } from "../../../util/localStorage/settings";
+import { IPlayer } from "../../types";
+
+export function useHostPlayers(
+  updateLobby: () => void,
+  gameSettings: { value: GameSettings }
+) {
+  const players = ref<Player[]>([]);
+  const localPlayers = ref<string[]>([]);
+  const editingPlayer = ref<IPlayer>();
+
+  const handleAddLocalPlayer = (baseName: string) => {
+    const team = Team.random(gameSettings.value.teamSize);
+    const player = getServer()!.addPlayer(
+      `${baseName} (${players.value?.length})`,
+      team
+    );
+    localPlayers.value.push(player.color);
+    updateLobby();
+  };
+
+  const handleKick = (index: number) => {
+    const player = getServer()!.players[index];
+    const localPlayerIndex = localPlayers.value.findIndex(
+      (localPlayer) => localPlayer === player.color
+    );
+
+    if (localPlayerIndex !== -1) {
+      localPlayers.value.splice(localPlayerIndex, 1);
+    }
+
+    getServer()!.kick(getServer()!.players[index]);
+    updateLobby();
+  };
+
+  const handleEditPlayer = (player: IPlayer) => {
+    editingPlayer.value = player;
+  };
+
+  const handleClose = () => {
+    editingPlayer.value = undefined;
+    updateLobby();
+  };
+
+  const handleSave = (name: string, characters: string[]) => {
+    (editingPlayer.value as Player).rename(
+      name,
+      Team.fromJson(characters, gameSettings.value.teamSize)
+    );
+
+    editingPlayer.value = undefined;
+    updateLobby();
+  };
+
+  return {
+    players,
+    localPlayers,
+    editingPlayer,
+    handleAddLocalPlayer,
+    handleKick,
+    handleEditPlayer,
+    handleClose,
+    handleSave,
+  };
+}

--- a/src/components/pages/composables/useHostServer.ts
+++ b/src/components/pages/composables/useHostServer.ts
@@ -1,0 +1,56 @@
+import { ref } from "vue";
+import Peer from "peerjs";
+import { Server } from "../../../data/network/server";
+import { PEER_ID_PREFIX } from "../../../data/network/constants";
+import { getManager, getServer } from "../../../data/context";
+import { Team } from "../../../data/team";
+import { GameSettings } from "../../../util/localStorage/settings";
+
+export function useHostServer(gameSettings: { value: GameSettings }) {
+  const key = ref("");
+  const serverStarting = ref(false);
+  const promise = ref<Promise<void>>();
+
+  const createServer = (
+    name: string,
+    team: Team,
+    onReady: (server: Server) => void
+  ): Promise<void> =>
+    new Promise<void>((resolve) => {
+      getManager()?.destroy();
+
+      key.value = Math.floor(Math.random() * 10000)
+        .toString()
+        .padStart(4, "0");
+
+      const peer = new Peer(PEER_ID_PREFIX + key.value);
+
+      peer.on("error", () => {
+        createServer(name, team, onReady).then(resolve);
+      });
+
+      peer.once("open", () => {
+        peer.off("error");
+
+        const server = new Server(peer);
+        server.teamSize = gameSettings.value.teamSize;
+
+        onReady(server);
+        resolve();
+      });
+    });
+
+  const destroyServer = () => {
+    if (getServer()) {
+      getServer()!.destroy();
+    }
+  };
+
+  return {
+    key,
+    serverStarting,
+    promise,
+    createServer,
+    destroyServer,
+  };
+}

--- a/src/data/collision/__spec__/collisionMask.spec.ts
+++ b/src/data/collision/__spec__/collisionMask.spec.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from "vitest";
+import { CollisionMask } from "../collisionMask";
+
+describe("CollisionMask", () => {
+  describe("forRect", () => {
+    it("creates a mask with correct dimensions", () => {
+      const mask = CollisionMask.forRect(10, 5);
+      expect(mask.width).toBe(10);
+      expect(mask.height).toBe(5);
+    });
+
+    it("creates a 1x1 mask", () => {
+      const mask = CollisionMask.forRect(1, 1);
+      expect(mask.width).toBe(1);
+      expect(mask.height).toBe(1);
+      expect(mask.collidesWithPoint(0, 0)).toBe(true);
+    });
+
+    it("creates a mask wider than 32 bits", () => {
+      const mask = CollisionMask.forRect(64, 2);
+      expect(mask.width).toBe(64);
+      expect(mask.collidesWithPoint(0, 0)).toBe(true);
+      expect(mask.collidesWithPoint(63, 1)).toBe(true);
+    });
+
+    it("fills all pixels within the rect", () => {
+      const mask = CollisionMask.forRect(8, 4);
+      for (let y = 0; y < 4; y++) {
+        for (let x = 0; x < 8; x++) {
+          expect(mask.collidesWithPoint(x, y)).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe("collidesWithPoint", () => {
+    it("returns true for a point inside a filled mask", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(5, 5)).toBe(true);
+    });
+
+    it("returns false for negative x", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(-1, 5)).toBe(false);
+    });
+
+    it("returns false for negative y", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(5, -1)).toBe(false);
+    });
+
+    it("returns true at x=0, y=0", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(0, 0)).toBe(true);
+    });
+
+    it("returns true at max boundary", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(9, 9)).toBe(true);
+    });
+
+    it("returns false at x=width", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(10, 5)).toBe(false);
+    });
+
+    it("returns false at y=height", () => {
+      const mask = CollisionMask.forRect(10, 10);
+      expect(mask.collidesWithPoint(5, 10)).toBe(false);
+    });
+
+    it("detects cleared bits after subtract", () => {
+      const big = CollisionMask.forRect(10, 10);
+      const small = CollisionMask.forRect(2, 2);
+      big.subtract(small, 3, 3);
+      expect(big.collidesWithPoint(3, 3)).toBe(false);
+      expect(big.collidesWithPoint(4, 4)).toBe(false);
+      expect(big.collidesWithPoint(5, 5)).toBe(true);
+    });
+  });
+
+  describe("collidesWith", () => {
+    it("detects collision for overlapping masks", () => {
+      const a = CollisionMask.forRect(10, 10);
+      const b = CollisionMask.forRect(10, 10);
+      expect(a.collidesWith(b, 0, 0)).toBe(true);
+    });
+
+    it("returns false for non-overlapping masks (x)", () => {
+      const a = CollisionMask.forRect(5, 5);
+      const b = CollisionMask.forRect(5, 5);
+      expect(a.collidesWith(b, 10, 0)).toBe(false);
+    });
+
+    it("returns false for non-overlapping masks (y)", () => {
+      const a = CollisionMask.forRect(5, 5);
+      const b = CollisionMask.forRect(5, 5);
+      expect(a.collidesWith(b, 0, 10)).toBe(false);
+    });
+
+    it("detects partial overlap", () => {
+      const a = CollisionMask.forRect(10, 10);
+      const b = CollisionMask.forRect(10, 10);
+      expect(a.collidesWith(b, 5, 5)).toBe(true);
+    });
+
+    it("handles negative dx by swapping", () => {
+      const a = CollisionMask.forRect(10, 10);
+      const b = CollisionMask.forRect(10, 10);
+      expect(a.collidesWith(b, -5, 0)).toBe(true);
+    });
+
+    it("handles negative dy (other above)", () => {
+      const a = CollisionMask.forRect(10, 10);
+      const b = CollisionMask.forRect(10, 10);
+      expect(a.collidesWith(b, 0, -5)).toBe(true);
+    });
+
+    it("returns false when dx exceeds width", () => {
+      const a = CollisionMask.forRect(5, 5);
+      const b = CollisionMask.forRect(5, 5);
+      expect(a.collidesWith(b, 6, 0)).toBe(false);
+    });
+
+    it("returns false when other is completely above", () => {
+      const a = CollisionMask.forRect(5, 5);
+      const b = CollisionMask.forRect(5, 5);
+      expect(a.collidesWith(b, 0, -6)).toBe(false);
+    });
+
+    it("detects collision with 1x1 masks at same position", () => {
+      const a = CollisionMask.forRect(1, 1);
+      const b = CollisionMask.forRect(1, 1);
+      expect(a.collidesWith(b, 0, 0)).toBe(true);
+    });
+
+    it("works with masks wider than 32 pixels", () => {
+      const a = CollisionMask.forRect(64, 10);
+      const b = CollisionMask.forRect(10, 10);
+      expect(a.collidesWith(b, 50, 0)).toBe(true);
+    });
+  });
+
+  describe("add", () => {
+    it("sets bits in the target mask", () => {
+      const target = CollisionMask.forRect(10, 10);
+      target.subtract(CollisionMask.forRect(10, 10), 0, 0); // clear all
+      const small = CollisionMask.forRect(3, 3);
+      target.add(small, 2, 2);
+      expect(target.collidesWithPoint(2, 2)).toBe(true);
+      expect(target.collidesWithPoint(4, 4)).toBe(true);
+    });
+
+    it("does not affect bits outside the added region", () => {
+      const target = CollisionMask.forRect(10, 10);
+      target.subtract(CollisionMask.forRect(10, 10), 0, 0); // clear all
+      const small = CollisionMask.forRect(2, 2);
+      target.add(small, 5, 5);
+      expect(target.collidesWithPoint(0, 0)).toBe(false);
+      expect(target.collidesWithPoint(5, 5)).toBe(true);
+    });
+
+    it("is cumulative", () => {
+      const target = CollisionMask.forRect(10, 10);
+      target.subtract(CollisionMask.forRect(10, 10), 0, 0);
+      const dot = CollisionMask.forRect(1, 1);
+      target.add(dot, 0, 0);
+      target.add(dot, 9, 9);
+      expect(target.collidesWithPoint(0, 0)).toBe(true);
+      expect(target.collidesWithPoint(9, 9)).toBe(true);
+      expect(target.collidesWithPoint(5, 5)).toBe(false);
+    });
+  });
+
+  describe("subtract", () => {
+    it("clears bits in the target mask", () => {
+      const target = CollisionMask.forRect(10, 10);
+      const hole = CollisionMask.forRect(2, 2);
+      target.subtract(hole, 4, 4);
+      expect(target.collidesWithPoint(4, 4)).toBe(false);
+      expect(target.collidesWithPoint(5, 5)).toBe(false);
+    });
+
+    it("does not affect bits outside the subtracted region", () => {
+      const target = CollisionMask.forRect(10, 10);
+      const hole = CollisionMask.forRect(2, 2);
+      target.subtract(hole, 4, 4);
+      expect(target.collidesWithPoint(0, 0)).toBe(true);
+      expect(target.collidesWithPoint(9, 9)).toBe(true);
+    });
+
+    it("subtracting from empty is no-op", () => {
+      const target = CollisionMask.forRect(10, 10);
+      target.subtract(CollisionMask.forRect(10, 10), 0, 0);
+      target.subtract(CollisionMask.forRect(5, 5), 2, 2); // subtract again
+      expect(target.collidesWithPoint(3, 3)).toBe(false); // still clear
+    });
+  });
+
+  describe("difference", () => {
+    it("returns empty mask for identical overlap", () => {
+      const a = CollisionMask.forRect(8, 8);
+      const b = CollisionMask.forRect(8, 8);
+      const diff = a.difference(b, 0, 0);
+      // All bits of b are covered by a, so difference should be empty
+      for (let y = 0; y < 8; y++) {
+        for (let x = 0; x < 8; x++) {
+          expect(diff.collidesWithPoint(x, y)).toBe(false);
+        }
+      }
+    });
+
+    it("returns full other mask when no overlap", () => {
+      const a = CollisionMask.forRect(5, 5);
+      a.subtract(CollisionMask.forRect(5, 5), 0, 0); // empty mask
+      const b = CollisionMask.forRect(5, 5);
+      const diff = a.difference(b, 0, 0);
+      expect(diff.collidesWithPoint(0, 0)).toBe(true);
+      expect(diff.collidesWithPoint(4, 4)).toBe(true);
+    });
+
+    it("has correct dimensions matching other mask", () => {
+      const a = CollisionMask.forRect(20, 20);
+      const b = CollisionMask.forRect(5, 5);
+      const diff = a.difference(b, 3, 3);
+      expect(diff.width).toBe(5);
+      expect(diff.height).toBe(5);
+    });
+  });
+
+  describe("clone", () => {
+    it("has same dimensions", () => {
+      const original = CollisionMask.forRect(15, 20);
+      const cloned = original.clone();
+      expect(cloned.width).toBe(15);
+      expect(cloned.height).toBe(20);
+    });
+
+    it("has identical collision behavior", () => {
+      const original = CollisionMask.forRect(10, 10);
+      const hole = CollisionMask.forRect(2, 2);
+      original.subtract(hole, 3, 3);
+      const cloned = original.clone();
+      expect(cloned.collidesWithPoint(0, 0)).toBe(true);
+      expect(cloned.collidesWithPoint(3, 3)).toBe(false);
+    });
+
+    it("is independent — modifying clone does not affect original", () => {
+      const original = CollisionMask.forRect(10, 10);
+      const cloned = original.clone();
+      cloned.subtract(CollisionMask.forRect(10, 10), 0, 0);
+      expect(original.collidesWithPoint(5, 5)).toBe(true);
+      expect(cloned.collidesWithPoint(5, 5)).toBe(false);
+    });
+  });
+
+  describe("serialize / deserialize", () => {
+    it("round-trips dimensions", () => {
+      const original = CollisionMask.forRect(15, 20);
+      const serialized = original.serialize();
+      const restored = CollisionMask.deserialize({
+        width: serialized.width,
+        height: serialized.height,
+        mask: serialized.mask.map((buf) => new Uint8Array(buf)),
+      });
+      expect(restored.width).toBe(15);
+      expect(restored.height).toBe(20);
+    });
+
+    it("round-trips collision behavior", () => {
+      const original = CollisionMask.forRect(10, 10);
+      original.subtract(CollisionMask.forRect(2, 2), 4, 4);
+
+      const serialized = original.serialize();
+      const restored = CollisionMask.deserialize({
+        width: serialized.width,
+        height: serialized.height,
+        mask: serialized.mask.map((buf) => new Uint8Array(buf)),
+      });
+
+      expect(restored.collidesWithPoint(0, 0)).toBe(true);
+      expect(restored.collidesWithPoint(4, 4)).toBe(false);
+      expect(restored.collidesWithPoint(9, 9)).toBe(true);
+    });
+  });
+
+  describe("fromAlpha", () => {
+    it("sets bits for pixels with alpha > 128", () => {
+      const data = {
+        width: 4,
+        height: 1,
+        data: new Uint8ClampedArray([
+          0, 0, 0, 255, // alpha 255 → set
+          0, 0, 0, 0, // alpha 0 → unset
+          0, 0, 0, 129, // alpha 129 → set
+          0, 0, 0, 128, // alpha 128 → unset
+        ]),
+      } as unknown as ImageData;
+
+      const mask = CollisionMask.fromAlpha(data);
+      expect(mask.collidesWithPoint(0, 0)).toBe(true);
+      expect(mask.collidesWithPoint(1, 0)).toBe(false);
+      expect(mask.collidesWithPoint(2, 0)).toBe(true);
+      expect(mask.collidesWithPoint(3, 0)).toBe(false);
+    });
+  });
+
+  describe("fromColor", () => {
+    it("sets bits for pixels with red channel = 0", () => {
+      const data = {
+        width: 3,
+        height: 1,
+        data: new Uint8ClampedArray([
+          0, 255, 255, 255, // red 0 → set
+          255, 0, 0, 255, // red 255 → unset
+          0, 0, 0, 0, // red 0 → set
+        ]),
+      } as unknown as ImageData;
+
+      const mask = CollisionMask.fromColor(data);
+      expect(mask.collidesWithPoint(0, 0)).toBe(true);
+      expect(mask.collidesWithPoint(1, 0)).toBe(false);
+      expect(mask.collidesWithPoint(2, 0)).toBe(true);
+    });
+  });
+});

--- a/src/data/damage/__spec__/genericDamage.spec.ts
+++ b/src/data/damage/__spec__/genericDamage.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { GenericDamage } from "../genericDamage";
+import { TargetList } from "../targetList";
+import { DamageSourceType } from "../types";
+import { HurtableEntity, TickingEntity } from "../../entity/types";
+
+function createMockEntity(id: number): HurtableEntity {
+  return {
+    id,
+    hp: 100,
+    getCenter: () => [0, 0] as [number, number],
+    damage: vi.fn(),
+    die: vi.fn(),
+    body: {} as any,
+  } as unknown as HurtableEntity;
+}
+
+describe("GenericDamage", () => {
+  it("has type Generic", () => {
+    const damage = new GenericDamage(new TargetList());
+    expect(damage.type).toBe(DamageSourceType.Generic);
+  });
+
+  it("has null cause by default", () => {
+    const damage = new GenericDamage(new TargetList());
+    expect(damage.cause).toBeNull();
+  });
+
+  describe("getTargets", () => {
+    it("returns the TargetList passed to constructor", () => {
+      const targets = new TargetList();
+      const damage = new GenericDamage(targets);
+      expect(damage.getTargets()).toBe(targets);
+    });
+  });
+
+  describe("damage", () => {
+    it("delegates to TargetList.damage with itself as source", () => {
+      const entity = createMockEntity(1);
+      const entityMap = new Map<number, TickingEntity>([
+        [1, entity as unknown as TickingEntity],
+      ]);
+
+      const targets = new TargetList();
+      targets.add(entity, 25);
+
+      const damage = new GenericDamage(targets);
+
+      // Call damage with explicit entityMap (avoids needing mock context)
+      targets.damage(damage, entityMap);
+      expect(entity.damage).toHaveBeenCalledWith(damage, 25, undefined);
+    });
+  });
+
+  describe("serialize / deserialize", () => {
+    it("round-trips an empty TargetList", () => {
+      const original = new GenericDamage(new TargetList());
+      const serialized = original.serialize();
+      const restored = GenericDamage.deserialize(serialized);
+      expect(restored.getTargets().hasEntities()).toBe(false);
+    });
+
+    it("round-trips a TargetList with targets", () => {
+      const entity = createMockEntity(5);
+      const targets = new TargetList();
+      targets.add(entity, 30);
+
+      const original = new GenericDamage(targets);
+      const serialized = original.serialize();
+      const restored = GenericDamage.deserialize(serialized);
+
+      expect(restored.getTargets().hasEntities()).toBe(true);
+      expect(restored.serialize()).toEqual(serialized);
+    });
+
+    it("round-trips a TargetList with force", () => {
+      const entity = createMockEntity(3);
+      const targets = new TargetList();
+      targets.add(entity, 20, { power: 5, direction: 1.5 });
+
+      const original = new GenericDamage(targets);
+      const serialized = original.serialize();
+      const restored = GenericDamage.deserialize(serialized);
+
+      expect(restored.serialize()).toEqual(serialized);
+    });
+  });
+});

--- a/src/data/damage/__spec__/impactDamage.spec.ts
+++ b/src/data/damage/__spec__/impactDamage.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ImpactDamage } from "../impactDamage";
+import { TargetList } from "../targetList";
+import { DamageSourceType } from "../types";
+import { HurtableEntity } from "../../entity/types";
+import {
+  installMockContext,
+  clearMockContext,
+  MockLevel,
+} from "../../__spec__/mockContext";
+import { CollisionMask } from "../../collision/collisionMask";
+
+function createMockEntity(
+  id: number,
+  center: [number, number]
+): HurtableEntity {
+  return {
+    id,
+    hp: 100,
+    getCenter: () => center,
+    damage: vi.fn(),
+    die: vi.fn(),
+    body: { mask: CollisionMask.forRect(3, 3) },
+  } as unknown as HurtableEntity;
+}
+
+describe("ImpactDamage", () => {
+  it("has type Impact", () => {
+    const damage = new ImpactDamage(10, 20, 0, 5);
+    expect(damage.type).toBe(DamageSourceType.Impact);
+  });
+
+  it("has null cause by default", () => {
+    const damage = new ImpactDamage(10, 20, 0, 5);
+    expect(damage.cause).toBeNull();
+  });
+
+  it("stores position", () => {
+    const damage = new ImpactDamage(15, 25, 0, 5);
+    expect(damage.x).toBe(15);
+    expect(damage.y).toBe(25);
+  });
+
+  describe("serialize / deserialize", () => {
+    it("serializes position", () => {
+      const damage = new ImpactDamage(10, 20, Math.PI, 5);
+      const serialized = damage.serialize();
+      expect(serialized[0]).toBe(10);
+      expect(serialized[1]).toBe(20);
+    });
+
+    it("preserves position through deserialization", () => {
+      const original = new ImpactDamage(15, 25, 0, 0);
+      const serialized = original.serialize();
+      const restored = ImpactDamage.deserialize(serialized);
+      expect(restored.x).toBe(15);
+      expect(restored.y).toBe(25);
+    });
+
+    it("round-trips with pre-computed targets", () => {
+      const entity = createMockEntity(1, [60, 60]);
+      const targets = new TargetList();
+      targets.add(entity, 10, { power: 1, direction: 0 });
+
+      const original = new ImpactDamage(10, 20, 0, 5, targets);
+      const serialized = original.serialize();
+      const restored = ImpactDamage.deserialize(serialized);
+
+      expect(restored.getTargets().hasEntities()).toBe(true);
+    });
+  });
+
+  describe("getTargets", () => {
+    let level: MockLevel;
+
+    beforeEach(() => {
+      const mocks = installMockContext();
+      level = mocks.level;
+    });
+
+    afterEach(() => {
+      clearMockContext();
+    });
+
+    it("calls withNearbyEntities with correct search area", () => {
+      level.withNearbyEntities.mockImplementation(() => {});
+
+      const damage = new ImpactDamage(10, 20, 0, 15);
+      damage.getTargets();
+
+      expect(level.withNearbyEntities).toHaveBeenCalledWith(
+        (10 + 3) * 6, // x offset
+        (20 + 8) * 6, // y offset
+        16 * 6, // range
+        expect.any(Function)
+      );
+    });
+
+    it("ignores non-hurtable entities", () => {
+      const nonHurtable = { position: { x: 60, y: 60 } };
+
+      level.withNearbyEntities.mockImplementation(
+        (x: number, y: number, range: number, fn: Function) => {
+          fn(nonHurtable, 10);
+        }
+      );
+
+      const damage = new ImpactDamage(10, 20, 0, 15);
+      const targets = damage.getTargets();
+      expect(targets.hasEntities()).toBe(false);
+    });
+
+    it("caches targets on subsequent calls", () => {
+      level.withNearbyEntities.mockImplementation(() => {});
+
+      const damage = new ImpactDamage(10, 20, 0, 15);
+      const targets1 = damage.getTargets();
+      const targets2 = damage.getTargets();
+      expect(targets1).toBe(targets2);
+      expect(level.withNearbyEntities).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses pre-computed targets when provided", () => {
+      const targets = new TargetList();
+      const damage = new ImpactDamage(10, 20, 0, 15, targets);
+      expect(damage.getTargets()).toBe(targets);
+      expect(level.withNearbyEntities).not.toHaveBeenCalled();
+    });
+
+    it("uses pre-computed targets with correct power and direction", () => {
+      const entity = createMockEntity(1, [60, 60]);
+      const direction = Math.PI / 4;
+      const power = 20;
+
+      const targets = new TargetList();
+      targets.add(entity, power, {
+        power: power / 10,
+        direction,
+      });
+
+      const damage = new ImpactDamage(10, 20, direction, power, targets);
+      const result = damage.getTargets();
+      const serialized = result.serialize();
+
+      expect(serialized[0][1]).toBe(power);
+      expect(serialized[0][2]).toBe(power / 10);
+      expect(serialized[0][3]).toBe(direction);
+    });
+  });
+});

--- a/src/data/entity/__spec__/types.spec.ts
+++ b/src/data/entity/__spec__/types.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  isHurtableEntity,
+  isSpawnableEntity,
+  isSyncableEntity,
+  isItem,
+} from "../types";
+
+describe("entity type guards", () => {
+  describe("isHurtableEntity", () => {
+    it("returns true for objects with getCenter", () => {
+      expect(isHurtableEntity({ getCenter: () => [0, 0] })).toBe(true);
+    });
+
+    it("returns false for objects without getCenter", () => {
+      expect(isHurtableEntity({ hp: 100 })).toBe(false);
+    });
+
+    it("returns false for empty objects", () => {
+      expect(isHurtableEntity({})).toBe(false);
+    });
+  });
+
+  describe("isSpawnableEntity", () => {
+    it("returns true for objects with serializeCreate", () => {
+      const entity = { serializeCreate: () => [] };
+      expect(isSpawnableEntity(entity as any)).toBe(true);
+    });
+
+    it("returns false for objects without serializeCreate", () => {
+      expect(isSpawnableEntity({ id: 1 } as any)).toBe(false);
+    });
+  });
+
+  describe("isSyncableEntity", () => {
+    it("returns true for objects with priority", () => {
+      expect(isSyncableEntity({ priority: 0 } as any)).toBe(true);
+    });
+
+    it("returns false for objects without priority", () => {
+      expect(isSyncableEntity({ id: 1 } as any)).toBe(false);
+    });
+  });
+
+  describe("isItem", () => {
+    it("returns true for objects with activate", () => {
+      expect(isItem({ activate: () => {} } as any)).toBe(true);
+    });
+
+    it("returns false for objects without activate", () => {
+      expect(isItem({ hp: 100 } as any)).toBe(false);
+    });
+  });
+});

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -28,29 +28,25 @@ import {
 } from "../../graphics/particles/factory/character";
 import { ControllableSound } from "../../sound/controllableSound";
 import { Sound } from "../../sound";
-import { Wings } from "./wings";
 import { SmokePuff } from "../../graphics/smokePuff";
 import { COLORS } from "../network/constants";
-import { BBox } from "../map/bbox";
 import { getLevel, getManager, getServer } from "../context";
 import { CharacterHealth } from "./characterHealth";
+import { CharacterMovement } from "./characterMovement";
 
 // Start bouncing when impact is greater than this value
 const BOUNCE_TRIGGER = 3.8;
 const SMOKE_TRIGGER = 2;
-const MAX_LADDER_MOUNT_SPEED = 1;
-
 const WALK_DURATION = 20;
 const MELEE_DURATION = 50;
 const PAGE_READ_DURATION = 60;
 const CLIMB_DURATION = 10;
-const JUMP_GRACE_TIME = 3;
 
 const MELEE_POWER = 20;
 
 const MAX_NAME_LENGTH = 30;
 
-enum AnimationState {
+export enum AnimationState {
   Idle = "elf_idle",
   Walk = "elf_walk",
   Jump = "elf_jump",
@@ -189,10 +185,8 @@ export class Character extends Container implements HurtableEntity, Syncable {
   private lastActiveTime = 0;
   private spellSource: any | null = null;
   private lookDirection = 1;
-  private wings?: Wings;
   private namePlateName: string;
-  private wasUp = false;
-  private lastGroundedTime = 0;
+  public readonly movement: CharacterMovement;
 
   private animator: Animator<AnimationState>;
 
@@ -209,10 +203,11 @@ export class Character extends Container implements HurtableEntity, Syncable {
         ? characterName.slice(0, MAX_NAME_LENGTH - 3) + "..."
         : characterName;
 
+    this.movement = new CharacterMovement(this);
     this.body = new Body(getLevel().terrain.characterMask, {
       mask: rectangle6x16,
       onCollide: this.onCollide,
-      ladderTest: this.ladderTest,
+      ladderTest: this.movement.ladderTest,
     });
     this.body.move(x, y);
     this.position.set(x * 6, y * 6);
@@ -372,7 +367,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
         this.position.set(x * 6, y * 6);
 
         if (this.body.grounded) {
-          this.lastGroundedTime = this.time;
+          this.movement.lastGroundedTime = this.time;
         }
 
         if (
@@ -426,142 +421,36 @@ export class Character extends Container implements HurtableEntity, Syncable {
     );
   }
 
-  ladderTest = (x: number, y: number) => {
-    if (!getManager().isTrusted(this)) {
-      return false;
-    }
-
-    for (let ladder of getLevel().terrain.ladders) {
-      if (
-        x + 6 >= ladder.left &&
-        x <= ladder.right &&
-        y + 16 > ladder.top &&
-        y < ladder.bottom
-      ) {
-        return true;
-      }
-    }
-
-    return false;
-  };
-
   control(controller: Controller) {
-    let foundLadder: BBox | null = null;
-    if (
-      this.body.grounded ||
-      this.body.onLadder ||
-      (this.body.yVelocity > 0 && this.body.yVelocity < MAX_LADDER_MOUNT_SPEED)
-    ) {
-      const [x, y] = this.body.precisePosition;
-      for (let ladder of getLevel().terrain.ladders) {
-        if (
-          x + 6 >= ladder.left &&
-          x <= ladder.right &&
-          y + 16 > ladder.top &&
-          y < ladder.bottom &&
-          ladder.top < (foundLadder?.top || Infinity)
-        ) {
-          foundLadder = ladder;
-        }
-      }
-    }
-
-    if (this.body.onLadder) {
-      this.setSpellSource(null, false);
-    }
-
-    const isUp = controller.isKeyDown(Key.Up) || controller.isKeyDown(Key.W);
-    if (!this.wings && foundLadder && isUp) {
-      this.body.mountLadder();
-    }
-
-    if (this.body.onLadder) {
-      if (!foundLadder) {
-        if (getManager().isTrusted(this)) {
-          this.body.unmountLadder();
-        }
-        return;
-      }
-
-      if (isUp) {
-        if (this.body.precisePosition[1] + 8 > foundLadder.top) {
-          this.body.setLadderDirection(-1);
-          this.animator.animate(AnimationState.Climb);
-        } else {
-          if (!this.wasUp) {
-            this.body.unmountLadder();
-            this.body.jump();
-            this.animator.animate(AnimationState.Jump);
-          }
-
-          this.body.setLadderDirection(0);
-        }
-      } else if (
-        controller.isKeyDown(Key.Down) ||
-        controller.isKeyDown(Key.D)
-      ) {
-        this.body.setLadderDirection(1);
-        this.animator.animate(AnimationState.Climb);
-      } else {
-        this.body.setLadderDirection(0);
-      }
-
-      this.wasUp = isUp;
-      return;
-    }
-
-    if (!isUp) {
-      return;
-    }
-
-    if (this.time - this.lastGroundedTime < JUMP_GRACE_TIME && !this.wings) {
-      if (this.body.jump()) {
-        this.animator.animate(AnimationState.Jump);
-      }
-    }
-
-    if (this.wings) {
-      this.wings.flap(this.time);
-      this.animator.animate(AnimationState.Float);
-
-      if (this.wings.power <= 0) {
-        this.removeWings();
-      }
-    }
+    this.movement.control(controller);
   }
 
   controlContinuous(dt: number, controller: Controller) {
-    if (this.animator.isBlocking) {
-      return;
-    }
+    this.movement.controlContinuous(dt, controller);
+  }
 
+  /** Trigger an animation by state name. Used by helpers. */
+  animate(state: keyof typeof AnimationState): void {
+    this.animator.animate(AnimationState[state]);
+  }
+
+  /** Check if current animation is blocking input. Used by CharacterMovement. */
+  isAnimationBlocking(): boolean {
+    return !!this.animator.isBlocking;
+  }
+
+  /** Update look direction from controller mouse position. Used by CharacterMovement. */
+  updateLookDirection(controller: Controller): void {
     this.lookDirection = Math.sign(
       controller.getMouse()[0] - this.getCenter()[0]
     );
     this.sprite.scale.x = 2 * this.lookDirection;
+  }
 
-    if (controller.isKeyDown(Key.Left) || controller.isKeyDown(Key.A)) {
-      this.body.walk(-1);
-
-      if (this.body.grounded) {
-        this.animator.animate(AnimationState.Walk);
-
-        if (this.sprite.animationSpeed * this.lookDirection < 0) {
-          this.sprite.animationSpeed *= this.lookDirection;
-        }
-      }
-    }
-
-    if (controller.isKeyDown(Key.Right) || controller.isKeyDown(Key.D)) {
-      this.body.walk(1);
-
-      if (this.body.grounded) {
-        this.animator.animate(AnimationState.Walk);
-
-        if (this.sprite.animationSpeed * this.lookDirection < 0) {
-          this.sprite.animationSpeed *= this.lookDirection;
-        }
-      }
+  /** Sync animation speed direction with look direction. Used by CharacterMovement. */
+  syncAnimationDirection(): void {
+    if (this.sprite.animationSpeed * this.lookDirection < 0) {
+      this.sprite.animationSpeed *= this.lookDirection;
     }
   }
 
@@ -659,25 +548,15 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   giveWings() {
-    this.body.unmountLadder();
-
-    this.wings = new Wings(this);
-    this.addChildAt(this.wings, 0);
+    this.movement.giveWings();
   }
 
   removeWings() {
-    if (!this.wings) {
-      return;
-    }
-
-    this.wings.stop();
-    this.removeChild(this.wings);
-    this.wings = undefined;
+    this.movement.removeWings();
   }
 
   endTurn() {
-    this.removeWings();
-    this.body.setLadderDirection(0);
+    this.movement.endTurn();
   }
 
   melee() {

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -456,6 +456,16 @@ export class Character extends Container implements HurtableEntity, Syncable {
     }
   }
 
+  /** Check if current animation matches a given state. Used by CharacterCombat. */
+  isInAnimationState(state: keyof typeof AnimationState): boolean {
+    return this.animator.animationState === AnimationState[state];
+  }
+
+  /** Set the default animation state. Used by CharacterCombat. */
+  setDefaultAnimation(state: keyof typeof AnimationState): void {
+    this.animator.setDefaultAnimation(AnimationState[state]);
+  }
+
   damage(source: DamageSource, damage: number, force?: Force) {
     this.health.damage(source, damage, force);
   }
@@ -517,7 +527,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   melee() {
-    this.animator.animate(AnimationState.Swing);
+    this.combat.melee();
   }
 
   get hp() {

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -32,6 +32,7 @@ import { SmokePuff } from "../../graphics/smokePuff";
 import { COLORS } from "../network/constants";
 import { getLevel, getManager, getServer } from "../context";
 import { CharacterHealth } from "./characterHealth";
+import { CharacterCombat } from "./characterCombat";
 import { CharacterMovement } from "./characterMovement";
 
 // Start bouncing when impact is greater than this value
@@ -183,9 +184,9 @@ export class Character extends Container implements HurtableEntity, Syncable {
 
   public time = 0;
   private lastActiveTime = 0;
-  private spellSource: any | null = null;
   private lookDirection = 1;
   private namePlateName: string;
+  public readonly combat: CharacterCombat;
   public readonly movement: CharacterMovement;
 
   private animator: Animator<AnimationState>;
@@ -203,6 +204,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
         ? characterName.slice(0, MAX_NAME_LENGTH - 3) + "..."
         : characterName;
 
+    this.combat = new CharacterCombat(this);
     this.movement = new CharacterMovement(this);
     this.body = new Body(getLevel().terrain.characterMask, {
       mask: rectangle6x16,
@@ -286,7 +288,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
           if (
             (getManager().getActiveCharacter() !== this ||
               !this.player.controller.isKeyDown()) &&
-            !this.spellSource
+            !this.combat.isCasting()
           ) {
             this.animator.animate(AnimationState.ReadDone);
           }
@@ -459,60 +461,15 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   setSpellSource(source: any, toggle = true) {
-    if (toggle) {
-      if (this.body.onLadder) {
-        return;
-      }
-
-      this.spellSource = source;
-
-      if (
-        this.animator.animationState !== AnimationState.SpellIdle &&
-        !this.player.controller.isKeyDown(Key.Left) &&
-        !this.player.controller.isKeyDown(Key.Right) &&
-        !this.player.controller.isKeyDown(Key.A) &&
-        !this.player.controller.isKeyDown(Key.D)
-      ) {
-        this.animator.animate(AnimationState.Spell);
-      }
-
-      this.animator.setDefaultAnimation(AnimationState.Spell);
-    } else if (!source || source === this.spellSource) {
-      this.spellSource = null;
-
-      let defaultAnimation;
-      if (
-        getManager().getActiveCharacter() === this &&
-        this.player.controller.isKeyDown(Key.Inventory)
-      ) {
-        defaultAnimation = AnimationState.Read;
-      } else {
-        defaultAnimation = AnimationState.Idle;
-      }
-
-      if (this.animator.animationState === AnimationState.SpellIdle) {
-        this.animator.animate(AnimationState.SpellDone);
-      } else if (this.animator.animationState === AnimationState.Spell) {
-        this.animator.animate(defaultAnimation);
-      }
-
-      this.animator.setDefaultAnimation(defaultAnimation);
-    }
+    this.combat.setSpellSource(source, toggle);
   }
 
   isCasting() {
-    return !!this.spellSource;
+    return this.combat.isCasting();
   }
 
   openSpellBook() {
-    if (
-      !this.spellSource &&
-      this.animator.animationState !== AnimationState.Read &&
-      this.animator.animationState !== AnimationState.ReadIdle
-    ) {
-      this.animator.animate(AnimationState.Read);
-      this.animator.setDefaultAnimation(AnimationState.Read);
-    }
+    this.combat.openSpellBook();
   }
 
   serialize() {

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -175,7 +175,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
   private static readonly maxInactiveTime = 3;
 
   public readonly body: Body;
-  public readonly health: CharacterHealth;
+  private readonly health: CharacterHealth;
   public id = -1;
   public readonly priority = Priority.Low;
   public readonly type = EntityType.Character;

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -12,7 +12,6 @@ import { Player } from "../network/player";
 import { Force, TargetList } from "../damage/targetList";
 import { EntityType, HurtableEntity, Priority, Syncable } from "./types";
 import { GenericDamage } from "../damage/genericDamage";
-import { ExplosiveDamage } from "../damage/explosiveDamage";
 import { DamageSource } from "../damage/types";
 import { ParticleEmitter } from "../../graphics/particles/types";
 import {
@@ -27,8 +26,6 @@ import {
   createBackgroundParticles,
   createWandParticles,
 } from "../../graphics/particles/factory/character";
-import { createCharacterGibs } from "./gib/characterGibs";
-import { Explosion } from "../../graphics/explosion";
 import { ControllableSound } from "../../sound/controllableSound";
 import { Sound } from "../../sound";
 import { Wings } from "./wings";
@@ -36,6 +33,7 @@ import { SmokePuff } from "../../graphics/smokePuff";
 import { COLORS } from "../network/constants";
 import { BBox } from "../map/bbox";
 import { getLevel, getManager, getServer } from "../context";
+import { CharacterHealth } from "./characterHealth";
 
 // Start bouncing when impact is greater than this value
 const BOUNCE_TRIGGER = 3.8;
@@ -174,12 +172,10 @@ const ANIMATION_CONFIG: Record<
 };
 
 export class Character extends Container implements HurtableEntity, Syncable {
-  private static readonly invulnerableTime = 1;
-  private static readonly damageNumberTime = 90;
   private static readonly maxInactiveTime = 3;
-  private static readonly damageAttributionTime = 120;
 
   public readonly body: Body;
+  public readonly health: CharacterHealth;
   public id = -1;
   public readonly priority = Priority.Low;
   public readonly type = EntityType.Character;
@@ -189,11 +185,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
   private particles?: ParticleEmitter;
   private foregroundParticles?: ParticleEmitter;
 
-  private _hp = 100;
-  private lastReportedHp = this._hp;
-  private time = 0;
-  private lastDamageTime = -1;
-  private _lastDamageDealer: Player | null = null;
+  public time = 0;
   private lastActiveTime = 0;
   private spellSource: any | null = null;
   private lookDirection = 1;
@@ -327,7 +319,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
     sprite2.alpha = 0.5;
 
     this.namePlate = new BitmapText({
-      text: `${this.namePlateName} ${this._hp}`,
+      text: `${this.namePlateName} 100`,
       style: {
         fontFamily: "Eternal",
         fontSize: 32,
@@ -336,6 +328,8 @@ export class Character extends Container implements HurtableEntity, Syncable {
     this.namePlate.tint = this.player.color;
     this.namePlate.anchor.set(0.5);
     this.namePlate.position.set(18, -40);
+
+    this.health = new CharacterHealth(this, this.namePlate, this.namePlateName);
 
     this.addChild(this.sprite, this.namePlate);
   }
@@ -363,20 +357,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
       this.body.active = 1;
     }
 
-    if (
-      this.lastReportedHp !== this._hp &&
-      this.time > this.lastDamageTime + Character.damageNumberTime
-    ) {
-      getLevel().numberContainer.damage(
-        this.lastReportedHp - this._hp,
-        ...this.getCenter()
-      );
-      this.namePlate.text = `${this.namePlateName} ${Math.max(
-        0,
-        Math.ceil(this._hp)
-      )}`;
-      this.lastReportedHp = this._hp;
-    }
+    this.health.reportDamageNumbers();
 
     if (this.body.active) {
       this.lastActiveTime = this.time;
@@ -585,28 +566,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   damage(source: DamageSource, damage: number, force?: Force) {
-    if (
-      this.lastDamageTime !== -1 &&
-      this.time <= this.lastDamageTime + Character.invulnerableTime
-    ) {
-      return;
-    }
-
-    this.player.stats.registerDamage(source, this, damage, force);
-
-    this.hp -= damage;
-    this.lastDamageTime = this.time;
-    this._lastDamageDealer = source.cause;
-    this.body.unmountLadder();
-
-    getLevel().bloodEmitter.burst(this, damage, source);
-    if (damage > 0) {
-      ControllableSound.fromEntity(this, Sound.Splat);
-    }
-
-    if (force) {
-      this.body.addAngularVelocity(force.power, force.direction);
-    }
+    this.health.damage(source, damage, force);
   }
 
   setSpellSource(source: any, toggle = true) {
@@ -695,58 +655,7 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   die() {
-    if (this._hp !== this.lastReportedHp) {
-      getLevel().numberContainer.damage(
-        this.lastReportedHp - this._hp,
-        ...this.getCenter()
-      );
-      this.namePlate.text = `${this.namePlateName} ${Math.max(
-        0,
-        Math.ceil(this._hp)
-      )}`;
-      this.lastReportedHp = this._hp;
-    }
-
-    getLevel().terrain.characterMask.subtract(
-      this.body.mask,
-      ...this.body.position
-    );
-
-    this.player.removeCharacter(this);
-
-    const [x, y] = this.getCenter();
-    new Explosion(x, y);
-    getLevel().shake();
-
-    const gibs = createCharacterGibs(...this.body.precisePosition);
-    gibs.forEach((gib) =>
-      gib.body.addVelocity((Math.random() - 0.5) * 8, -2 - Math.random() * 3)
-    );
-    getLevel().add(...gibs);
-    getLevel().bloodEmitter.burst(this, 100);
-
-    getLevel().terrain.draw((ctx) => {
-      const splat = AssetsContainer.instance.assets!["atlas"].textures[
-        "gibs_splat"
-      ] as Texture;
-
-      ctx.drawImage(
-        splat.source.resource,
-        splat.frame.left,
-        splat.frame.top,
-        splat.frame.width,
-        splat.frame.height,
-        x / 6 - splat.frame.width / 2,
-        y / 6 - splat.frame.height / 2 + 5,
-        splat.frame.width,
-        splat.frame.height
-      );
-    });
-
-    getServer()?.damage(
-      new ExplosiveDamage(x / 6, y / 6, 16, 1, 1),
-      this.player
-    );
+    this.health.die();
   }
 
   giveWings() {
@@ -776,23 +685,11 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   get hp() {
-    return this._hp;
+    return this.health.hp;
   }
 
   set hp(hp: number) {
-    const oldHp = this._hp;
-    const diff = hp - oldHp;
-    if (diff > 0) {
-      getLevel().numberContainer.heal(diff, ...this.getCenter());
-      this.lastReportedHp += diff;
-      this.namePlate.text = `${this.namePlateName} ${Math.max(
-        0,
-        Math.ceil(this.lastReportedHp)
-      )}`;
-    }
-
-    this._hp = hp;
-    this.body.active = 1;
+    this.health.hp = hp;
   }
 
   get direction() {
@@ -800,10 +697,6 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   get lastDamageDealer() {
-    if (this.time > this.lastDamageTime + Character.damageAttributionTime) {
-      return null;
-    }
-
-    return this._lastDamageDealer;
+    return this.health.lastDamageDealer;
   }
 }

--- a/src/data/entity/characterCombat.ts
+++ b/src/data/entity/characterCombat.ts
@@ -1,0 +1,70 @@
+import { Key } from "../controller/controller";
+import { getManager } from "../context";
+import type { Character } from "./character";
+
+export class CharacterCombat {
+  private spellSource: any | null = null;
+
+  constructor(private character: Character) {}
+
+  setSpellSource(source: any, toggle = true): void {
+    if (toggle) {
+      if (this.character.body.onLadder) {
+        return;
+      }
+
+      this.spellSource = source;
+
+      if (
+        !this.character.isInAnimationState("SpellIdle") &&
+        !this.character.player.controller.isKeyDown(Key.Left) &&
+        !this.character.player.controller.isKeyDown(Key.Right) &&
+        !this.character.player.controller.isKeyDown(Key.A) &&
+        !this.character.player.controller.isKeyDown(Key.D)
+      ) {
+        this.character.animate("Spell");
+      }
+
+      this.character.setDefaultAnimation("Spell");
+    } else if (!source || source === this.spellSource) {
+      this.spellSource = null;
+
+      let defaultAnimation: "Read" | "Idle";
+      if (
+        getManager().getActiveCharacter() === this.character &&
+        this.character.player.controller.isKeyDown(Key.Inventory)
+      ) {
+        defaultAnimation = "Read";
+      } else {
+        defaultAnimation = "Idle";
+      }
+
+      if (this.character.isInAnimationState("SpellIdle")) {
+        this.character.animate("SpellDone");
+      } else if (this.character.isInAnimationState("Spell")) {
+        this.character.animate(defaultAnimation);
+      }
+
+      this.character.setDefaultAnimation(defaultAnimation);
+    }
+  }
+
+  isCasting(): boolean {
+    return !!this.spellSource;
+  }
+
+  openSpellBook(): void {
+    if (
+      !this.spellSource &&
+      !this.character.isInAnimationState("Read") &&
+      !this.character.isInAnimationState("ReadIdle")
+    ) {
+      this.character.animate("Read");
+      this.character.setDefaultAnimation("Read");
+    }
+  }
+
+  melee(): void {
+    this.character.animate("Swing");
+  }
+}

--- a/src/data/entity/characterHealth.ts
+++ b/src/data/entity/characterHealth.ts
@@ -1,0 +1,172 @@
+import { BitmapText } from "pixi.js";
+import { Player } from "../network/player";
+import { DamageSource } from "../damage/types";
+import { Force } from "../damage/targetList";
+import { ControllableSound } from "../../sound/controllableSound";
+import { Sound } from "../../sound";
+import { getLevel, getServer } from "../context";
+import { GenericDamage } from "../damage/genericDamage";
+import { TargetList } from "../damage/targetList";
+import { ExplosiveDamage } from "../damage/explosiveDamage";
+import { AssetsContainer } from "../../util/assets/assetsContainer";
+import { Texture } from "pixi.js";
+import { Explosion } from "../../graphics/explosion";
+import { createCharacterGibs } from "./gib/characterGibs";
+import type { Character } from "./character";
+
+export class CharacterHealth {
+  private static readonly invulnerableTime = 1;
+  private static readonly damageNumberTime = 90;
+  private static readonly damageAttributionTime = 120;
+
+  private _hp = 100;
+  private lastReportedHp = this._hp;
+  private lastDamageTime = -1;
+  private _lastDamageDealer: Player | null = null;
+
+  constructor(
+    private character: Character,
+    private namePlate: BitmapText,
+    private namePlateName: string
+  ) {}
+
+  get hp(): number {
+    return this._hp;
+  }
+
+  set hp(hp: number) {
+    const oldHp = this._hp;
+    const diff = hp - oldHp;
+    if (diff > 0) {
+      getLevel().numberContainer.heal(diff, ...this.character.getCenter());
+      this.lastReportedHp += diff;
+      this.namePlate.text = `${this.namePlateName} ${Math.max(
+        0,
+        Math.ceil(this.lastReportedHp)
+      )}`;
+    }
+
+    this._hp = hp;
+    this.character.body.active = 1;
+  }
+
+  get lastDamageDealer(): Player | null {
+    if (
+      this.character.time >
+      this.lastDamageTime + CharacterHealth.damageAttributionTime
+    ) {
+      return null;
+    }
+
+    return this._lastDamageDealer;
+  }
+
+  reportDamageNumbers(): void {
+    if (
+      this.lastReportedHp !== this._hp &&
+      this.character.time >
+        this.lastDamageTime + CharacterHealth.damageNumberTime
+    ) {
+      getLevel().numberContainer.damage(
+        this.lastReportedHp - this._hp,
+        ...this.character.getCenter()
+      );
+      this.namePlate.text = `${this.namePlateName} ${Math.max(
+        0,
+        Math.ceil(this._hp)
+      )}`;
+      this.lastReportedHp = this._hp;
+    }
+  }
+
+  damage(source: DamageSource, damage: number, force?: Force): void {
+    if (
+      this.lastDamageTime !== -1 &&
+      this.character.time <=
+        this.lastDamageTime + CharacterHealth.invulnerableTime
+    ) {
+      return;
+    }
+
+    this.character.player.stats.registerDamage(
+      source,
+      this.character,
+      damage,
+      force
+    );
+
+    this.hp -= damage;
+    this.lastDamageTime = this.character.time;
+    this._lastDamageDealer = source.cause;
+    this.character.body.unmountLadder();
+
+    getLevel().bloodEmitter.burst(this.character, damage, source);
+    if (damage > 0) {
+      ControllableSound.fromEntity(this.character, Sound.Splat);
+    }
+
+    if (force) {
+      this.character.body.addAngularVelocity(force.power, force.direction);
+    }
+  }
+
+  die(): void {
+    if (this._hp !== this.lastReportedHp) {
+      getLevel().numberContainer.damage(
+        this.lastReportedHp - this._hp,
+        ...this.character.getCenter()
+      );
+      this.namePlate.text = `${this.namePlateName} ${Math.max(
+        0,
+        Math.ceil(this._hp)
+      )}`;
+      this.lastReportedHp = this._hp;
+    }
+
+    getLevel().terrain.characterMask.subtract(
+      this.character.body.mask,
+      ...this.character.body.position
+    );
+
+    this.character.player.removeCharacter(this.character);
+
+    const [x, y] = this.character.getCenter();
+    new Explosion(x, y);
+    getLevel().shake();
+
+    const gibs = createCharacterGibs(
+      ...this.character.body.precisePosition
+    );
+    gibs.forEach((gib) =>
+      gib.body.addVelocity(
+        (Math.random() - 0.5) * 8,
+        -2 - Math.random() * 3
+      )
+    );
+    getLevel().add(...gibs);
+    getLevel().bloodEmitter.burst(this.character, 100);
+
+    getLevel().terrain.draw((ctx) => {
+      const splat = AssetsContainer.instance.assets!["atlas"].textures[
+        "gibs_splat"
+      ] as Texture;
+
+      ctx.drawImage(
+        splat.source.resource,
+        splat.frame.left,
+        splat.frame.top,
+        splat.frame.width,
+        splat.frame.height,
+        x / 6 - splat.frame.width / 2,
+        y / 6 - splat.frame.height / 2 + 5,
+        splat.frame.width,
+        splat.frame.height
+      );
+    });
+
+    getServer()?.damage(
+      new ExplosiveDamage(x / 6, y / 6, 16, 1, 1),
+      this.character.player
+    );
+  }
+}

--- a/src/data/entity/characterHealth.ts
+++ b/src/data/entity/characterHealth.ts
@@ -5,8 +5,6 @@ import { Force } from "../damage/targetList";
 import { ControllableSound } from "../../sound/controllableSound";
 import { Sound } from "../../sound";
 import { getLevel, getServer } from "../context";
-import { GenericDamage } from "../damage/genericDamage";
-import { TargetList } from "../damage/targetList";
 import { ExplosiveDamage } from "../damage/explosiveDamage";
 import { AssetsContainer } from "../../util/assets/assetsContainer";
 import { Texture } from "pixi.js";

--- a/src/data/entity/characterMovement.ts
+++ b/src/data/entity/characterMovement.ts
@@ -1,0 +1,181 @@
+import { Controller, Key } from "../controller/controller";
+import { BBox } from "../map/bbox";
+import { Wings } from "./wings";
+import { getLevel, getManager } from "../context";
+import type { Character } from "./character";
+
+const MAX_LADDER_MOUNT_SPEED = 1;
+const JUMP_GRACE_TIME = 3;
+
+export class CharacterMovement {
+  private wasUp = false;
+  public lastGroundedTime = 0;
+  private wings?: Wings;
+
+  constructor(private character: Character) {}
+
+  ladderTest = (x: number, y: number): boolean => {
+    if (!getManager().isTrusted(this.character)) {
+      return false;
+    }
+
+    for (let ladder of getLevel().terrain.ladders) {
+      if (
+        x + 6 >= ladder.left &&
+        x <= ladder.right &&
+        y + 16 > ladder.top &&
+        y < ladder.bottom
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  control(controller: Controller): void {
+    let foundLadder: BBox | null = null;
+    if (
+      this.character.body.grounded ||
+      this.character.body.onLadder ||
+      (this.character.body.yVelocity > 0 &&
+        this.character.body.yVelocity < MAX_LADDER_MOUNT_SPEED)
+    ) {
+      const [x, y] = this.character.body.precisePosition;
+      for (let ladder of getLevel().terrain.ladders) {
+        if (
+          x + 6 >= ladder.left &&
+          x <= ladder.right &&
+          y + 16 > ladder.top &&
+          y < ladder.bottom &&
+          ladder.top < (foundLadder?.top || Infinity)
+        ) {
+          foundLadder = ladder;
+        }
+      }
+    }
+
+    if (this.character.body.onLadder) {
+      this.character.setSpellSource(null, false);
+    }
+
+    const isUp =
+      controller.isKeyDown(Key.Up) || controller.isKeyDown(Key.W);
+    if (!this.wings && foundLadder && isUp) {
+      this.character.body.mountLadder();
+    }
+
+    if (this.character.body.onLadder) {
+      if (!foundLadder) {
+        if (getManager().isTrusted(this.character)) {
+          this.character.body.unmountLadder();
+        }
+        return;
+      }
+
+      if (isUp) {
+        if (
+          this.character.body.precisePosition[1] + 8 >
+          foundLadder.top
+        ) {
+          this.character.body.setLadderDirection(-1);
+          this.character.animate("Climb");
+        } else {
+          if (!this.wasUp) {
+            this.character.body.unmountLadder();
+            this.character.body.jump();
+            this.character.animate("Jump");
+          }
+
+          this.character.body.setLadderDirection(0);
+        }
+      } else if (
+        controller.isKeyDown(Key.Down) ||
+        controller.isKeyDown(Key.D)
+      ) {
+        this.character.body.setLadderDirection(1);
+        this.character.animate("Climb");
+      } else {
+        this.character.body.setLadderDirection(0);
+      }
+
+      this.wasUp = isUp;
+      return;
+    }
+
+    if (!isUp) {
+      return;
+    }
+
+    if (
+      this.character.time - this.lastGroundedTime < JUMP_GRACE_TIME &&
+      !this.wings
+    ) {
+      if (this.character.body.jump()) {
+        this.character.animate("Jump");
+      }
+    }
+
+    if (this.wings) {
+      this.wings.flap(this.character.time);
+      this.character.animate("Float");
+
+      if (this.wings.power <= 0) {
+        this.removeWings();
+      }
+    }
+  }
+
+  controlContinuous(dt: number, controller: Controller): void {
+    if (this.character.isAnimationBlocking()) {
+      return;
+    }
+
+    this.character.updateLookDirection(controller);
+
+    if (
+      controller.isKeyDown(Key.Left) ||
+      controller.isKeyDown(Key.A)
+    ) {
+      this.character.body.walk(-1);
+
+      if (this.character.body.grounded) {
+        this.character.animate("Walk");
+        this.character.syncAnimationDirection();
+      }
+    }
+
+    if (
+      controller.isKeyDown(Key.Right) ||
+      controller.isKeyDown(Key.D)
+    ) {
+      this.character.body.walk(1);
+
+      if (this.character.body.grounded) {
+        this.character.animate("Walk");
+        this.character.syncAnimationDirection();
+      }
+    }
+  }
+
+  giveWings(): void {
+    this.character.body.unmountLadder();
+    this.wings = new Wings(this.character);
+    this.character.addChildAt(this.wings, 0);
+  }
+
+  removeWings(): void {
+    if (!this.wings) {
+      return;
+    }
+
+    this.wings.stop();
+    this.character.removeChild(this.wings);
+    this.wings = undefined;
+  }
+
+  endTurn(): void {
+    this.removeWings();
+    this.character.body.setLadderDirection(0);
+  }
+}

--- a/src/data/entity/index.ts
+++ b/src/data/entity/index.ts
@@ -29,7 +29,7 @@ import { Character } from "./character";
 import { MagicScroll } from "./magicScroll";
 import { Potion } from "./potion";
 import { PotionType } from "./potionData";
-import { EntityType, Item, Spawnable } from "./types";
+import { EntityType, Item, Spawnable, SpawnableFactory } from "./types";
 
 // Starting at 1 because 0 is a falsy value 🤡
 let id = 1;
@@ -38,10 +38,7 @@ export const setId = (value: number) => (id = value);
 
 export const getId = () => id++;
 
-export const ENTITIES: Record<
-  EntityType,
-  { create: (data: any) => Spawnable }
-> = {
+export const ENTITIES: Record<EntityType, SpawnableFactory> = {
   [EntityType.Shield]: Shield,
   [EntityType.Zoltraak]: Zoltraak,
   [EntityType.Fireball]: Fireball,

--- a/src/data/entity/types.ts
+++ b/src/data/entity/types.ts
@@ -46,6 +46,11 @@ export interface Item extends Spawnable, HurtableEntity {
   die(): void;
 }
 
+export interface SpawnableFactory {
+  create(data: any): Spawnable;
+  cast?(...args: any[]): any;
+}
+
 export function isHurtableEntity(entity: {}): entity is HurtableEntity {
   return "getCenter" in entity;
 }

--- a/src/data/spells/__spec__/defineProjectile.spec.ts
+++ b/src/data/spells/__spec__/defineProjectile.spec.ts
@@ -1,0 +1,453 @@
+import { vi } from "vitest";
+import { Sound } from "../../../sound";
+import { EntityType, Priority } from "../../entity/types";
+import { Element } from "../types";
+
+// --- Mocks ---
+
+// Mock pixi.js — provide all symbols that may be imported transitively
+vi.mock("pixi.js", () => {
+  class Container {
+    position = {
+      x: 0,
+      y: 0,
+      set(x: number, y: number) {
+        this.x = x;
+        this.y = y;
+      },
+    };
+    children: any[] = [];
+    addChild(child: any) {
+      this.children.push(child);
+    }
+  }
+
+  class AnimatedSprite {
+    animationSpeed = 0;
+    rotation = 0;
+    alpha = 1;
+    currentFrame = 0;
+    totalFrames = 8;
+    anchor = { set: vi.fn() };
+    scale = { set: vi.fn() };
+    position = { set: vi.fn() };
+    play = vi.fn();
+  }
+
+  class Sprite {
+    position = { x: 0, y: 0, set: vi.fn() };
+    anchor = { set: vi.fn() };
+    scale = { set: vi.fn() };
+    rotation = 0;
+    alpha = 1;
+    texture = null;
+    addChild = vi.fn();
+  }
+
+  class Graphics {
+    clear = vi.fn().mockReturnThis();
+    beginFill = vi.fn().mockReturnThis();
+    drawCircle = vi.fn().mockReturnThis();
+    endFill = vi.fn().mockReturnThis();
+    position = { x: 0, y: 0, set: vi.fn() };
+  }
+
+  class BitmapText {
+    position = { x: 0, y: 0, set: vi.fn() };
+    text = "";
+    anchor = { set: vi.fn() };
+  }
+
+  class TilingSprite {
+    position = { x: 0, y: 0 };
+    tilePosition = { x: 0, y: 0 };
+  }
+
+  class Texture {
+    static from = vi.fn().mockReturnValue({});
+    static WHITE = {};
+    static EMPTY = {};
+  }
+
+  const UPDATE_PRIORITY = { NORMAL: 0, HIGH: 1, LOW: -1 };
+  const TextureStyle = {};
+
+  class Application {
+    stage = new Container();
+    ticker = { add: vi.fn(), remove: vi.fn() };
+    renderer = { resize: vi.fn() };
+    init = vi.fn().mockResolvedValue(undefined);
+  }
+
+  class Rectangle {
+    constructor(
+      public x = 0,
+      public y = 0,
+      public width = 0,
+      public height = 0
+    ) {}
+  }
+
+  class Ticker {
+    add = vi.fn();
+    remove = vi.fn();
+    start = vi.fn();
+    stop = vi.fn();
+    static shared = { add: vi.fn(), remove: vi.fn() };
+  }
+
+  const FederatedPointerEvent = class {};
+  const FederatedWheelEvent = class {};
+
+  return {
+    Container,
+    AnimatedSprite,
+    Sprite,
+    Graphics,
+    BitmapText,
+    TilingSprite,
+    Texture,
+    Application,
+    Rectangle,
+    Ticker,
+    UPDATE_PRIORITY,
+    TextureStyle,
+    FederatedPointerEvent,
+    FederatedWheelEvent,
+  };
+});
+
+// Mock AssetsContainer
+vi.mock("../../../util/assets/assetsContainer", () => {
+  return {
+    AssetsContainer: {
+      instance: {
+        assets: {
+          atlas: {
+            animations: {
+              fireball: [{}],
+              default: [{}],
+            },
+          },
+        },
+      },
+    },
+  };
+});
+
+// Mock ControllableSound
+vi.mock("../../../sound/controllableSound", () => {
+  return {
+    ControllableSound: {
+      fromEntity: vi.fn(),
+    },
+  };
+});
+
+// Mock graphics
+vi.mock("../../../graphics/explosion", () => ({
+  Explosion: vi.fn(),
+}));
+
+vi.mock("../../../graphics/acidSplash", () => ({
+  AcidSplash: vi.fn(),
+}));
+
+vi.mock("../../../graphics/iceImpact", () => ({
+  IceImpact: vi.fn(),
+}));
+
+// Mock SimpleParticleEmitter
+vi.mock("../../../graphics/particles/simpleParticleEmitter", () => ({
+  SimpleParticleEmitter: vi.fn(),
+}));
+
+// Mock SimpleBody
+const mockBody = {
+  move: vi.fn(),
+  addAngularVelocity: vi.fn(),
+  tick: vi.fn(),
+  precisePosition: [10, 20] as [number, number],
+  velocity: 5,
+  direction: 1.5,
+  mask: {},
+  serialize: vi.fn().mockReturnValue([10, 20, 1, 0]),
+  deserialize: vi.fn(),
+};
+
+vi.mock("../../collision/simpleBody", () => {
+  return {
+    SimpleBody: vi.fn().mockImplementation(() => mockBody),
+  };
+});
+
+// Mock context
+const mockGetServer = vi.fn();
+const mockGetManager = vi.fn();
+const mockGetLevel = vi.fn();
+
+vi.mock("../../context", () => ({
+  getServer: () => mockGetServer(),
+  getManager: () => mockGetManager(),
+  getLevel: () => mockGetLevel(),
+}));
+
+// Mock spell utils
+vi.mock("../utils", () => ({
+  applyExplosiveDamage: vi.fn(),
+  applyImpactDamage: vi.fn(),
+  applyFallDamage: vi.fn(),
+  castProjectile: vi.fn().mockImplementation((factory: any) => {
+    const mockMask = {};
+    return factory(mockMask);
+  }),
+  createParticles: vi.fn().mockReturnValue(null),
+}));
+
+// --- Import after mocks ---
+import { defineProjectile } from "../defineProjectile";
+
+// --- Helpers ---
+
+function createMinimalConfig(overrides: any = {}) {
+  return {
+    type: EntityType.Fireball,
+    body: {
+      mask: {} as any,
+      friction: 0.98,
+      gravity: 0.3,
+    },
+    sprite: {
+      animation: "fireball",
+      animationSpeed: 0.2,
+      anchor: [0.5, 0.5] as [number, number],
+    },
+    lifetime: 100,
+    damage: {
+      type: "explosive" as const,
+      radius: 10,
+      intensity: 5,
+      base: 20,
+      element: Element.Physical,
+      multiplier: 1,
+    },
+    deathEffect: "explosion" as const,
+    cast: {
+      speed: 2,
+    },
+    ...overrides,
+  };
+}
+
+function createMockLevel() {
+  return {
+    terrain: {
+      characterMask: {},
+      collisionMask: { collidesWith: vi.fn() },
+    },
+    remove: vi.fn(),
+    add: vi.fn(),
+    particleContainer: {
+      destroyEmitter: vi.fn(),
+    },
+  };
+}
+
+function createMockServer() {
+  return {
+    kill: vi.fn(),
+    create: vi.fn(),
+    dynamicUpdate: vi.fn(),
+  };
+}
+
+function createMockManager() {
+  return {
+    setTurnState: vi.fn(),
+  };
+}
+
+// --- Tests ---
+
+describe("defineProjectile", () => {
+  let mockLevel: ReturnType<typeof createMockLevel>;
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockManager: ReturnType<typeof createMockManager>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockLevel = createMockLevel();
+    mockServer = createMockServer();
+    mockManager = createMockManager();
+
+    mockGetLevel.mockReturnValue(mockLevel);
+    mockGetServer.mockReturnValue(mockServer);
+    mockGetManager.mockReturnValue(mockManager);
+
+    // Reset precisePosition to known values
+    mockBody.precisePosition = [10, 20];
+    mockBody.velocity = 5;
+    mockBody.direction = 1.5;
+  });
+
+  describe("factory shape", () => {
+    it("returns an object with create and cast methods", () => {
+      const factory = defineProjectile(createMinimalConfig());
+
+      expect(factory).toHaveProperty("create");
+      expect(factory).toHaveProperty("cast");
+      expect(typeof factory.create).toBe("function");
+      expect(typeof factory.cast).toBe("function");
+    });
+  });
+
+  describe("create", () => {
+    it("produces an entity with correct type", () => {
+      const factory = defineProjectile(createMinimalConfig());
+      const entity = factory.create([10, 20, 5, 1.5]);
+
+      expect((entity as any).type).toBe(EntityType.Fireball);
+    });
+
+    it("produces an entity with correct id initialized to -1", () => {
+      const factory = defineProjectile(createMinimalConfig());
+      const entity = factory.create([10, 20, 5, 1.5]);
+
+      expect(entity.id).toBe(-1);
+    });
+
+    it("produces an entity with all required interface methods", () => {
+      const factory = defineProjectile(createMinimalConfig());
+      const entity = factory.create([10, 20, 5, 1.5]);
+
+      expect(typeof (entity as any).tick).toBe("function");
+      expect(typeof (entity as any).die).toBe("function");
+      expect(typeof (entity as any).getCenter).toBe("function");
+      expect(typeof (entity as any).serialize).toBe("function");
+      expect(typeof (entity as any).deserialize).toBe("function");
+      expect(typeof (entity as any).serializeCreate).toBe("function");
+    });
+
+    it("defaults priority to Priority.Dynamic when not specified", () => {
+      const factory = defineProjectile(createMinimalConfig());
+      const entity = factory.create([10, 20, 5, 1.5]);
+
+      expect((entity as any).priority).toBe(Priority.Dynamic);
+    });
+
+    it("uses specified priority when provided", () => {
+      const factory = defineProjectile(
+        createMinimalConfig({ priority: Priority.High })
+      );
+      const entity = factory.create([10, 20, 5, 1.5]);
+
+      expect((entity as any).priority).toBe(Priority.High);
+    });
+  });
+
+  describe("serializeCreate", () => {
+    it("returns [x, y, velocity, direction] from the body", () => {
+      mockBody.precisePosition = [10, 20];
+      mockBody.velocity = 5;
+      mockBody.direction = 1.5;
+
+      const factory = defineProjectile(createMinimalConfig());
+      const entity = factory.create([10, 20, 5, 1.5]);
+      const result = (entity as any).serializeCreate();
+
+      expect(result[0]).toBe(10); // x
+      expect(result[1]).toBe(20); // y
+      expect(result[2]).toBe(5);  // velocity
+      expect(result[3]).toBe(1.5); // direction
+    });
+  });
+
+  describe("getCenter", () => {
+    it("returns position when no centerOffset is specified", () => {
+      const factory = defineProjectile(createMinimalConfig());
+      const entity = factory.create([10, 20, 5, 1.5]);
+
+      // Position is set as bx * 6, by * 6 = 10*6=60, 20*6=120
+      const center = (entity as any).getCenter();
+      expect(center[0]).toBe(60); // x = 10 * 6
+      expect(center[1]).toBe(120); // y = 20 * 6
+    });
+
+    it("applies centerOffset when specified", () => {
+      const factory = defineProjectile(
+        createMinimalConfig({ centerOffset: [5, 10] })
+      );
+      const entity = factory.create([10, 20, 5, 1.5]);
+
+      const center = (entity as any).getCenter();
+      expect(center[0]).toBe(65);  // 60 + 5
+      expect(center[1]).toBe(130); // 120 + 10
+    });
+  });
+
+  describe("serialize / deserialize", () => {
+    it("serialize delegates to body.serialize()", () => {
+      mockBody.serialize.mockReturnValue([10, 20, 1, 0]);
+
+      const factory = defineProjectile(createMinimalConfig());
+      const entity = factory.create([10, 20, 5, 1.5]);
+      const result = (entity as any).serialize();
+
+      expect(mockBody.serialize).toHaveBeenCalled();
+      expect(result).toEqual([10, 20, 1, 0]);
+    });
+
+    it("deserialize delegates to body.deserialize()", () => {
+      const factory = defineProjectile(createMinimalConfig());
+      const entity = factory.create([10, 20, 5, 1.5]);
+      const data = [10, 20, 1, 0];
+      (entity as any).deserialize(data);
+
+      expect(mockBody.deserialize).toHaveBeenCalledWith(data);
+    });
+  });
+
+  describe("cast", () => {
+    it("computes speed as power * multiplier when cast.speed is a number", async () => {
+      const { castProjectile } = await import("../utils");
+      const factory = defineProjectile(createMinimalConfig({ cast: { speed: 3 } }));
+
+      factory.cast(10, 20, {} as any, 0.5, 1.0);
+
+      // castProjectile is called with a factory function
+      expect(castProjectile).toHaveBeenCalled();
+      // SimpleBody should have been called with the entity created
+      const { SimpleBody } = await import("../../collision/simpleBody");
+      // Check addAngularVelocity was called with speed = power * multiplier = 0.5 * 3 = 1.5
+      expect(mockBody.addAngularVelocity).toHaveBeenCalledWith(1.5, 1.0);
+    });
+
+    it("computes speed via function when cast.speed is a function", async () => {
+      const speedFn = vi.fn().mockReturnValue(7);
+      const factory = defineProjectile(
+        createMinimalConfig({ cast: { speed: speedFn } })
+      );
+
+      factory.cast(10, 20, {} as any, 0.5, 1.0);
+
+      expect(speedFn).toHaveBeenCalledWith(0.5);
+      expect(mockBody.addAngularVelocity).toHaveBeenCalledWith(7, 1.0);
+    });
+  });
+
+  describe("tick", () => {
+    it("calls body.tick(dt) and updates position", () => {
+      mockBody.precisePosition = [15, 25];
+
+      const factory = defineProjectile(createMinimalConfig());
+      const entity = factory.create([15, 25, 5, 1.0]);
+      (entity as any).tick(16);
+
+      expect(mockBody.tick).toHaveBeenCalledWith(16);
+      // Position should be updated: bx * 6 = 15 * 6 = 90, by * 6 = 25 * 6 = 150
+      expect((entity as any).position.x).toBe(90);
+      expect((entity as any).position.y).toBe(150);
+    });
+  });
+});

--- a/src/data/spells/acid.ts
+++ b/src/data/spells/acid.ts
@@ -12,7 +12,7 @@ import { ControllableSound } from "../../sound/controllableSound";
 import { Sound } from "../../sound";
 import { AcidSplash } from "../../graphics/acidSplash";
 import { FallDamage, Shape } from "../damage/fallDamage";
-import { AcidDrop } from "./acidDrop";
+import { acidDrop } from "./acidDrop";
 import { CollisionMask } from "../collision/collisionMask";
 
 export class Acid extends Container implements Spawnable {
@@ -78,15 +78,12 @@ export class Acid extends Container implements Spawnable {
     getLevel().bloodEmitter.burst(this, 30);
     for (let i = 0; i < Acid.splitAmount; i++) {
       const direction = Math.atan2(vy, vx) + Math.PI;
-      const entity = new AcidDrop(
-        x,
-        y,
-        0.6 + Math.random() * 0.4,
+      const speed = 0.6 + Math.random() * 0.4;
+      const dir =
         direction -
-          Acid.splitRange / 2 +
-          (i / (Acid.splitAmount - 1)) * Acid.splitRange,
-        this.collisionMask
-      );
+        Acid.splitRange / 2 +
+        (i / (Acid.splitAmount - 1)) * Acid.splitRange;
+      const entity = acidDrop.create([x, y, speed, dir]);
       getServer()!.create(entity);
     }
   };

--- a/src/data/spells/acid.ts
+++ b/src/data/spells/acid.ts
@@ -11,7 +11,8 @@ import { getLevel, getManager, getServer } from "../context";
 import { ControllableSound } from "../../sound/controllableSound";
 import { Sound } from "../../sound";
 import { AcidSplash } from "../../graphics/acidSplash";
-import { FallDamage, Shape } from "../damage/fallDamage";
+import { Shape } from "../damage/fallDamage";
+import { applyFallDamage } from "./utils";
 import { acidDrop } from "./acidDrop";
 import { CollisionMask } from "../collision/collisionMask";
 
@@ -89,15 +90,12 @@ export class Acid extends Container implements Spawnable {
   };
 
   private _die(x: number, y: number) {
-    getServer()?.damage(
-      new FallDamage(
-        x,
-        y,
-        Shape.Acid,
-        24 + getManager().getElementValue(Element.Life) * 3
-      ),
-      getServer()!.getActivePlayer()
-    );
+    applyFallDamage(x, y, {
+      shape: Shape.Acid,
+      base: 24,
+      element: Element.Life,
+      multiplier: 3,
+    });
     getServer()!.kill(this);
   }
 

--- a/src/data/spells/acidDrop.ts
+++ b/src/data/spells/acidDrop.ts
@@ -1,136 +1,41 @@
-import { AnimatedSprite, Container } from "pixi.js";
-import { AssetsContainer } from "../../util/assets/assetsContainer";
-import { SimpleBody } from "../collision/simpleBody";
 import { circle3x3 } from "../collision/precomputed/circles";
-import { Character } from "../entity/character";
-
-import { TurnState } from "../network/types";
-import { EntityType, Priority, Spawnable } from "../entity/types";
+import { EntityType } from "../entity/types";
+import { Shape } from "../damage/fallDamage";
 import { Element } from "./types";
-import { getLevel, getManager, getServer } from "../context";
-import { ControllableSound } from "../../sound/controllableSound";
 import { Sound } from "../../sound";
-import { AcidSplash } from "../../graphics/acidSplash";
-import { FallDamage, Shape } from "../damage/fallDamage";
-import { CollisionMask } from "../collision/collisionMask";
+import { defineProjectile } from "./defineProjectile";
 
-export class AcidDrop extends Container implements Spawnable {
-  public readonly body: SimpleBody;
-  private sprite: AnimatedSprite;
-  private lifetime = 200;
+export const acidDrop = defineProjectile({
+  type: EntityType.AcidDrop,
+  body: {
+    mask: circle3x3,
+    friction: 0.99,
+    gravity: 0.04,
+    bounciness: 1,
+  },
+  sprite: {
+    animation: "spells_acid",
+    animationSpeed: 0.3,
+    anchor: [0.5, 0.5],
+    scale: 2,
+    alpha: 0.6,
+    offset: [10, 10],
+    randomStartFrame: true,
+  },
+  sound: Sound.Fire,
+  lifetime: 200,
+  damage: {
+    type: "fall",
+    shape: Shape.Acid,
+    base: 10,
+    element: Element.Life,
+    multiplier: 1,
+  },
+  deathEffect: "acidSplash",
+  deathSound: Sound.Slime,
+  centerOffset: [10, 10],
+  cast: { speed: 1 / 1.5 },
+});
 
-  public id = -1;
-  public readonly type = EntityType.AcidDrop;
-  public readonly priority = Priority.Dynamic;
-
-  constructor(
-    x: number,
-    y: number,
-    speed: number,
-    direction: number,
-    collisionMask: CollisionMask
-  ) {
-    super();
-
-    this.body = new SimpleBody(collisionMask, {
-      mask: circle3x3,
-      onCollide: getServer() ? this.onCollide : undefined,
-      friction: 0.99,
-      gravity: 0.04,
-      bounciness: 1,
-    });
-    this.body.move(x, y);
-    this.body.addAngularVelocity(speed, direction);
-    this.position.set(x * 6, y * 6);
-    ControllableSound.fromEntity(this, Sound.Fire);
-
-    const atlas = AssetsContainer.instance.assets!["atlas"];
-
-    this.sprite = new AnimatedSprite(atlas.animations["spells_acid"]);
-    this.sprite.scale.set(2);
-    this.sprite.animationSpeed = 0.3;
-    this.sprite.currentFrame = Math.floor(
-      this.sprite.totalFrames * Math.random()
-    );
-    this.sprite.play();
-    this.sprite.anchor.set(0.5);
-    this.sprite.position.set(10);
-    this.sprite.alpha = 0.6;
-
-    // const sprite2 = new Sprite(Texture.from(circle3x3Canvas));
-    // sprite2.anchor.set(0);
-    // sprite2.scale.set(6);
-    // sprite2.alpha = 0.5;
-
-    this.addChild(this.sprite);
-  }
-
-  private onCollide = (_x: number, _y: number, vx: number, vy: number) => {
-    const [x, y] = this.body.precisePosition;
-    this._die(x, y);
-  };
-
-  private _die(x: number, y: number) {
-    getServer()?.damage(
-      new FallDamage(
-        x,
-        y,
-        Shape.Acid,
-        10 + getManager().getElementValue(Element.Life)
-      ),
-      getServer()!.getActivePlayer()
-    );
-    getServer()!.kill(this);
-  }
-
-  die() {
-    getLevel().remove(this);
-    getManager().setTurnState(TurnState.Ending);
-    new AcidSplash(...this.getCenter());
-    ControllableSound.fromEntity(this, Sound.Slime);
-  }
-
-  getCenter(): [number, number] {
-    return [this.position.x + 10, this.position.y + 10];
-  }
-
-  tick(dt: number) {
-    this.body.tick(dt);
-    const [x, y] = this.body.precisePosition;
-    this.position.set(x * 6, y * 6);
-
-    this.lifetime -= dt;
-    if (this.lifetime <= 0 && getServer()) {
-      this._die(x, y);
-    }
-  }
-
-  serializeCreate() {
-    return [
-      ...this.body.precisePosition,
-      this.body.velocity,
-      this.body.direction,
-    ] as const;
-  }
-
-  static create(data: ReturnType<AcidDrop["serializeCreate"]>) {
-    return new AcidDrop(...data, getLevel().terrain.characterMask);
-  }
-
-  static cast(
-    x: number,
-    y: number,
-    character: Character,
-    power: number,
-    direction: number
-  ) {
-    if (!getServer()) {
-      return;
-    }
-
-    const entity = new AcidDrop(x, y, power / 1.5, direction, getLevel().terrain.characterMask);
-
-    getServer()!.create(entity);
-    return entity;
-  }
-}
+// Re-export for backwards compatibility with entity registry
+export const AcidDrop = acidDrop;

--- a/src/data/spells/defineProjectile.ts
+++ b/src/data/spells/defineProjectile.ts
@@ -1,0 +1,369 @@
+import { AnimatedSprite, Container } from "pixi.js";
+import { AssetsContainer } from "../../util/assets/assetsContainer";
+import { SimpleBody } from "../collision/simpleBody";
+import { CollisionMask } from "../collision/collisionMask";
+import {
+  EntityType,
+  Priority,
+  Spawnable,
+  SpawnableFactory,
+  Syncable,
+} from "../entity/types";
+import { TurnState } from "../network/types";
+import { Element } from "./types";
+import { Shape } from "../damage/fallDamage";
+import { Sound } from "../../sound";
+import { Character } from "../entity/character";
+import { ParticleEmitter } from "../../graphics/particles/types";
+import { Explosion } from "../../graphics/explosion";
+import { AcidSplash } from "../../graphics/acidSplash";
+import { IceImpact } from "../../graphics/iceImpact";
+import { ControllableSound } from "../../sound/controllableSound";
+import { getLevel, getManager, getServer } from "../context";
+import {
+  applyExplosiveDamage,
+  applyImpactDamage,
+  applyFallDamage,
+  castProjectile,
+  createParticles,
+} from "./utils";
+
+export interface ProjectileConfig {
+  type: EntityType;
+  priority?: Priority;
+
+  body: {
+    mask: CollisionMask;
+    friction: number;
+    gravity: number;
+    bounciness?: number;
+    bounces?: number;
+  };
+
+  sprite: {
+    animation: string;
+    animationSpeed: number;
+    anchor: [number, number];
+    scale?: number;
+    alpha?: number;
+    offset?: [number, number];
+    rotateWithDirection?: boolean;
+    randomStartFrame?: boolean;
+  };
+
+  particles?: {
+    animation: string;
+    config: Omit<
+      Parameters<typeof createParticles>[1],
+      "initialize"
+    > & {
+      initialize: (position: { x: number; y: number }) => {
+        x: number;
+        y: number;
+        xVelocity?: number;
+        yVelocity?: number;
+        scale?: number;
+        alpha?: number;
+      };
+    };
+  };
+
+  sound?: Sound;
+  lifetime: number;
+
+  damage: {
+    type: "explosive" | "impact" | "fall";
+    radius?: number;
+    intensity?: number;
+    shape?: Shape;
+    base: number;
+    element: Element;
+    multiplier: number;
+  };
+
+  bounceDamage?: {
+    type: "explosive";
+    radius: number;
+    intensity: number;
+    base: number;
+    element: Element;
+    multiplier: number;
+  };
+
+  deathEffect:
+    | "explosion"
+    | "acidSplash"
+    | "iceImpact"
+    | { custom: (x: number, y: number, direction?: number) => void };
+
+  deathSound?: Sound;
+  turnState?: TurnState;
+
+  cast: {
+    speed: number | ((power: number) => number);
+  };
+
+  centerOffset?: [number, number];
+
+  onTick?: (entity: ProjectileEntity, dt: number) => void;
+  onCollide?: (
+    entity: ProjectileEntity,
+    x: number,
+    y: number,
+    vx: number,
+    vy: number
+  ) => boolean;
+}
+
+export interface ProjectileEntity extends Container, Syncable {
+  readonly body: SimpleBody;
+  readonly sprite: AnimatedSprite;
+  readonly particles: ParticleEmitter | null;
+}
+
+export function defineProjectile(config: ProjectileConfig): SpawnableFactory {
+  const priority = config.priority ?? Priority.Dynamic;
+  const turnState = config.turnState ?? TurnState.Ending;
+  const centerOffset = config.centerOffset ?? [0, 0];
+
+  function createEntity(
+    x: number,
+    y: number,
+    speed: number,
+    direction: number,
+    collisionMask: CollisionMask
+  ): Spawnable & { body: SimpleBody } {
+    const container = new Container() as Container & {
+      id: number;
+      type: EntityType;
+      priority: Priority;
+      body: SimpleBody;
+      sprite: AnimatedSprite;
+      particles: ParticleEmitter | null;
+    };
+
+    container.id = -1;
+    (container as any).type = config.type;
+    (container as any).priority = priority;
+
+    // Track bounces
+    let bounces = config.body.bounces ?? 0;
+    let lifetime = config.lifetime;
+
+    // Collision handler
+    const onCollide = (cx: number, cy: number, vx: number, vy: number) => {
+      if (config.onCollide) {
+        const suppress = config.onCollide(
+          container as unknown as ProjectileEntity,
+          cx,
+          cy,
+          vx,
+          vy
+        );
+        if (suppress) return;
+      }
+
+      if (bounces > 0) {
+        // Check if this is a player collision (not terrain)
+        const playerCollision =
+          !getLevel().terrain.collisionMask.collidesWith(body.mask, cx, cy);
+
+        if (!playerCollision) {
+          bounces--;
+          if (config.bounceDamage) {
+            applyExplosiveDamage(cx, cy, config.bounceDamage);
+          }
+          getServer()!.dynamicUpdate(container as unknown as Syncable);
+          return;
+        }
+        // Player collision — fall through to die
+      }
+
+      die(cx, cy);
+    };
+
+    // Body
+    const body = new SimpleBody(collisionMask, {
+      mask: config.body.mask,
+      onCollide: getServer() ? onCollide : undefined,
+      friction: config.body.friction,
+      gravity: config.body.gravity,
+      bounciness: config.body.bounciness,
+    });
+    body.move(x, y);
+    body.addAngularVelocity(speed, direction);
+    container.position.set(x * 6, y * 6);
+    container.body = body;
+
+    // Sound
+    if (config.sound) {
+      ControllableSound.fromEntity(
+        [container.position.x, container.position.y],
+        config.sound
+      );
+    }
+
+    // Sprite
+    const atlas = AssetsContainer.instance.assets!["atlas"];
+    const sprite = new AnimatedSprite(atlas.animations[config.sprite.animation]);
+    sprite.animationSpeed = config.sprite.animationSpeed;
+    sprite.play();
+    sprite.anchor.set(...config.sprite.anchor);
+    if (config.sprite.scale) sprite.scale.set(config.sprite.scale);
+    if (config.sprite.alpha !== undefined) sprite.alpha = config.sprite.alpha;
+    if (config.sprite.offset) sprite.position.set(...config.sprite.offset);
+    if (config.sprite.rotateWithDirection) sprite.rotation = direction;
+    if (config.sprite.randomStartFrame) {
+      sprite.currentFrame = Math.floor(sprite.totalFrames * Math.random());
+    }
+    container.addChild(sprite);
+    container.sprite = sprite;
+
+    // Particles
+    let particles: ParticleEmitter | null = null;
+    if (config.particles) {
+      const particleConfig = config.particles;
+      particles = createParticles(particleConfig.animation, {
+        ...particleConfig.config,
+        initialize: () =>
+          particleConfig.config.initialize({
+            x: container.position.x,
+            y: container.position.y,
+          }),
+      });
+    }
+    container.particles = particles;
+
+    // Death
+    function die(dx: number, dy: number) {
+      const dmg = config.damage;
+      if (dmg.type === "explosive") {
+        applyExplosiveDamage(dx, dy, {
+          radius: dmg.radius!,
+          intensity: dmg.intensity!,
+          base: dmg.base,
+          element: dmg.element,
+          multiplier: dmg.multiplier,
+        });
+      } else if (dmg.type === "impact") {
+        applyImpactDamage(dx, dy, sprite.rotation, {
+          base: dmg.base,
+          element: dmg.element,
+          multiplier: dmg.multiplier,
+        });
+      } else if (dmg.type === "fall") {
+        applyFallDamage(dx, dy, {
+          shape: dmg.shape!,
+          base: dmg.base,
+          element: dmg.element,
+          multiplier: dmg.multiplier,
+        });
+      }
+      getServer()!.kill(container as unknown as Spawnable);
+    }
+
+    // Spawnable/Syncable methods
+    (container as any).tick = (dt: number) => {
+      body.tick(dt);
+      const [bx, by] = body.precisePosition;
+      container.position.set(bx * 6, by * 6);
+      if (config.sprite.rotateWithDirection) {
+        sprite.rotation = body.direction;
+      }
+
+      if (config.onTick) {
+        config.onTick(container as unknown as ProjectileEntity, dt);
+      }
+
+      lifetime -= dt;
+      if (lifetime <= 0 && getServer()) {
+        die(bx, by);
+      }
+    };
+
+    (container as any).die = () => {
+      getLevel().remove(container);
+      if (particles) {
+        getLevel().particleContainer.destroyEmitter(particles);
+      }
+
+      const effect = config.deathEffect;
+      if (effect === "explosion") {
+        new Explosion(container.position.x, container.position.y);
+      } else if (effect === "acidSplash") {
+        new AcidSplash(
+          container.position.x + centerOffset[0],
+          container.position.y + centerOffset[1]
+        );
+      } else if (effect === "iceImpact") {
+        new IceImpact(
+          container.position.x,
+          container.position.y,
+          sprite.rotation
+        );
+      } else {
+        effect.custom(
+          container.position.x,
+          container.position.y,
+          sprite.rotation
+        );
+      }
+
+      if (config.deathSound) {
+        ControllableSound.fromEntity(
+          [container.position.x, container.position.y],
+          config.deathSound
+        );
+      }
+
+      getManager().setTurnState(turnState);
+    };
+
+    (container as any).getCenter = (): [number, number] => [
+      container.position.x + centerOffset[0],
+      container.position.y + centerOffset[1],
+    ];
+
+    (container as any).serialize = () => body.serialize();
+
+    (container as any).deserialize = (data: any) => body.deserialize(data);
+
+    (container as any).serializeCreate = () =>
+      [
+        ...body.precisePosition,
+        body.velocity,
+        body.direction,
+      ] as const;
+
+    return container as unknown as Spawnable & { body: SimpleBody };
+  }
+
+  return {
+    create(data: readonly [number, number, number, number]) {
+      return createEntity(
+        data[0],
+        data[1],
+        data[2],
+        data[3],
+        getLevel().terrain.characterMask
+      );
+    },
+
+    cast(
+      x: number,
+      y: number,
+      _character: Character,
+      power: number,
+      direction: number
+    ) {
+      const speed =
+        typeof config.cast.speed === "function"
+          ? config.cast.speed(power)
+          : power * config.cast.speed;
+
+      return castProjectile((collisionMask) =>
+        createEntity(x, y, speed, direction, collisionMask)
+      );
+    },
+  };
+}

--- a/src/data/spells/defineProjectile.ts
+++ b/src/data/spells/defineProjectile.ts
@@ -126,39 +126,84 @@ export type ProjectileFactory = SpawnableFactory & {
 };
 
 export function defineProjectile(config: ProjectileConfig): ProjectileFactory {
-  const priority = config.priority ?? Priority.Dynamic;
-  const turnState = config.turnState ?? TurnState.Ending;
+  const configPriority = config.priority ?? Priority.Dynamic;
+  const configTurnState = config.turnState ?? TurnState.Ending;
   const centerOffset = config.centerOffset ?? [0, 0];
 
-  function createEntity(
-    x: number,
-    y: number,
-    speed: number,
-    direction: number,
-    collisionMask: CollisionMask
-  ): Spawnable & { body: SimpleBody } {
-    const container = new Container() as Container & {
-      id: number;
-      type: EntityType;
-      priority: Priority;
-      body: SimpleBody;
-      sprite: AnimatedSprite;
-      particles: ParticleEmitter | null;
-    };
+  class ProjectileEntityImpl extends Container implements Syncable {
+    public id = -1;
+    public readonly type = config.type;
+    public readonly priority = configPriority;
+    public readonly body: SimpleBody;
+    public readonly sprite: AnimatedSprite;
+    public readonly particles: ParticleEmitter | null;
 
-    container.id = -1;
-    (container as any).type = config.type;
-    (container as any).priority = priority;
+    private bounces = config.body.bounces ?? 0;
+    private lifetime = config.lifetime;
 
-    // Track bounces
-    let bounces = config.body.bounces ?? 0;
-    let lifetime = config.lifetime;
+    constructor(
+      x: number,
+      y: number,
+      speed: number,
+      direction: number,
+      collisionMask: CollisionMask
+    ) {
+      super();
 
-    // Collision handler
-    const onCollide = (cx: number, cy: number, vx: number, vy: number) => {
+      this.body = new SimpleBody(collisionMask, {
+        mask: config.body.mask,
+        onCollide: getServer() ? this.onCollide : undefined,
+        friction: config.body.friction,
+        gravity: config.body.gravity,
+        bounciness: config.body.bounciness,
+      });
+      this.body.move(x, y);
+      this.body.addAngularVelocity(speed, direction);
+      this.position.set(x * 6, y * 6);
+
+      if (config.sound) {
+        ControllableSound.fromEntity(this, config.sound);
+      }
+
+      const atlas = AssetsContainer.instance.assets!["atlas"];
+      this.sprite = new AnimatedSprite(
+        atlas.animations[config.sprite.animation]
+      );
+      this.sprite.animationSpeed = config.sprite.animationSpeed;
+      this.sprite.play();
+      this.sprite.anchor.set(...config.sprite.anchor);
+      if (config.sprite.scale) this.sprite.scale.set(config.sprite.scale);
+      if (config.sprite.alpha !== undefined)
+        this.sprite.alpha = config.sprite.alpha;
+      if (config.sprite.offset)
+        this.sprite.position.set(...config.sprite.offset);
+      if (config.sprite.rotateWithDirection) this.sprite.rotation = direction;
+      if (config.sprite.randomStartFrame) {
+        this.sprite.currentFrame = Math.floor(
+          this.sprite.totalFrames * Math.random()
+        );
+      }
+      this.addChild(this.sprite);
+
+      if (config.particles) {
+        const particleConfig = config.particles;
+        this.particles = createParticles(particleConfig.animation, {
+          ...particleConfig.config,
+          initialize: () =>
+            particleConfig.config.initialize({
+              x: this.position.x,
+              y: this.position.y,
+            }),
+        });
+      } else {
+        this.particles = null;
+      }
+    }
+
+    private onCollide = (cx: number, cy: number, vx: number, vy: number) => {
       if (config.onCollide) {
         const suppress = config.onCollide(
-          container as unknown as ProjectileEntity,
+          this as unknown as ProjectileEntity,
           cx,
           cy,
           vx,
@@ -167,79 +212,28 @@ export function defineProjectile(config: ProjectileConfig): ProjectileFactory {
         if (suppress) return;
       }
 
-      if (bounces > 0) {
-        // Check if this is a player collision (not terrain)
+      if (this.bounces > 0) {
         const playerCollision =
-          !getLevel().terrain.collisionMask.collidesWith(body.mask, cx, cy);
+          !getLevel().terrain.collisionMask.collidesWith(
+            this.body.mask,
+            cx,
+            cy
+          );
 
         if (!playerCollision) {
-          bounces--;
+          this.bounces--;
           if (config.bounceDamage) {
             applyExplosiveDamage(cx, cy, config.bounceDamage);
           }
-          getServer()!.dynamicUpdate(container as unknown as Syncable);
+          getServer()!.dynamicUpdate(this);
           return;
         }
-        // Player collision — fall through to die
       }
 
-      die(cx, cy);
+      this.applyDamageAndKill(cx, cy);
     };
 
-    // Body
-    const body = new SimpleBody(collisionMask, {
-      mask: config.body.mask,
-      onCollide: getServer() ? onCollide : undefined,
-      friction: config.body.friction,
-      gravity: config.body.gravity,
-      bounciness: config.body.bounciness,
-    });
-    body.move(x, y);
-    body.addAngularVelocity(speed, direction);
-    container.position.set(x * 6, y * 6);
-    container.body = body;
-
-    // Sound
-    if (config.sound) {
-      ControllableSound.fromEntity(
-        [container.position.x, container.position.y],
-        config.sound
-      );
-    }
-
-    // Sprite
-    const atlas = AssetsContainer.instance.assets!["atlas"];
-    const sprite = new AnimatedSprite(atlas.animations[config.sprite.animation]);
-    sprite.animationSpeed = config.sprite.animationSpeed;
-    sprite.play();
-    sprite.anchor.set(...config.sprite.anchor);
-    if (config.sprite.scale) sprite.scale.set(config.sprite.scale);
-    if (config.sprite.alpha !== undefined) sprite.alpha = config.sprite.alpha;
-    if (config.sprite.offset) sprite.position.set(...config.sprite.offset);
-    if (config.sprite.rotateWithDirection) sprite.rotation = direction;
-    if (config.sprite.randomStartFrame) {
-      sprite.currentFrame = Math.floor(sprite.totalFrames * Math.random());
-    }
-    container.addChild(sprite);
-    container.sprite = sprite;
-
-    // Particles
-    let particles: ParticleEmitter | null = null;
-    if (config.particles) {
-      const particleConfig = config.particles;
-      particles = createParticles(particleConfig.animation, {
-        ...particleConfig.config,
-        initialize: () =>
-          particleConfig.config.initialize({
-            x: container.position.x,
-            y: container.position.y,
-          }),
-      });
-    }
-    container.particles = particles;
-
-    // Death
-    function die(dx: number, dy: number) {
+    private applyDamageAndKill(dx: number, dy: number) {
       const dmg = config.damage;
       if (dmg.type === "explosive") {
         applyExplosiveDamage(dx, dy, {
@@ -250,7 +244,7 @@ export function defineProjectile(config: ProjectileConfig): ProjectileFactory {
           multiplier: dmg.multiplier,
         });
       } else if (dmg.type === "impact") {
-        applyImpactDamage(dx, dy, sprite.rotation, {
+        applyImpactDamage(dx, dy, this.sprite.rotation, {
           base: dmg.base,
           element: dmg.element,
           multiplier: dmg.multiplier,
@@ -263,88 +257,81 @@ export function defineProjectile(config: ProjectileConfig): ProjectileFactory {
           multiplier: dmg.multiplier,
         });
       }
-      getServer()!.kill(container as unknown as Spawnable);
+      getServer()!.kill(this);
     }
 
-    // Spawnable/Syncable methods
-    (container as any).tick = (dt: number) => {
-      body.tick(dt);
-      const [bx, by] = body.precisePosition;
-      container.position.set(bx * 6, by * 6);
+    tick(dt: number) {
+      this.body.tick(dt);
+      const [bx, by] = this.body.precisePosition;
+      this.position.set(bx * 6, by * 6);
       if (config.sprite.rotateWithDirection) {
-        sprite.rotation = body.direction;
+        this.sprite.rotation = this.body.direction;
       }
 
       if (config.onTick) {
-        config.onTick(container as unknown as ProjectileEntity, dt);
+        config.onTick(this as unknown as ProjectileEntity, dt);
       }
 
-      lifetime -= dt;
-      if (lifetime <= 0 && getServer()) {
-        die(bx, by);
+      this.lifetime -= dt;
+      if (this.lifetime <= 0 && getServer()) {
+        this.applyDamageAndKill(bx, by);
       }
-    };
+    }
 
-    (container as any).die = () => {
-      getLevel().remove(container);
-      if (particles) {
-        getLevel().particleContainer.destroyEmitter(particles);
+    die() {
+      getLevel().remove(this);
+      if (this.particles) {
+        getLevel().particleContainer.destroyEmitter(this.particles);
       }
 
       const effect = config.deathEffect;
       if (effect === "explosion") {
-        new Explosion(container.position.x, container.position.y);
+        new Explosion(this.position.x, this.position.y);
       } else if (effect === "acidSplash") {
         new AcidSplash(
-          container.position.x + centerOffset[0],
-          container.position.y + centerOffset[1]
+          this.position.x + centerOffset[0],
+          this.position.y + centerOffset[1]
         );
       } else if (effect === "iceImpact") {
-        new IceImpact(
-          container.position.x,
-          container.position.y,
-          sprite.rotation
-        );
+        new IceImpact(this.position.x, this.position.y, this.sprite.rotation);
       } else {
-        effect.custom(
-          container.position.x,
-          container.position.y,
-          sprite.rotation
-        );
+        effect.custom(this.position.x, this.position.y, this.sprite.rotation);
       }
 
       if (config.deathSound) {
-        ControllableSound.fromEntity(
-          [container.position.x, container.position.y],
-          config.deathSound
-        );
+        ControllableSound.fromEntity(this, config.deathSound);
       }
 
-      getManager().setTurnState(turnState);
-    };
+      getManager().setTurnState(configTurnState);
+    }
 
-    (container as any).getCenter = (): [number, number] => [
-      container.position.x + centerOffset[0],
-      container.position.y + centerOffset[1],
-    ];
+    getCenter(): [number, number] {
+      return [
+        this.position.x + centerOffset[0],
+        this.position.y + centerOffset[1],
+      ];
+    }
 
-    (container as any).serialize = () => body.serialize();
+    serialize() {
+      return this.body.serialize();
+    }
 
-    (container as any).deserialize = (data: any) => body.deserialize(data);
+    deserialize(data: ReturnType<ProjectileEntityImpl["serialize"]>) {
+      this.body.deserialize(data);
+    }
 
-    (container as any).serializeCreate = () =>
-      [
-        ...body.precisePosition,
-        body.velocity,
-        body.direction,
+    serializeCreate() {
+      return [
+        ...this.body.precisePosition,
+        this.body.velocity,
+        this.body.direction,
       ] as const;
-
-    return container as unknown as Spawnable & { body: SimpleBody };
+    }
   }
 
   return {
     create(data: readonly [number, number, number, number]) {
-      return createEntity(
+      return new ProjectileEntityImpl(
         data[0],
         data[1],
         data[2],
@@ -365,8 +352,9 @@ export function defineProjectile(config: ProjectileConfig): ProjectileFactory {
           ? config.cast.speed(power)
           : power * config.cast.speed;
 
-      return castProjectile((collisionMask) =>
-        createEntity(x, y, speed, direction, collisionMask)
+      return castProjectile(
+        (collisionMask) =>
+          new ProjectileEntityImpl(x, y, speed, direction, collisionMask)
       );
     },
   };

--- a/src/data/spells/defineProjectile.ts
+++ b/src/data/spells/defineProjectile.ts
@@ -121,7 +121,11 @@ export interface ProjectileEntity extends Container, Syncable {
   readonly particles: ParticleEmitter | null;
 }
 
-export function defineProjectile(config: ProjectileConfig): SpawnableFactory {
+export type ProjectileFactory = SpawnableFactory & {
+  cast(...args: any[]): any;
+};
+
+export function defineProjectile(config: ProjectileConfig): ProjectileFactory {
   const priority = config.priority ?? Priority.Dynamic;
   const turnState = config.turnState ?? TurnState.Ending;
   const centerOffset = config.centerOffset ?? [0, 0];

--- a/src/data/spells/fireball.ts
+++ b/src/data/spells/fireball.ts
@@ -1,170 +1,54 @@
-import { AnimatedSprite, Container } from "pixi.js";
-import { AssetsContainer } from "../../util/assets/assetsContainer";
-import { SimpleBody } from "../collision/simpleBody";
 import { circle3x3 } from "../collision/precomputed/circles";
-import { ExplosiveDamage } from "../damage/explosiveDamage";
-import { Character } from "../entity/character";
-
-import { SimpleParticleEmitter } from "../../graphics/particles/simpleParticleEmitter";
-import { Explosion } from "../../graphics/explosion";
-import { ParticleEmitter } from "../../graphics/particles/types";
-import { TurnState } from "../network/types";
-import { EntityType, Priority, Syncable } from "../entity/types";
+import { EntityType, Priority } from "../entity/types";
 import { Element } from "./types";
-import { getLevel, getManager, getServer } from "../context";
-import { ControllableSound } from "../../sound/controllableSound";
 import { Sound } from "../../sound";
-import { CollisionMask } from "../collision/collisionMask";
+import { defineProjectile } from "./defineProjectile";
 
-export class Fireball extends Container implements Syncable {
-  public readonly body: SimpleBody;
-  private sprite: AnimatedSprite;
-  private particles: ParticleEmitter;
-  private bounces = 5;
-  private lifetime = 100;
+export const fireball = defineProjectile({
+  type: EntityType.Fireball,
+  priority: Priority.Dynamic,
+  body: {
+    mask: circle3x3,
+    friction: 0.96,
+    gravity: 0.25,
+    bounciness: -0.9,
+    bounces: 5,
+  },
+  sprite: {
+    animation: "spells_flame",
+    animationSpeed: 0.3,
+    anchor: [0.25, 0.5],
+  },
+  particles: {
+    animation: "spells_puff",
+    config: {
+      initialize: (pos) => ({
+        x: pos.x + 8,
+        y: pos.y,
+        yVelocity: -3,
+      }),
+    },
+  },
+  sound: Sound.Fire,
+  lifetime: 100,
+  damage: {
+    type: "explosive",
+    radius: 16,
+    intensity: 3,
+    base: 2,
+    element: Element.Arcane,
+    multiplier: 1,
+  },
+  bounceDamage: {
+    type: "explosive",
+    radius: 4,
+    intensity: 1,
+    base: 1,
+    element: Element.Arcane,
+    multiplier: 1,
+  },
+  deathEffect: "explosion",
+  cast: { speed: 1.2 },
+});
 
-  public id = -1;
-  public readonly type = EntityType.Fireball;
-  public readonly priority = Priority.Dynamic;
-
-  constructor(x: number, y: number, speed: number, direction: number, collisionMask: CollisionMask) {
-    super();
-
-    this.body = new SimpleBody(collisionMask, {
-      mask: circle3x3,
-      onCollide: getServer() ? this.onCollide : undefined,
-      bounciness: -0.9,
-      friction: 0.96,
-      gravity: 0.25,
-    });
-    this.body.move(x, y);
-    this.body.addAngularVelocity(speed, direction);
-    this.position.set(x * 6, y * 6);
-    ControllableSound.fromEntity(this, Sound.Fire);
-
-    const atlas = AssetsContainer.instance.assets!["atlas"];
-
-    this.sprite = new AnimatedSprite(atlas.animations["spells_flame"]);
-    this.sprite.animationSpeed = 0.3;
-    this.sprite.play();
-    this.sprite.anchor.set(0.25, 0.5);
-
-    this.particles = new SimpleParticleEmitter(
-      atlas.animations["spells_puff"],
-      {
-        ...SimpleParticleEmitter.defaultConfig,
-        initialize: () => ({
-          x: this.position.x + 8,
-          y: this.position.y,
-          yVelocity: -3,
-        }),
-      }
-    );
-
-    // const sprite2 = new Sprite(Texture.fromBuffer(circle3x3Canvas.data, 3, 3));
-    // sprite2.anchor.set(0);
-    // sprite2.scale.set(6);
-
-    this.addChild(this.sprite);
-    getLevel().particleContainer.addEmitter(this.particles);
-  }
-
-  private onCollide = (x: number, y: number) => {
-    this.bounces--;
-
-    const playerCollision = !getLevel().terrain.collisionMask.collidesWith(
-      this.body.mask,
-      x,
-      y
-    );
-
-    if (this.bounces === 0 || playerCollision) {
-      this._die(x, y);
-    } else {
-      getServer()!.damage(
-        new ExplosiveDamage(
-          x,
-          y,
-          4,
-          1,
-          1 + getManager().getElementValue(Element.Arcane)
-        ),
-        getServer()!.getActivePlayer()
-      );
-      getServer()!.dynamicUpdate(this);
-    }
-  };
-
-  private _die(x: number, y: number) {
-    getServer()!.damage(
-      new ExplosiveDamage(
-        x,
-        y,
-        16,
-        3,
-        2 + getManager().getElementValue(Element.Arcane)
-      ),
-      getServer()!.getActivePlayer()
-    );
-    getServer()!.kill(this);
-  }
-
-  die() {
-    getLevel().remove(this);
-    getLevel().particleContainer.destroyEmitter(this.particles);
-    new Explosion(this.position.x, this.position.y);
-    getManager().setTurnState(TurnState.Ending);
-  }
-
-  getCenter(): [number, number] {
-    return [this.position.x, this.position.y];
-  }
-
-  tick(dt: number) {
-    this.body.tick(dt);
-    const [x, y] = this.body.precisePosition;
-    this.position.set(x * 6, y * 6);
-
-    this.lifetime -= dt;
-    if (this.lifetime <= 0 && getServer()) {
-      this._die(x, y);
-    }
-  }
-
-  serialize() {
-    return this.body.serialize();
-  }
-
-  deserialize(data: ReturnType<Fireball["serialize"]>) {
-    this.body.deserialize(data);
-  }
-
-  serializeCreate() {
-    return [
-      ...this.body.precisePosition,
-      this.body.velocity,
-      this.body.direction,
-    ] as const;
-  }
-
-  static create(data: ReturnType<Fireball["serializeCreate"]>) {
-    return new Fireball(...data, getLevel().terrain.characterMask);
-  }
-
-  static cast(
-    x: number,
-    y: number,
-    character: Character,
-    power: number,
-    direction: number
-  ) {
-    if (!getServer()) {
-      return;
-    }
-
-    const entity = new Fireball(x, y, power * 1.2, direction, getLevel().terrain.characterMask);
-
-    getServer()!.create(entity);
-    return entity;
-  }
-}
+export const Fireball = fireball;

--- a/src/data/spells/nephtear.ts
+++ b/src/data/spells/nephtear.ts
@@ -1,154 +1,51 @@
-import { AnimatedSprite, Container } from "pixi.js";
-import { AssetsContainer } from "../../util/assets/assetsContainer";
-import { SimpleBody } from "../collision/simpleBody";
 import { circle3x3 } from "../collision/precomputed/circles";
-import { Character } from "../entity/character";
-
-import { SimpleParticleEmitter } from "../../graphics/particles/simpleParticleEmitter";
-import { ParticleEmitter } from "../../graphics/particles/types";
-import { TurnState } from "../network/types";
-import { EntityType, Spawnable } from "../entity/types";
+import { EntityType } from "../entity/types";
 import { Element } from "./types";
-import { getLevel, getManager, getServer } from "../context";
-import { ControllableSound } from "../../sound/controllableSound";
 import { Sound } from "../../sound";
-import { CollisionMask } from "../collision/collisionMask";
+import { defineProjectile } from "./defineProjectile";
 import { map } from "../../util/math";
-import { IceImpact } from "../../graphics/iceImpact";
-import { ImpactDamage } from "../damage/impactDamage";
 
-export class Nephtear extends Container implements Spawnable {
-  public readonly body: SimpleBody;
-  private sprite: AnimatedSprite;
-  private particles: ParticleEmitter;
-  private lifetime = 200;
+export const nephtear = defineProjectile({
+  type: EntityType.Nephtear,
+  body: {
+    mask: circle3x3,
+    friction: 1,
+    gravity: 0.01,
+  },
+  sprite: {
+    animation: "spells_iceSpike",
+    animationSpeed: 0.1,
+    anchor: [0.5, 0.5],
+    scale: 2,
+    offset: [8, 8],
+    rotateWithDirection: true,
+  },
+  particles: {
+    animation: "spells_sparkle",
+    config: {
+      spawnRange: 16,
+      lifeTime: 20,
+      lifeTimeVariance: 1,
+      initialize: (pos) => ({
+        x: pos.x + 8,
+        y: pos.y + 8,
+        scale: map(0.5, 1, Math.random()),
+        xVelocity: Math.random() - 0.5,
+        yVelocity: Math.random() - 0.5,
+      }),
+    },
+  },
+  sound: Sound.Glass,
+  lifetime: 200,
+  damage: {
+    type: "impact",
+    base: 30,
+    element: Element.Elemental,
+    multiplier: 0.7,
+  },
+  deathEffect: "iceImpact",
+  centerOffset: [8, 8],
+  cast: { speed: (power) => 2 + power / 3 },
+});
 
-  public id = -1;
-  public readonly type = EntityType.Nephtear;
-
-  constructor(x: number, y: number, speed: number, direction: number, collisionMask: CollisionMask) {
-    super();
-
-    this.body = new SimpleBody(collisionMask, {
-      mask: circle3x3,
-      onCollide: getServer() ? this.onCollide : undefined,
-      friction: 1,
-      gravity: 0.01,
-    });
-    this.body.move(x, y);
-    this.body.addAngularVelocity(speed, direction);
-    this.position.set(x * 6, y * 6);
-    ControllableSound.fromEntity(this, Sound.Glass);
-
-    const atlas = AssetsContainer.instance.assets!["atlas"];
-
-    this.sprite = new AnimatedSprite(atlas.animations["spells_iceSpike"]);
-    this.sprite.animationSpeed = 0.1;
-    this.sprite.rotation = direction;
-    this.sprite.scale.set(2);
-    this.sprite.position.set(8, 8);
-    this.sprite.play();
-    this.sprite.anchor.set(0.5);
-
-    this.particles = new SimpleParticleEmitter(
-      atlas.animations["spells_sparkle"],
-      {
-        ...SimpleParticleEmitter.defaultConfig,
-        spawnRange: 16,
-        lifeTime: 20,
-        lifeTimeVariance: 1,
-        initialize: () => ({
-          x: this.position.x + 8,
-          y: this.position.y + 8,
-          scale: map(0.5, 1, Math.random()),
-          xVelocity: Math.random() - 0.5,
-          yVelocity: Math.random() - 0.5,
-        }),
-      }
-    );
-
-    // const sprite2 = new Sprite(Texture.from(circle3x3Canvas));
-    // sprite2.anchor.set(0);
-    // sprite2.scale.set(6);
-
-    this.addChild(this.sprite);
-    getLevel().particleContainer.addEmitter(this.particles);
-  }
-
-  private onCollide = (x: number, y: number) => {
-    this._die(x, y);
-  };
-
-  private _die(x: number, y: number) {
-    getServer()!.damage(
-      new ImpactDamage(
-        x,
-        y,
-        this.sprite.rotation,
-        30 * (0.7 + getManager().getElementValue(Element.Elemental) * 0.3)
-      ),
-      getServer()!.getActivePlayer()
-    );
-    getServer()!.kill(this);
-  }
-
-  die() {
-    getLevel().remove(this);
-    getLevel().particleContainer.destroyEmitter(this.particles);
-    new IceImpact(this.position.x, this.position.y, this.sprite.rotation);
-    getManager().setTurnState(TurnState.Ending);
-  }
-
-  getCenter(): [number, number] {
-    return [this.position.x + 8, this.position.y + 8];
-  }
-
-  tick(dt: number) {
-    this.body.tick(dt);
-    const [x, y] = this.body.precisePosition;
-    this.position.set(x * 6, y * 6);
-    this.sprite.rotation = this.body.direction;
-
-    this.lifetime -= dt;
-    if (this.lifetime <= 0 && getServer()) {
-      this._die(x, y);
-    }
-  }
-
-  serialize() {
-    return this.body.serialize();
-  }
-
-  deserialize(data: ReturnType<Nephtear["serialize"]>) {
-    this.body.deserialize(data);
-  }
-
-  serializeCreate() {
-    return [
-      ...this.body.precisePosition,
-      this.body.velocity,
-      this.body.direction,
-    ] as const;
-  }
-
-  static create(data: ReturnType<Nephtear["serializeCreate"]>) {
-    return new Nephtear(...data, getLevel().terrain.characterMask);
-  }
-
-  static cast(
-    x: number,
-    y: number,
-    character: Character,
-    power: number,
-    direction: number
-  ) {
-    if (!getServer()) {
-      return;
-    }
-
-    const entity = new Nephtear(x, y, 2 + power / 3, direction, getLevel().terrain.characterMask);
-
-    getServer()!.create(entity);
-    return entity;
-  }
-}
+export const Nephtear = nephtear;

--- a/src/data/spells/utils/casting.ts
+++ b/src/data/spells/utils/casting.ts
@@ -1,0 +1,12 @@
+import { Spawnable } from "../../entity/types";
+import { getLevel, getServer } from "../../context";
+import { CollisionMask } from "../../collision/collisionMask";
+
+export function castProjectile<T extends Spawnable>(
+  factory: (collisionMask: CollisionMask) => T
+): T | undefined {
+  if (!getServer()) return;
+  const entity = factory(getLevel().terrain.characterMask);
+  getServer()!.create(entity);
+  return entity;
+}

--- a/src/data/spells/utils/damage.ts
+++ b/src/data/spells/utils/damage.ts
@@ -1,0 +1,81 @@
+import { ExplosiveDamage } from "../../damage/explosiveDamage";
+import { ImpactDamage } from "../../damage/impactDamage";
+import { FallDamage, Shape } from "../../damage/fallDamage";
+import { Element } from "../types";
+import { getManager, getServer } from "../../context";
+
+export interface ExplosiveDamageConfig {
+  radius: number;
+  intensity: number;
+  base: number;
+  element: Element;
+  multiplier: number;
+}
+
+export interface ImpactDamageConfig {
+  base: number;
+  element: Element;
+  multiplier: number;
+}
+
+export interface FallDamageConfig {
+  shape: Shape;
+  base: number;
+  element: Element;
+  multiplier: number;
+}
+
+export function applyExplosiveDamage(
+  x: number,
+  y: number,
+  config: ExplosiveDamageConfig
+) {
+  getServer()!.damage(
+    new ExplosiveDamage(
+      x,
+      y,
+      config.radius,
+      config.intensity,
+      config.base +
+        getManager().getElementValue(config.element) * config.multiplier
+    ),
+    getServer()!.getActivePlayer()
+  );
+}
+
+export function applyImpactDamage(
+  x: number,
+  y: number,
+  direction: number,
+  config: ImpactDamageConfig
+) {
+  getServer()!.damage(
+    new ImpactDamage(
+      x,
+      y,
+      direction,
+      config.base *
+        (config.multiplier +
+          getManager().getElementValue(config.element) *
+            (1 - config.multiplier))
+    ),
+    getServer()!.getActivePlayer()
+  );
+}
+
+export function applyFallDamage(
+  x: number,
+  y: number,
+  config: FallDamageConfig
+) {
+  getServer()!.damage(
+    new FallDamage(
+      x,
+      y,
+      config.shape,
+      config.base +
+        getManager().getElementValue(config.element) * config.multiplier
+    ),
+    getServer()!.getActivePlayer()
+  );
+}

--- a/src/data/spells/utils/index.ts
+++ b/src/data/spells/utils/index.ts
@@ -1,0 +1,12 @@
+export {
+  applyExplosiveDamage,
+  applyImpactDamage,
+  applyFallDamage,
+} from "./damage";
+export type {
+  ExplosiveDamageConfig,
+  ImpactDamageConfig,
+  FallDamageConfig,
+} from "./damage";
+export { castProjectile } from "./casting";
+export { createParticles } from "./particles";

--- a/src/data/spells/utils/particles.ts
+++ b/src/data/spells/utils/particles.ts
@@ -1,0 +1,19 @@
+import { AssetsContainer } from "../../../util/assets/assetsContainer";
+import { SimpleParticleEmitter } from "../../../graphics/particles/simpleParticleEmitter";
+import { ParticleEmitter } from "../../../graphics/particles/types";
+import { getLevel } from "../../context";
+
+type ParticleConfig = ConstructorParameters<typeof SimpleParticleEmitter>[1];
+
+export function createParticles(
+  animation: string,
+  config: Partial<ParticleConfig> & Pick<ParticleConfig, "initialize">
+): ParticleEmitter {
+  const atlas = AssetsContainer.instance.assets!["atlas"];
+  const emitter = new SimpleParticleEmitter(atlas.animations[animation], {
+    ...SimpleParticleEmitter.defaultConfig,
+    ...config,
+  } as ParticleConfig);
+  getLevel().particleContainer.addEmitter(emitter);
+  return emitter;
+}

--- a/src/util/__spec__/array.spec.ts
+++ b/src/util/__spec__/array.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getRandom } from "../array";
+
+describe("array", () => {
+  describe("getRandom", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("returns first element when Math.random returns 0", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      expect(getRandom([10, 20, 30])).toBe(10);
+    });
+
+    it("returns last element when Math.random returns 0.999", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.999);
+      expect(getRandom([10, 20, 30])).toBe(30);
+    });
+
+    it("returns the only element of a single-element array", () => {
+      expect(getRandom([42])).toBe(42);
+    });
+  });
+});

--- a/src/util/__spec__/data.spec.ts
+++ b/src/util/__spec__/data.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { base64ToBytes, bytesToBase64 } from "../data";
+
+describe("data", () => {
+  describe("base64ToBytes", () => {
+    it("decodes a known base64 string", () => {
+      // "SGVsbG8=" is base64 for "Hello"
+      const bytes = base64ToBytes("SGVsbG8=");
+      expect(Array.from(bytes)).toEqual([72, 101, 108, 108, 111]);
+    });
+
+    it("handles empty string", () => {
+      const bytes = base64ToBytes("");
+      expect(bytes.length).toBe(0);
+    });
+  });
+
+  describe("bytesToBase64", () => {
+    it("encodes a known byte array", () => {
+      const bytes = new Uint8Array([72, 101, 108, 108, 111]);
+      expect(bytesToBase64(bytes.buffer)).toBe("SGVsbG8=");
+    });
+  });
+
+  describe("round-trip", () => {
+    it("preserves data through encode then decode", () => {
+      const original = new Uint8Array([0, 1, 127, 128, 255]);
+      const encoded = bytesToBase64(original.buffer);
+      const decoded = base64ToBytes(encoded);
+      expect(Array.from(decoded)).toEqual(Array.from(original));
+    });
+
+    it("preserves large data", () => {
+      const original = new Uint8Array(256);
+      for (let i = 0; i < 256; i++) original[i] = i;
+      const encoded = bytesToBase64(original.buffer);
+      const decoded = base64ToBytes(encoded);
+      expect(Array.from(decoded)).toEqual(Array.from(original));
+    });
+  });
+});

--- a/src/util/__spec__/math.spec.ts
+++ b/src/util/__spec__/math.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import {
+  mod,
+  dot,
+  getRayDistance,
+  getSquareDistance,
+  getDistance,
+  getAngle,
+  map,
+  angleDiff,
+} from "../math";
+
+describe("math", () => {
+  describe("mod", () => {
+    it("returns value within range for positive input", () => {
+      expect(mod(3, 5)).toBe(3);
+    });
+
+    it("wraps negative values correctly", () => {
+      expect(mod(-1, 5)).toBe(4);
+      expect(mod(-6, 5)).toBe(4);
+    });
+
+    it("returns 0 when value equals modulo", () => {
+      expect(mod(5, 5)).toBe(0);
+    });
+
+    it("wraps large values", () => {
+      expect(mod(13, 5)).toBe(3);
+    });
+  });
+
+  describe("dot", () => {
+    it("returns 0 for orthogonal vectors", () => {
+      expect(dot(1, 0, 0, 1)).toBe(0);
+    });
+
+    it("returns product for parallel vectors", () => {
+      expect(dot(3, 0, 4, 0)).toBe(12);
+    });
+
+    it("computes correctly for arbitrary vectors", () => {
+      expect(dot(2, 3, 4, 5)).toBe(2 * 4 + 3 * 5);
+    });
+  });
+
+  describe("getRayDistance", () => {
+    it("returns distance for point behind the ray origin", () => {
+      // Ray at (10, 0) pointing right, point at (0, 5)
+      // v1 = (10-0, 0-5) = (10, -5), v2 = (1, 0), dot = 10 > 0 → not infinity
+      const dist = getRayDistance(10, 0, 0, 0, 5);
+      expect(dist).toBeCloseTo(5, 5);
+    });
+
+    it("returns POSITIVE_INFINITY for point in front of the ray", () => {
+      // Ray at origin pointing right, point at (5, 0) is ahead
+      expect(getRayDistance(0, 0, 0, 5, 0)).toBe(Number.POSITIVE_INFINITY);
+    });
+
+    it("returns 0 for point directly on the ray line behind origin", () => {
+      // Ray at (10, 0) pointing right, point at (0, 0)
+      const dist = getRayDistance(10, 0, 0, 0, 0);
+      expect(dist).toBeCloseTo(0, 5);
+    });
+
+    it("works with angled rays", () => {
+      // Ray at (0, 10) pointing up (negative y), point at (5, 20)
+      // v1 = (0-5, 10-20) = (-5, -10), v2 = (cos(-PI/2), sin(-PI/2)) = (0, -1)
+      // dot = 0 + 10 = 10 > 0
+      const dist = getRayDistance(0, 10, -Math.PI / 2, 5, 20);
+      expect(dist).toBeCloseTo(5, 5);
+    });
+  });
+
+  describe("getSquareDistance", () => {
+    it("returns 0 for same point", () => {
+      expect(getSquareDistance(3, 4, 3, 4)).toBe(0);
+    });
+
+    it("returns squared distance for 3-4-5 triangle", () => {
+      expect(getSquareDistance(0, 0, 3, 4)).toBe(25);
+    });
+  });
+
+  describe("getDistance", () => {
+    it("returns 0 for same point", () => {
+      expect(getDistance(0, 0, 0, 0)).toBe(0);
+    });
+
+    it("returns 5 for 3-4-5 triangle", () => {
+      expect(getDistance(0, 0, 3, 4)).toBe(5);
+    });
+
+    it("handles negative coordinates", () => {
+      expect(getDistance(-3, -4, 0, 0)).toBe(5);
+    });
+  });
+
+  describe("getAngle", () => {
+    it("returns 0 for point directly to the right", () => {
+      expect(getAngle(0, 0, 1, 0)).toBe(0);
+    });
+
+    it("returns PI/2 for point directly below", () => {
+      expect(getAngle(0, 0, 0, 1)).toBeCloseTo(Math.PI / 2, 5);
+    });
+
+    it("returns PI for point directly to the left", () => {
+      expect(getAngle(0, 0, -1, 0)).toBeCloseTo(Math.PI, 5);
+    });
+
+    it("returns -PI/2 for point directly above", () => {
+      expect(getAngle(0, 0, 0, -1)).toBeCloseTo(-Math.PI / 2, 5);
+    });
+  });
+
+  describe("map", () => {
+    it("returns from when t=0", () => {
+      expect(map(10, 20, 0)).toBe(10);
+    });
+
+    it("returns to when t=1", () => {
+      expect(map(10, 20, 1)).toBe(20);
+    });
+
+    it("returns midpoint when t=0.5", () => {
+      expect(map(10, 20, 0.5)).toBe(15);
+    });
+
+    it("extrapolates beyond range", () => {
+      expect(map(10, 20, 2)).toBe(30);
+    });
+  });
+
+  describe("angleDiff", () => {
+    it("returns 0 for same angle", () => {
+      expect(angleDiff(1, 1)).toBeCloseTo(0, 5);
+    });
+
+    it("returns positive for clockwise difference", () => {
+      expect(angleDiff(0, Math.PI / 2)).toBeCloseTo(Math.PI / 2, 5);
+    });
+
+    it("wraps across PI boundary correctly", () => {
+      // From just below PI to just above -PI should be a small positive step
+      const diff = angleDiff(Math.PI - 0.1, -Math.PI + 0.1);
+      expect(diff).toBeCloseTo(0.2, 5);
+    });
+
+    it("returns negative for counter-clockwise difference", () => {
+      expect(angleDiff(Math.PI / 2, 0)).toBeCloseTo(-Math.PI / 2, 5);
+    });
+  });
+});

--- a/src/util/__spec__/time.spec.ts
+++ b/src/util/__spec__/time.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { minutesToMs, secondsToMs } from "../time";
+
+describe("time", () => {
+  describe("minutesToMs", () => {
+    it("converts 1 minute to 60000ms", () => {
+      expect(minutesToMs(1)).toBe(60000);
+    });
+
+    it("converts 0 minutes to 0ms", () => {
+      expect(minutesToMs(0)).toBe(0);
+    });
+
+    it("handles fractional minutes", () => {
+      expect(minutesToMs(0.5)).toBe(30000);
+    });
+  });
+
+  describe("secondsToMs", () => {
+    it("converts 1 second to 1000ms", () => {
+      expect(secondsToMs(1)).toBe(1000);
+    });
+
+    it("converts 0 seconds to 0ms", () => {
+      expect(secondsToMs(0)).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces a `defineProjectile(config)` factory that produces game entities from declarative config, replacing ~150-line spell classes with ~20-line config objects
- Creates a shared utility layer (`src/data/spells/utils/`) for damage application, casting, and particle creation — usable by all spells
- Migrates 3 spells (fireball, acidDrop, nephtear) to config-driven definitions and refactors acid to use shared damage utilities
- Adds `SpawnableFactory` interface to unify class-based and factory-based spell entities in the `ENTITIES` registry

## Test plan

- [x] 14 new unit tests for `defineProjectile` factory (entity creation, serialization, speed computation, priority defaults, centerOffset)
- [x] All 171 existing tests pass
- [x] Production build succeeds
- [ ] Manual test: cast fireball (Ignis) — verify bouncing, particle trail, explosion on death
- [ ] Manual test: cast nephtear — verify rotation, sparkle particles, ice impact effect
- [ ] Manual test: cast acid (Reamstroha) — verify acid drops spawn on collision via factory
- [ ] Manual test: 2-player local game — verify network serialization works for migrated spells

🤖 Generated with [Claude Code](https://claude.com/claude-code)