### PR TITLE
fix: incremental step-up scan for slope walking

### DIFF
--- a/src/data/collision/__spec__/body.spec.ts
+++ b/src/data/collision/__spec__/body.spec.ts
@@ -75,4 +75,57 @@ describe("body", () => {
     // Body must have passed x=50 — if stuck, x will be ~49.
     expect(x).toBeGreaterThan(52);
   });
+
+  test("Blocked by a wall taller than MAX_STEP", () => {
+    // 100x100 surface with a 4-pixel step at x=50 (too tall to step up).
+    // Ground at y=90 for x<50, then y=86 for x>=50.
+    const surface = CollisionMask.forRect(100, 100);
+    surface.subtract(CollisionMask.forRect(32, 90), 0, 0);
+    surface.subtract(CollisionMask.forRect(18, 90), 32, 0);
+    const clearRight = CollisionMask.forRect(50, 86);
+    surface.subtract(clearRight, 50, 0);
+
+    const mask = CollisionMask.forRect(1, 1);
+    const body = new Body(surface, { mask });
+
+    body.move(45, 89);
+    // @ts-expect-error - accessing private _grounded for test setup
+    body._grounded = true;
+
+    const dt = 1;
+    for (let i = 0; i < 60; i++) {
+      body.walk(1);
+      body.tick(dt);
+    }
+
+    const [x] = body.precisePosition;
+    // Body must NOT have passed the wall.
+    expect(x).toBeLessThan(50);
+  });
+
+  test("Walks up a 3-pixel step (MAX_STEP)", () => {
+    // 100x100 surface with a 3-pixel step at x=50.
+    // Ground at y=90 for x<50, then y=87 for x>=50.
+    const surface = CollisionMask.forRect(100, 100);
+    surface.subtract(CollisionMask.forRect(32, 90), 0, 0);
+    surface.subtract(CollisionMask.forRect(18, 90), 32, 0);
+    surface.subtract(CollisionMask.forRect(50, 87), 50, 0);
+
+    const mask = CollisionMask.forRect(1, 1);
+    const body = new Body(surface, { mask });
+
+    body.move(45, 89);
+    // @ts-expect-error - accessing private _grounded for test setup
+    body._grounded = true;
+
+    const dt = 1;
+    for (let i = 0; i < 60; i++) {
+      body.walk(1);
+      body.tick(dt);
+    }
+
+    const [x] = body.precisePosition;
+    // Body must have passed the 3-pixel step.
+    expect(x).toBeGreaterThan(52);
+  });
 });

--- a/src/data/collision/__spec__/body.spec.ts
+++ b/src/data/collision/__spec__/body.spec.ts
@@ -44,4 +44,35 @@ describe("body", () => {
     expect(x).toBeCloseTo(expectedX, 0);
     expect(y).toBeCloseTo(expectedY, 0);
   });
+
+  test("Walks up a 2-pixel step", () => {
+    // 100x100 surface with a 2-pixel step at x=50.
+    // Ground level is y=90 for x<50, then y=88 for x>=50.
+    const surface = CollisionMask.forRect(100, 100);
+    // Clear everything above ground on the left side (y=0..89 for x=0..49).
+    // Use two 32-aligned subtracts to avoid the lshift=32 overflow in subtract(_, 0, 0).
+    surface.subtract(CollisionMask.forRect(32, 90), 0, 0); // clears x=0..31
+    surface.subtract(CollisionMask.forRect(18, 90), 32, 0); // clears x=32..49
+    // Clear everything above the raised ground on the right side (y=0..87 for x=50..99).
+    surface.subtract(CollisionMask.forRect(50, 88), 50, 0);
+
+    const mask = CollisionMask.forRect(1, 1);
+    const body = new Body(surface, { mask });
+
+    // Place body on the left ground, just before the step.
+    body.move(45, 89);
+    // @ts-expect-error - accessing private _grounded for test setup
+    body._grounded = true;
+
+    const dt = 1; // 30fps (TARGET_FPS / 30)
+    // Walk right for 60 ticks — enough to reach and pass the step.
+    for (let i = 0; i < 60; i++) {
+      body.walk(1);
+      body.tick(dt);
+    }
+
+    const [x] = body.precisePosition;
+    // Body must have passed x=50 — if stuck, x will be ~49.
+    expect(x).toBeGreaterThan(52);
+  });
 });

--- a/src/data/collision/body.ts
+++ b/src/data/collision/body.ts
@@ -3,6 +3,7 @@ import { CollisionMask } from "./collisionMask";
 
 // Random value that determines how much gravity a body must receive before something is considered a collision with the ground/ceiling
 const COLLISION_TRIGGER = 7;
+const MAX_STEP = 3;
 
 const GRAVITY = 0.2;
 const AIR_CONTROL = 0.3;
@@ -288,20 +289,25 @@ export class Body implements PhysicsBody {
 
     // Check if we're going to hit a wall
     if (xDiff !== 0 && this.surface.collidesWith(this.mask, this.rX, this.rY)) {
-      const amount = Math.min(3, Math.ceil(Math.abs(xDiff)));
+      let stepped = false;
 
-      // Check if we can walk up steps <= 45 degrees.
-      if (
-        this.yVelocity >= -amount &&
-        !this.surface.collidesWith(this.mask, this.rX, this.rY - amount)
-      ) {
-        this.y = this.rY - amount;
+      // Scan for the minimum step-up that clears the obstacle.
+      for (let step = 1; step <= MAX_STEP; step++) {
+        if (!this.surface.collidesWith(this.mask, this.rX, this.rY - step)) {
+          // Only allow step-up when not moving upward faster than the step height.
+          if (this.yVelocity >= -step) {
+            this.y = this.rY - step;
+            this.rY = this.y;
+            this.yVelocity = 0;
+            this._grounded = true;
+            this.unmountLadder();
+            stepped = true;
+          }
+          break; // Found a clearable height — stop scanning regardless.
+        }
+      }
 
-        this.rY = this.y;
-        this.yVelocity = 0;
-        this._grounded = true;
-        this.unmountLadder();
-      } else {
+      if (!stepped) {
         let xCopy = xDiff;
 
         // We hit a wall, align with it.


### PR DESCRIPTION
## Summary

- Characters could get permanently stuck on diagonal terrain when walking, requiring a jump to continue
- Root cause: step-up height was tied to `xDiff` (`Math.ceil(xDiff)` = 1 at walking speed), making the body unable to handle 2-pixel steps in the terrain staircase rasterization
- Fix: replace the single-height check with an incremental scan from 1 to `MAX_STEP` (3), accepting the first clear height

## Changes

- **`src/data/collision/body.ts`**: New `MAX_STEP` constant, step-up logic replaced with incremental scan loop. Wall-slide binary search unchanged.
- **`src/data/collision/__spec__/body.spec.ts`**: 3 new tests covering 2px step (bug fix), 3px step (MAX_STEP boundary), 4px step (wall blocking regression guard)

## Test plan

- [x] 2-pixel step: body walks up without getting stuck
- [x] 3-pixel step (MAX_STEP): body walks up at the boundary
- [x] 4-pixel step (above MAX_STEP): body is blocked
- [x] Existing framerate-agnostic tests still pass (10 tests across 5 fps values)
- [x] Full test suite passes (198 tests)
- [x] Type check passes
- [ ] Manual test: walk characters up diagonal terrain slopes in-game

🤖 Generated with [Claude Code](https://claude.com/claude-code)