### PR TITLE
perf: batch of performance optimizations

### DIFF
--- a/src/components/organisms/Hud.vue
+++ b/src/components/organisms/Hud.vue
@@ -24,15 +24,11 @@ const { forceOpen } = defineProps<{
   forceOpen: boolean;
 }>();
 
-const getElements = () =>
+const elements = ref(
   Object.fromEntries(
-    Object.values(Element).map((element) => [
-      element,
-      getManager().getElementValue(element),
-    ])
-  ) as Record<Element, number>;
-
-const elements = ref(getElements());
+    Object.values(Element).map((element) => [element, 1.75])
+  ) as Record<Element, number>
+);
 const turnTime = ref(0);
 const gameTime = ref(0);
 const mana = ref(0);
@@ -49,13 +45,17 @@ const poll = () => {
 
   const data = getManager().getHudData();
 
-  const newElements = getElements();
+  let elementsChanged = false;
   const currentElements = elements.value;
-  for (const key in newElements) {
-    if (newElements[key as Element] !== currentElements[key as Element]) {
-      elements.value = newElements;
-      break;
+  for (const element of Object.values(Element)) {
+    const newValue = getManager().getElementValue(element);
+    if (newValue !== currentElements[element]) {
+      currentElements[element] = newValue;
+      elementsChanged = true;
     }
+  }
+  if (elementsChanged) {
+    elements.value = { ...currentElements };
   }
 
   if (turnTime.value !== data.turnTime) turnTime.value = data.turnTime;

--- a/src/components/organisms/Hud.vue
+++ b/src/components/organisms/Hud.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from "vue";
+import { onBeforeUnmount, onMounted, ref, shallowRef, triggerRef } from "vue";
 import { getManager, getServer } from "../../data/context";
 import { Player } from "../../data/network/player";
 import { Popup } from "../../data/network/types";
@@ -24,7 +24,7 @@ const { forceOpen } = defineProps<{
   forceOpen: boolean;
 }>();
 
-const elements = ref(
+const elements = shallowRef(
   Object.fromEntries(
     Object.values(Element).map((element) => [element, DEFAULT_ELEMENT_VALUE])
   ) as Record<Element, number>
@@ -55,7 +55,7 @@ const poll = () => {
     }
   }
   if (elementsChanged) {
-    elements.value = { ...currentElements };
+    triggerRef(elements);
   }
 
   if (turnTime.value !== data.turnTime) turnTime.value = data.turnTime;

--- a/src/components/organisms/Hud.vue
+++ b/src/components/organisms/Hud.vue
@@ -5,7 +5,7 @@ import { Player } from "../../data/network/player";
 import { Popup } from "../../data/network/types";
 import { Element } from "../../data/spells/types";
 import { ELEMENT_MAP } from "../../graphics/elements";
-import { MAX_MANA } from "../../data/network/constants";
+import { DEFAULT_ELEMENT_VALUE, MAX_MANA } from "../../data/network/constants";
 import { AccumulatedStat } from "../../data/network/accumulatedStat";
 import EndGameDialog from "./EndGameDialog.vue";
 import IconButton from "../atoms/IconButton.vue";
@@ -26,7 +26,7 @@ const { forceOpen } = defineProps<{
 
 const elements = ref(
   Object.fromEntries(
-    Object.values(Element).map((element) => [element, 1.75])
+    Object.values(Element).map((element) => [element, DEFAULT_ELEMENT_VALUE])
   ) as Record<Element, number>
 );
 const turnTime = ref(0);

--- a/src/components/organisms/Hud.vue
+++ b/src/components/organisms/Hud.vue
@@ -48,24 +48,35 @@ const poll = () => {
   }
 
   const data = getManager().getHudData();
-  elements.value = getElements();
-  turnTime.value = data.turnTime;
-  gameTime.value = data.gameTime;
-  players.value = data.players;
-  activePlayer.value = data.activePlayer;
-  mana.value = data.mana;
-  stats.value = data.stats;
 
-  maxHp.value = 100;
+  const newElements = getElements();
+  const currentElements = elements.value;
+  for (const key in newElements) {
+    if (newElements[key as Element] !== currentElements[key as Element]) {
+      elements.value = newElements;
+      break;
+    }
+  }
+
+  if (turnTime.value !== data.turnTime) turnTime.value = data.turnTime;
+  if (gameTime.value !== data.gameTime) gameTime.value = data.gameTime;
+  if (mana.value !== data.mana) mana.value = data.mana;
+  if (players.value !== data.players) players.value = data.players;
+  if (activePlayer.value !== data.activePlayer)
+    activePlayer.value = data.activePlayer;
+  if (stats.value !== data.stats) stats.value = data.stats;
+
+  let newMaxHp = 100;
   for (let player of data.players) {
     let hp =
       player.characters.reduce((sum, character) => sum + character.hp, 0) /
       player.characters.length;
 
-    if (hp > maxHp.value) {
-      maxHp.value = hp;
+    if (hp > newMaxHp) {
+      newMaxHp = hp;
     }
   }
+  if (maxHp.value !== newMaxHp) maxHp.value = newMaxHp;
 
   if (!popup.value) {
     const popped = getManager().popupPop();

--- a/src/components/organisms/Inventory.vue
+++ b/src/components/organisms/Inventory.vue
@@ -34,15 +34,29 @@ const availableList = ref<boolean[]>([]);
 const poll = () => {
   if (props.isOpen) {
     const mana = getManager().self.mana;
-    availableList.value = [];
+    const executedSpells = getManager().self.executedSpells;
+    let changed = false;
+
     SPELLS.forEach((spell) => {
-      availableList.value[spell.iconId] =
+      const available =
         (spell.costMultiplier?.() || 1) * spell.cost <= mana &&
-        !getManager().self.executedSpells.includes(spell);
+        !executedSpells.includes(spell);
+
+      if (availableList.value[spell.iconId] !== available) {
+        availableList.value[spell.iconId] = available;
+        changed = true;
+      }
     });
+
+    if (changed) {
+      availableList.value = [...availableList.value];
+    }
   } else {
     if (getManager().self === getManager().getActivePlayer()) {
-      selectedSpell.value = getManager().selectedSpell;
+      const newSpell = getManager().selectedSpell;
+      if (selectedSpell.value !== newSpell) {
+        selectedSpell.value = newSpell;
+      }
     }
   }
 };

--- a/src/components/organisms/Inventory.vue
+++ b/src/components/organisms/Inventory.vue
@@ -31,16 +31,23 @@ const sections = {
 const selectedSpell = ref(getManager()?.selectedSpell);
 const availableList = ref<boolean[]>([]);
 
+let cachedExecutedSpells: Spell[] | null = null;
+let cachedExecutedSet: Set<Spell> = new Set();
+
 const poll = () => {
   if (props.isOpen) {
     const mana = getManager().self.mana;
-    const executedSet = new Set(getManager().self.executedSpells);
+    const currentExecuted = getManager().self.executedSpells;
+    if (cachedExecutedSpells !== currentExecuted) {
+      cachedExecutedSpells = currentExecuted;
+      cachedExecutedSet = new Set(currentExecuted);
+    }
     let changed = false;
 
     SPELLS.forEach((spell) => {
       const available =
         (spell.costMultiplier?.() || 1) * spell.cost <= mana &&
-        !executedSet.has(spell);
+        !cachedExecutedSet.has(spell);
 
       if (availableList.value[spell.iconId] !== available) {
         availableList.value[spell.iconId] = available;

--- a/src/components/organisms/Inventory.vue
+++ b/src/components/organisms/Inventory.vue
@@ -34,13 +34,13 @@ const availableList = ref<boolean[]>([]);
 const poll = () => {
   if (props.isOpen) {
     const mana = getManager().self.mana;
-    const executedSpells = getManager().self.executedSpells;
+    const executedSet = new Set(getManager().self.executedSpells);
     let changed = false;
 
     SPELLS.forEach((spell) => {
       const available =
         (spell.costMultiplier?.() || 1) * spell.cost <= mana &&
-        !executedSpells.includes(spell);
+        !executedSet.has(spell);
 
       if (availableList.value[spell.iconId] !== available) {
         availableList.value[spell.iconId] = available;

--- a/src/components/organisms/Inventory.vue
+++ b/src/components/organisms/Inventory.vue
@@ -32,14 +32,16 @@ const selectedSpell = ref(getManager()?.selectedSpell);
 const availableList = ref<boolean[]>([]);
 
 let cachedExecutedSpells: Spell[] | null = null;
+let cachedExecutedLength = 0;
 let cachedExecutedSet: Set<Spell> = new Set();
 
 const poll = () => {
   if (props.isOpen) {
     const mana = getManager().self.mana;
     const currentExecuted = getManager().self.executedSpells;
-    if (cachedExecutedSpells !== currentExecuted) {
+    if (cachedExecutedSpells !== currentExecuted || cachedExecutedLength !== currentExecuted.length) {
       cachedExecutedSpells = currentExecuted;
+      cachedExecutedLength = currentExecuted.length;
       cachedExecutedSet = new Set(currentExecuted);
     }
     let changed = false;

--- a/src/data/damage/__spec__/targetList.spec.ts
+++ b/src/data/damage/__spec__/targetList.spec.ts
@@ -163,4 +163,45 @@ describe("TargetList", () => {
       expect(entities).toEqual([entity]);
     });
   });
+
+  describe("hasEntity", () => {
+    it("returns true when entity is in the target list", () => {
+      const entity = createMockEntity(1);
+      const entityMap = new Map<number, TickingEntity>([
+        [1, entity as unknown as TickingEntity],
+      ]);
+
+      const list = new TargetList();
+      list.add(entity, 10);
+
+      expect(list.hasEntity(entity, entityMap)).toBe(true);
+    });
+
+    it("returns false when entity is not in the target list", () => {
+      const entity1 = createMockEntity(1);
+      const entity2 = createMockEntity(2);
+      const entityMap = new Map<number, TickingEntity>([
+        [1, entity1 as unknown as TickingEntity],
+        [2, entity2 as unknown as TickingEntity],
+      ]);
+
+      const list = new TargetList();
+      list.add(entity1, 10);
+
+      expect(list.hasEntity(entity2, entityMap)).toBe(false);
+    });
+
+    it("returns false when entity id exists but resolved entity differs", () => {
+      const entity1 = createMockEntity(1);
+      const differentEntity = createMockEntity(1);
+      const entityMap = new Map<number, TickingEntity>([
+        [1, differentEntity as unknown as TickingEntity],
+      ]);
+
+      const list = new TargetList();
+      list.add(entity1, 10);
+
+      expect(list.hasEntity(entity1, entityMap)).toBe(false);
+    });
+  });
 });

--- a/src/data/damage/explosiveDamage.ts
+++ b/src/data/damage/explosiveDamage.ts
@@ -116,9 +116,10 @@ export class ExplosiveDamage implements DamageSource {
         this.x * 6,
         this.y * 6,
         range,
-        (entity, distance) => {
+        (entity, distanceSquared) => {
           if (isHurtableEntity(entity)) {
             const [x, y] = entity.getCenter();
+            const distance = Math.sqrt(distanceSquared);
             this.targets!.add(
               entity,
               (5 + 5 * ((range - distance) / range)) * this.damageMultiplier,

--- a/src/data/damage/targetList.ts
+++ b/src/data/damage/targetList.ts
@@ -59,6 +59,18 @@ export class TargetList {
     );
   }
 
+  hasEntity(
+    entity: HurtableEntity,
+    entityMap: Map<number, TickingEntity> = getLevel().entityMap
+  ) {
+    for (const target of this.targets) {
+      if (entityMap.get(target.entityId) === entity) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   hasEntities() {
     return !!this.targets.length;
   }

--- a/src/data/map/level.ts
+++ b/src/data/map/level.ts
@@ -133,6 +133,12 @@ export class Level {
     this.viewport.resize(window.innerWidth, window.innerHeight);
   };
 
+  destroy() {
+    window.removeEventListener("resize", this.resize);
+    this.app.destroy();
+    this.target.removeChild(this.app.canvas);
+  }
+
   getRandomSpawnLocation() {
     if (!this.spawnLocations.length) {
       this.spawnLocations = this.terrain.getSpawnLocations();

--- a/src/data/map/level.ts
+++ b/src/data/map/level.ts
@@ -213,6 +213,7 @@ export class Level {
     }
 
     this.cameraTarget.tick(dt);
+    this.terrain.flush();
   }
 
   add(

--- a/src/data/map/level.ts
+++ b/src/data/map/level.ts
@@ -274,10 +274,12 @@ export class Level {
       }
 
       if ("priority" in object) {
-        this.syncables[object.priority].splice(
-          this.syncables[object.priority].indexOf(object),
-          1
-        );
+        const arr = this.syncables[object.priority];
+        const index = arr.indexOf(object);
+        if (index !== -1) {
+          arr[index] = arr[arr.length - 1];
+          arr.pop();
+        }
       }
     }
   }

--- a/src/data/map/level.ts
+++ b/src/data/map/level.ts
@@ -135,8 +135,9 @@ export class Level {
 
   destroy() {
     window.removeEventListener("resize", this.resize);
+    const canvas = this.app.canvas;
     this.app.destroy();
-    this.target.removeChild(this.app.canvas);
+    canvas.remove();
   }
 
   getRandomSpawnLocation() {

--- a/src/data/map/level.ts
+++ b/src/data/map/level.ts
@@ -280,14 +280,14 @@ export class Level {
     x: number,
     y: number,
     range: number,
-    fn: (entity: HurtableEntity, distance: number) => void | boolean
+    fn: (entity: HurtableEntity, distanceSquared: number) => void | boolean
   ) {
     const rangeSquared = range ** 2;
     for (let entity of this.hurtables) {
       const [ex, ey] = entity.getCenter();
-      const distance = (ex - x) ** 2 + (ey - y) ** 2;
-      if (distance < rangeSquared) {
-        if (fn(entity, Math.sqrt(distance))) {
+      const distanceSquared = (ex - x) ** 2 + (ey - y) ** 2;
+      if (distanceSquared < rangeSquared) {
+        if (fn(entity, distanceSquared)) {
           return;
         }
       }

--- a/src/data/map/terrain.ts
+++ b/src/data/map/terrain.ts
@@ -281,6 +281,13 @@ export class Terrain {
     }
   }
 
+  flush() {
+    this.terrain.flush();
+    for (let layer of this.layerTextures) {
+      layer.flush();
+    }
+  }
+
   serialize() {
     return this.map.toConfig(true);
   }

--- a/src/data/map/updatingTexture.ts
+++ b/src/data/map/updatingTexture.ts
@@ -2,6 +2,7 @@ import { Texture } from "pixi.js";
 
 export class UpdatingTexture {
   private ctx: OffscreenCanvasRenderingContext2D;
+  private _dirty = false;
   public readonly texture: Texture;
 
   constructor(canvas: OffscreenCanvas, scale = 1, offsetX = 0, offsetY = 0) {
@@ -22,6 +23,13 @@ export class UpdatingTexture {
     fn(this.ctx);
     this.ctx.fill();
 
-    this.texture.source.update();
+    this._dirty = true;
+  }
+
+  flush() {
+    if (this._dirty) {
+      this.texture.source.update();
+      this._dirty = false;
+    }
   }
 }

--- a/src/data/network/accumulatedStat.ts
+++ b/src/data/network/accumulatedStat.ts
@@ -1,4 +1,5 @@
 import { Element } from "../spells/types";
+import { DEFAULT_ELEMENT_VALUE } from "./constants";
 import { Player } from "./player";
 import { Stats } from "./stats";
 
@@ -198,7 +199,7 @@ const ACCUMULATORS = {
               stat.elementUsage[element]
                 ? stat.elementEfficiency[element] /
                   stat.elementUsage[element] /
-                  1.75
+                  DEFAULT_ELEMENT_VALUE
                 : 0.57,
             ])
           ),

--- a/src/data/network/constants.ts
+++ b/src/data/network/constants.ts
@@ -8,3 +8,5 @@ export const PEER_ID_PREFIX = "sorcerers-";
 export const FIXED_INTERVAL = 1000 / 20;
 
 export const LAST_GAME_KEY = "lastGameKey";
+
+export const DEFAULT_ELEMENT_VALUE = 1.75;

--- a/src/data/network/index.ts
+++ b/src/data/network/index.ts
@@ -36,6 +36,7 @@ export const connect = async (
   });
 
   const handleBack = () => {
+    level.destroy();
     setGameContext(null);
     Ticker.shared.remove(ticker, null);
     window.clearInterval(fixedTick);

--- a/src/data/network/manager.ts
+++ b/src/data/network/manager.ts
@@ -14,6 +14,7 @@ import { Character } from "../entity/character";
 import { minutesToMs, secondsToMs } from "../../util/time";
 import { GameSettings, defaults } from "../../util/localStorage/settings";
 import { AccumulatedStat } from "./accumulatedStat";
+import { DEFAULT_ELEMENT_VALUE } from "./constants";
 import { getContextOrNull, getLevel, setFallbackManager } from "../context";
 
 const TURN_GRACE_PERIOD = 3000;
@@ -34,7 +35,7 @@ export abstract class Manager {
   protected time = 0;
   protected frames = 0;
   protected elements = Object.fromEntries(
-    Object.values(Element).map((element) => [element, 1.75])
+    Object.values(Element).map((element) => [element, DEFAULT_ELEMENT_VALUE])
   ) as Record<Element, number>;
   private cachedElementValues: Partial<
     Record<Element, { value: number; time: number }>
@@ -309,7 +310,7 @@ export abstract class Manager {
       );
 
       if (buffed) {
-        const value = Math.min(1.75, this.elements[element] * 2);
+        const value = Math.min(DEFAULT_ELEMENT_VALUE, this.elements[element] * 2);
         this.cachedElementValues[element] = { value, time: this.time };
         return value;
       }

--- a/src/data/network/server.ts
+++ b/src/data/network/server.ts
@@ -36,6 +36,23 @@ export class Server extends Manager {
   private localPlayers: Player[] = [];
   private damageQueue: DamageSource[] = [];
 
+  private lowPriorityMessage: Extract<
+    Message,
+    { type: MessageType.EntityUpdate }
+  > = {
+    type: MessageType.EntityUpdate,
+    priority: Priority.Low,
+    entities: [],
+  };
+  private highPriorityMessage: Extract<
+    Message,
+    { type: MessageType.EntityUpdate }
+  > = {
+    type: MessageType.EntityUpdate,
+    priority: Priority.High,
+    entities: [],
+  };
+
   private static _serverInstance?: Server;
   static get instance() {
     return Server._serverInstance!;
@@ -176,28 +193,22 @@ export class Server extends Manager {
     }
 
     if (this.frames % 20 === 0) {
-      const data: Message = {
-        type: MessageType.EntityUpdate,
-        priority: Priority.Low,
-        entities: getLevel().syncables[Priority.Low].map((entity) =>
-          entity.serialize()
-        ),
-      };
+      const syncables = getLevel().syncables[Priority.Low];
+      this.lowPriorityMessage.entities = syncables.map((entity) =>
+        entity.serialize()
+      );
 
       for (let player of this.players) {
-        player.connection?.send(data);
+        player.connection?.send(this.lowPriorityMessage);
       }
     } else if (this.frames % 4 === 0) {
-      const data: Message = {
-        type: MessageType.EntityUpdate,
-        priority: Priority.High,
-        entities: getLevel().syncables[Priority.High].map((entity) =>
-          entity.serialize()
-        ),
-      };
+      const syncables = getLevel().syncables[Priority.High];
+      this.highPriorityMessage.entities = syncables.map((entity) =>
+        entity.serialize()
+      );
 
       for (let player of this.players) {
-        player.connection?.send(data);
+        player.connection?.send(this.highPriorityMessage);
       }
     }
 

--- a/src/data/network/server.ts
+++ b/src/data/network/server.ts
@@ -194,18 +194,22 @@ export class Server extends Manager {
 
     if (this.frames % 20 === 0) {
       const syncables = getLevel().syncables[Priority.Low];
-      this.lowPriorityMessage.entities = syncables.map((entity) =>
-        entity.serialize()
-      );
+      const entities = this.lowPriorityMessage.entities;
+      for (let i = 0; i < syncables.length; i++) {
+        entities[i] = syncables[i].serialize();
+      }
+      entities.length = syncables.length;
 
       for (let player of this.players) {
         player.connection?.send(this.lowPriorityMessage);
       }
     } else if (this.frames % 4 === 0) {
       const syncables = getLevel().syncables[Priority.High];
-      this.highPriorityMessage.entities = syncables.map((entity) =>
-        entity.serialize()
-      );
+      const entities = this.highPriorityMessage.entities;
+      for (let i = 0; i < syncables.length; i++) {
+        entities[i] = syncables[i].serialize();
+      }
+      entities.length = syncables.length;
 
       for (let player of this.players) {
         player.connection?.send(this.highPriorityMessage);

--- a/src/data/network/server.ts
+++ b/src/data/network/server.ts
@@ -354,8 +354,7 @@ export class Server extends Manager {
     if (
       damageSource
         .getTargets()
-        .getEntities()
-        .includes(this.getActiveCharacter()!)
+        .hasEntity(this.getActiveCharacter()!)
     ) {
       this.setTurnState(TurnState.Ending);
     }

--- a/src/data/spells/chainLightning.ts
+++ b/src/data/spells/chainLightning.ts
@@ -135,13 +135,13 @@ export class ChainLightning extends Container implements Spawnable {
         checkX,
         checkY,
         ChainLightning.maxRange,
-        (entity, distance) => {
+        (entity, distanceSquared) => {
           if (entity === character || targets.includes(entity)) {
             return;
           }
 
           if (i > 0) {
-            nextTargets.push([distance, entity]);
+            nextTargets.push([distanceSquared, entity]);
             return;
           }
 

--- a/src/data/spells/chainLightning.ts
+++ b/src/data/spells/chainLightning.ts
@@ -125,18 +125,20 @@ export class ChainLightning extends Container implements Spawnable {
     }
 
     const targets: Target[] = [];
+    const targetSet = new Set<HurtableEntity>();
+    const nextTargets: Array<[number, HurtableEntity]> = [];
 
     let checkX = x * 6;
     let checkY = y * 6;
 
     for (let i = 0; i < ChainLightning.maxChains; i++) {
-      const nextTargets: Array<[number, HurtableEntity]> = [];
+      nextTargets.length = 0;
       getLevel().withNearbyEntities(
         checkX,
         checkY,
         ChainLightning.maxRange,
         (entity, distanceSquared) => {
-          if (entity === character || targets.includes(entity)) {
+          if (entity === character || targetSet.has(entity)) {
             return;
           }
 
@@ -165,6 +167,7 @@ export class ChainLightning extends Container implements Spawnable {
 
       [checkX, checkY] = nextTarget[1].getCenter();
       targets.push(nextTarget[1]);
+      targetSet.add(nextTarget[1]);
 
       if (nextTarget[1] instanceof Shield) {
         break;

--- a/src/data/spells/zoltraak.ts
+++ b/src/data/spells/zoltraak.ts
@@ -154,12 +154,12 @@ export class Zoltraak extends Container implements Spawnable {
       x,
       y,
       MAX_DISTANCE,
-      (entity, distance) => {
+      (entity, distanceSquared) => {
         const [cx, cy] = entity.getCenter();
         const rayDistance = getRayDistance(x, y, angle, cx, cy);
 
         if (rayDistance <= 48) {
-          targets.push({ distance, entity });
+          targets.push({ distance: distanceSquared, entity });
         }
       }
     );

--- a/src/graphics/cameraTarget.ts
+++ b/src/graphics/cameraTarget.ts
@@ -21,7 +21,7 @@ export class CameraTarget {
 
   static shakeAmount = 10;
   static shakeIntensity = 12;
-  static shakeInterval = 25;
+
 
   private controller: KeyboardController | undefined;
   private target?: Spawnable;
@@ -36,11 +36,13 @@ export class CameraTarget {
   private attached = true;
   private oldCDown = false;
   private oldMouseDown = false;
-  private intervalId = -1;
 
   private speed = 0;
   private scale = 1;
   private time = 0;
+
+  private shakeRemaining = 0;
+  private shakeCenter: [number, number] = [0, 0];
 
   constructor(private viewport: Viewport) {
     this.position = [
@@ -50,7 +52,20 @@ export class CameraTarget {
   }
 
   tick(dt: number) {
-    if (!this.controller || this.intervalId !== -1) {
+    if (this.shakeRemaining > 0) {
+      this.viewport.moveCenter(
+        this.shakeCenter[0] +
+          Math.random() * CameraTarget.shakeIntensity -
+          CameraTarget.shakeIntensity / 2,
+        this.shakeCenter[1] +
+          Math.random() * CameraTarget.shakeIntensity -
+          CameraTarget.shakeIntensity / 2
+      );
+      this.shakeRemaining--;
+      return;
+    }
+
+    if (!this.controller) {
       return;
     }
 
@@ -277,26 +292,8 @@ export class CameraTarget {
   }
 
   shake() {
-    window.clearInterval(this.intervalId);
-
     const center = this.viewport.center;
-
-    let shakes = CameraTarget.shakeAmount;
-    this.intervalId = window.setInterval(() => {
-      this.viewport.moveCenter(
-        center[0] +
-          Math.random() * CameraTarget.shakeIntensity -
-          CameraTarget.shakeIntensity / 2,
-        center[1] +
-          Math.random() * CameraTarget.shakeIntensity -
-          CameraTarget.shakeIntensity / 2
-      );
-
-      shakes--;
-      if (shakes <= 0) {
-        window.clearInterval(this.intervalId);
-        this.intervalId = -1;
-      }
-    }, CameraTarget.shakeInterval);
+    this.shakeCenter = [center[0], center[1]];
+    this.shakeRemaining = CameraTarget.shakeAmount;
   }
 }

--- a/src/graphics/cameraTarget.ts
+++ b/src/graphics/cameraTarget.ts
@@ -19,9 +19,8 @@ export class CameraTarget {
   private static acceleration = 0.7;
   private static manualAcceleration = 0.35;
 
-  static shakeAmount = 10;
+  static shakeAmount = 15;
   static shakeIntensity = 12;
-
 
   private controller: KeyboardController | undefined;
   private target?: Spawnable;

--- a/src/graphics/cameraTarget.ts
+++ b/src/graphics/cameraTarget.ts
@@ -19,8 +19,9 @@ export class CameraTarget {
   private static acceleration = 0.7;
   private static manualAcceleration = 0.35;
 
-  static shakeAmount = 15;
+  static shakeAmount = 10;
   static shakeIntensity = 12;
+  static shakeInterval = 25;
 
   private controller: KeyboardController | undefined;
   private target?: Spawnable;
@@ -42,6 +43,7 @@ export class CameraTarget {
 
   private shakeRemaining = 0;
   private shakeCenter: [number, number] = [0, 0];
+  private shakeTimer = 0;
 
   constructor(private viewport: Viewport) {
     this.position = [
@@ -52,6 +54,17 @@ export class CameraTarget {
 
   tick(dt: number) {
     if (this.shakeRemaining > 0) {
+      const dtMs = dt * (1000 / 60);
+      this.shakeTimer += dtMs;
+
+      while (
+        this.shakeTimer >= CameraTarget.shakeInterval &&
+        this.shakeRemaining > 0
+      ) {
+        this.shakeTimer -= CameraTarget.shakeInterval;
+        this.shakeRemaining--;
+      }
+
       this.viewport.moveCenter(
         this.shakeCenter[0] +
           Math.random() * CameraTarget.shakeIntensity -
@@ -60,7 +73,6 @@ export class CameraTarget {
           Math.random() * CameraTarget.shakeIntensity -
           CameraTarget.shakeIntensity / 2
       );
-      this.shakeRemaining--;
       return;
     }
 
@@ -294,5 +306,6 @@ export class CameraTarget {
     const center = this.viewport.center;
     this.shakeCenter = [center[0], center[1]];
     this.shakeRemaining = CameraTarget.shakeAmount;
+    this.shakeTimer = 0;
   }
 }


### PR DESCRIPTION
## Summary

- **Batch texture uploads** to once per frame instead of on every terrain modification
- **Pass squared distance** in `withNearbyEntities` to avoid sqrt in hot paths
- **Skip HUD ref updates** when values are unchanged
- **Skip inventory ref updates** when spell availability hasn't changed
- **Reuse network sync message objects** instead of allocating new ones each frame
- **Remove resize listener and destroy Pixi app** on level cleanup (leak fix)
- **Reduce allocations in hot paths**: in-place element updates in HUD, Set-based spell lookups in Inventory, tick-integrated camera shake, swap-and-pop for syncables removal

## Test plan
- [x] `yarn check-types` passes
- [x] All 157 tests pass
- [ ] Manual playtest: verify HUD updates correctly during gameplay
- [ ] Manual playtest: verify camera shake feels the same on explosions
- [ ] Manual playtest: verify inventory spell availability displays correctly
- [ ] Manual playtest: verify entity removal doesn't cause visual glitches

🤖 Generated with [Claude Code](https://claude.com/claude-code)