### PR TITLE
fix(network): reduce knockback desync between client and server

### DIFF
--- a/src/data/damage/__spec__/genericDamage.spec.ts
+++ b/src/data/damage/__spec__/genericDamage.spec.ts
@@ -48,7 +48,7 @@ describe("GenericDamage", () => {
 
       // Call damage with explicit entityMap (avoids needing mock context)
       targets.damage(damage, entityMap);
-      expect(entity.damage).toHaveBeenCalledWith(damage, 25, undefined);
+      expect(entity.damage).toHaveBeenCalledWith(damage, 25, undefined, undefined);
     });
   });
 

--- a/src/data/damage/__spec__/targetList.spec.ts
+++ b/src/data/damage/__spec__/targetList.spec.ts
@@ -49,7 +49,7 @@ describe("TargetList", () => {
       list.add(entity, 25);
       list.damage(source, entityMap);
 
-      expect(entity.damage).toHaveBeenCalledWith(source, 25, undefined);
+      expect(entity.damage).toHaveBeenCalledWith(source, 25, undefined, undefined);
     });
 
     it("applies damage with force when provided", () => {
@@ -62,7 +62,7 @@ describe("TargetList", () => {
       list.add(entity, 15, force);
       list.damage(source, entityMap);
 
-      expect(entity.damage).toHaveBeenCalledWith(source, 15, force);
+      expect(entity.damage).toHaveBeenCalledWith(source, 15, force, undefined);
     });
 
     it("skips entities not found in the entity map", () => {
@@ -91,8 +91,8 @@ describe("TargetList", () => {
       list.add(entity2, 20);
       list.damage(source, entityMap);
 
-      expect(entity1.damage).toHaveBeenCalledWith(source, 10, undefined);
-      expect(entity2.damage).toHaveBeenCalledWith(source, 20, undefined);
+      expect(entity1.damage).toHaveBeenCalledWith(source, 10, undefined, undefined);
+      expect(entity2.damage).toHaveBeenCalledWith(source, 20, undefined, undefined);
     });
   });
 

--- a/src/data/damage/explosiveDamage.ts
+++ b/src/data/damage/explosiveDamage.ts
@@ -64,7 +64,7 @@ export class ExplosiveDamage implements DamageSource {
     private targets?: TargetList
   ) {}
 
-  damage() {
+  damage(skipForce?: boolean) {
     getLevel().terrain.draw((ctx) => {
       const offset = Math.ceil(this.range * ExplosiveDamage.gradientMultiplier);
       ctx.drawImage(
@@ -95,7 +95,7 @@ export class ExplosiveDamage implements DamageSource {
       );
     }
 
-    this.getTargets().damage(this);
+    this.getTargets().damage(this, undefined, skipForce);
   }
 
   serialize() {

--- a/src/data/damage/fallDamage.ts
+++ b/src/data/damage/fallDamage.ts
@@ -109,7 +109,7 @@ export class FallDamage implements DamageSource {
     public targets?: TargetList
   ) {}
 
-  damage() {
+  damage(skipForce?: boolean) {
     const data = SHAPES[this.shape];
 
     if (data.draw) {
@@ -120,7 +120,7 @@ export class FallDamage implements DamageSource {
       data.subtract.call(this, ctx)
     );
 
-    this.getTargets().damage(this);
+    this.getTargets().damage(this, undefined, skipForce);
   }
 
   getTargets() {

--- a/src/data/damage/genericDamage.ts
+++ b/src/data/damage/genericDamage.ts
@@ -9,8 +9,8 @@ export class GenericDamage implements DamageSource {
 
   constructor(public targets: TargetList) {}
 
-  damage() {
-    this.targets.damage(this);
+  damage(skipForce?: boolean) {
+    this.targets.damage(this, undefined, skipForce);
   }
 
   serialize() {

--- a/src/data/damage/impactDamage.ts
+++ b/src/data/damage/impactDamage.ts
@@ -20,12 +20,12 @@ export class ImpactDamage implements DamageSource {
     public targets?: TargetList
   ) {}
 
-  damage() {
+  damage(skipForce?: boolean) {
     if (getLevel().terrain.subtractCircle(this.x, this.y, 8, circle16x16)) {
       ControllableSound.fromEntity([this.x * 6, this.y * 6], Sound.Stone);
     }
 
-    this.getTargets().damage(this);
+    this.getTargets().damage(this, undefined, skipForce);
   }
 
   serialize() {

--- a/src/data/damage/targetList.ts
+++ b/src/data/damage/targetList.ts
@@ -28,13 +28,14 @@ export class TargetList {
 
   damage(
     source: DamageSource,
-    entityMap: Map<number, TickingEntity> = getLevel().entityMap
+    entityMap: Map<number, TickingEntity> = getLevel().entityMap,
+    skipForce?: boolean
   ) {
     for (let target of this.targets) {
       const entity = entityMap.get(target.entityId) as
         | HurtableEntity
         | undefined;
-      entity?.damage(source, target.damage, target.force);
+      entity?.damage(source, target.damage, target.force, skipForce);
     }
   }
 

--- a/src/data/damage/types.ts
+++ b/src/data/damage/types.ts
@@ -8,7 +8,7 @@ export interface DamageSource {
 
   cause: Player | null;
 
-  damage(): void;
+  damage(skipForce?: boolean): void;
   serialize(): any;
   getTargets(): TargetList;
 }

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -466,8 +466,8 @@ export class Character extends Container implements HurtableEntity, Syncable {
     this.animator.setDefaultAnimation(AnimationState[state]);
   }
 
-  damage(source: DamageSource, damage: number, force?: Force) {
-    this.health.damage(source, damage, force);
+  damage(source: DamageSource, damage: number, force?: Force, skipForce?: boolean) {
+    this.health.damage(source, damage, force, skipForce);
   }
 
   setSpellSource(source: any, toggle = true) {

--- a/src/data/entity/characterHealth.ts
+++ b/src/data/entity/characterHealth.ts
@@ -77,7 +77,7 @@ export class CharacterHealth {
     }
   }
 
-  damage(source: DamageSource, damage: number, force?: Force): void {
+  damage(source: DamageSource, damage: number, force?: Force, skipForce?: boolean): void {
     if (
       this.lastDamageTime !== -1 &&
       this.character.time <=
@@ -103,7 +103,7 @@ export class CharacterHealth {
       ControllableSound.fromEntity(this.character, Sound.Splat);
     }
 
-    if (force) {
+    if (force && !skipForce) {
       this.character.body.addAngularVelocity(force.power, force.direction);
     }
   }

--- a/src/data/entity/types.ts
+++ b/src/data/entity/types.ts
@@ -29,7 +29,7 @@ export interface HurtableEntity extends Spawnable {
   body: PhysicsBody;
   hp: number;
 
-  damage(source: DamageSource, damage: number, force?: Force): void;
+  damage(source: DamageSource, damage: number, force?: Force, skipForce?: boolean): void;
   die(): void;
 }
 

--- a/src/data/network/client.ts
+++ b/src/data/network/client.ts
@@ -265,7 +265,16 @@ export class Client extends Manager {
         const damageSource = DAMAGE_SOURCES[message.kind].deserialize(
           message.data
         );
-        damageSource.damage();
+        damageSource.damage(true);
+
+        if (message.entities) {
+          for (const [id, ...data] of message.entities) {
+            const entity = getLevel().entityMap.get(id);
+            if (entity instanceof Character) {
+              entity.deserialize(data);
+            }
+          }
+        }
 
         if (
           damageSource

--- a/src/data/network/server.ts
+++ b/src/data/network/server.ts
@@ -369,10 +369,20 @@ export class Server extends Manager {
 
     damageSource.damage();
 
+    // Collect post-knockback character states for affected entities
+    const affectedEntities = damageSource.getTargets().getEntities();
+    const entities: [number, ...any[]][] = [];
+    for (const entity of affectedEntities) {
+      if (entity instanceof Character && entity.hp > 0) {
+        entities.push([entity.id, ...entity.body.serialize()]);
+      }
+    }
+
     this.broadcast({
       type: MessageType.SyncDamage,
       kind: damageSource.type,
       data: damageSource.serialize(),
+      entities: entities.length > 0 ? entities : undefined,
     });
   }
 

--- a/src/data/network/server.ts
+++ b/src/data/network/server.ts
@@ -35,6 +35,7 @@ export class Server extends Manager {
   private disconnectedPlayers: Player[] = [];
   private localPlayers: Player[] = [];
   private damageQueue: DamageSource[] = [];
+  private burstSyncFrames = 0;
 
   private lowPriorityMessage: Extract<
     Message,
@@ -192,7 +193,12 @@ export class Server extends Manager {
       this.damage(damageSource);
     }
 
-    if (this.frames % 20 === 0) {
+    if (this.burstSyncFrames > 0) {
+      this.burstSyncFrames--;
+    }
+
+    const lowSyncInterval = this.burstSyncFrames > 0 ? 4 : 20;
+    if (this.frames % lowSyncInterval === 0) {
       const syncables = getLevel().syncables[Priority.Low];
       const entities = this.lowPriorityMessage.entities;
       for (let i = 0; i < syncables.length; i++) {
@@ -203,7 +209,9 @@ export class Server extends Manager {
       for (let player of this.players) {
         player.connection?.send(this.lowPriorityMessage);
       }
-    } else if (this.frames % 4 === 0) {
+    }
+
+    if (this.frames % 4 === 0) {
       const syncables = getLevel().syncables[Priority.High];
       const entities = this.highPriorityMessage.entities;
       for (let i = 0; i < syncables.length; i++) {
@@ -384,6 +392,10 @@ export class Server extends Manager {
       data: damageSource.serialize(),
       entities: entities.length > 0 ? entities : undefined,
     });
+
+    if (entities.length > 0) {
+      this.burstSyncFrames = 20;
+    }
   }
 
   dealFallDamage(x: number, y: number, character: Character) {

--- a/src/data/network/types.ts
+++ b/src/data/network/types.ts
@@ -94,6 +94,7 @@ export type Message =
       type: MessageType.SyncDamage;
       kind: DamageSourceType;
       data: any;
+      entities?: [number, ...any[]][];
     }
   | {
       type: MessageType.Popup;


### PR DESCRIPTION
## Summary

- Server now includes post-knockback character states (position + velocity) in `SyncDamage` messages so clients use authoritative physics instead of computing knockback independently
- Added `skipForce` flag through the damage path so clients skip `addAngularVelocity` and rely on the server-provided state
- After damage knocks characters, temporarily increases their sync rate from 1/sec to 5/sec for 1 second to reduce settling drift

## Test plan

- [ ] Host a multiplayer game (two browser tabs or host + client)
- [ ] Cast explosive spells (fireball, bomb) near characters
- [ ] Verify knockback trajectories are closer between both screens
- [ ] Verify terrain destruction still works correctly on client
- [ ] Verify HP, blood effects, and sound still play on client

🤖 Generated with [Claude Code](https://claude.com/claude-code)