### PR TITLE
Add AI image denoise and WebP compression

### DIFF
--- a/src/components/organisms/AiAlignDialog.vue
+++ b/src/components/organisms/AiAlignDialog.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
 import Dialog from "../molecules/Dialog.vue";
+import { selectiveAverage, posterize } from "../../util/denoise";
+import { WEBP_QUALITY } from "../../data/map";
 
 const PREVIEW_SCALE = 6;
 
@@ -23,6 +25,7 @@ const scaleX = ref(100);
 const scaleY = ref(100);
 
 const sharpen = ref(false);
+const reducePalette = ref(false);
 const darkenAmount = ref(30);
 
 const maskImg = ref<HTMLImageElement>();
@@ -59,7 +62,7 @@ watch(
 const previewCanvas = ref<HTMLCanvasElement>();
 
 watch(
-  [maskLoaded, aiLoaded, offsetX, offsetY, scaleX, scaleY, previewCanvas],
+  [maskLoaded, aiLoaded, offsetX, offsetY, scaleX, scaleY, darkenAmount, previewCanvas],
   () => {
     const canvas = previewCanvas.value;
     const mi = maskImg.value;
@@ -86,8 +89,8 @@ watch(
       aiH * PREVIEW_SCALE
     );
 
-    // Draw mask outline on top (semi-transparent)
-    ctx.globalAlpha = 0.6;
+    // Draw mask on top — opacity driven by darken amount to emulate final terrain look
+    ctx.globalAlpha = darkenAmount.value / 100;
     ctx.drawImage(mi, 0, 0, mi.width * PREVIEW_SCALE, mi.height * PREVIEW_SCALE);
     ctx.globalAlpha = 1;
   },
@@ -135,6 +138,15 @@ function handleConfirm() {
       px[i + 1] = Math.min(255, Math.max(0, Math.round(px[i + 1] + (px[i + 1] - blurData[i + 1]) * amount)));
       px[i + 2] = Math.min(255, Math.max(0, Math.round(px[i + 2] + (px[i + 2] - blurData[i + 2]) * amount)));
     }
+
+    // Denoise: selective neighborhood average
+    const denoised = selectiveAverage(px, cropW, cropH);
+    aiData.data.set(denoised);
+  }
+
+  if (reducePalette.value) {
+    const posterized = posterize(aiData.data, cropW, cropH);
+    aiData.data.set(posterized);
   }
 
   // Draw cropped mask
@@ -191,9 +203,9 @@ function handleConfirm() {
     });
 
   Promise.all([
-    terrainCanvas.convertToBlob({ type: "image/png" }).then(blobToDataUrl),
-    bgCanvas.convertToBlob({ type: "image/png" }).then(blobToDataUrl),
-    maskCanvas.convertToBlob({ type: "image/png" }).then(blobToDataUrl),
+    terrainCanvas.convertToBlob({ type: "image/webp", quality: WEBP_QUALITY }).then(blobToDataUrl),
+    bgCanvas.convertToBlob({ type: "image/webp", quality: WEBP_QUALITY }).then(blobToDataUrl),
+    maskCanvas.convertToBlob({ type: "image/webp" }).then(blobToDataUrl),
   ]).then(([terrain, background, mask]) => {
     props.onConfirm({ terrain, background, mask, width: cropW, height: cropH });
   });
@@ -207,40 +219,43 @@ function handleConfirm() {
         <canvas ref="previewCanvas" class="preview" />
       </div>
 
-      <div class="controls">
-        <label class="control">
-          <span>X offset</span>
-          <input type="range" v-model.number="offsetX" :min="-200" :max="200" />
-          <input type="number" v-model.number="offsetX" class="num" />
+      <div class="slider-row">
+        <label class="slider-label">
+          <span class="label">X offset</span>
+          <input type="range" v-model.number="offsetX" :min="-200" :max="200" class="slider" />
+          <span class="slider-value">{{ offsetX }}</span>
         </label>
-        <label class="control">
-          <span>Y offset</span>
-          <input type="range" v-model.number="offsetY" :min="-200" :max="200" />
-          <input type="number" v-model.number="offsetY" class="num" />
+        <label class="slider-label">
+          <span class="label">Y offset</span>
+          <input type="range" v-model.number="offsetY" :min="-200" :max="200" class="slider" />
+          <span class="slider-value">{{ offsetY }}</span>
         </label>
-        <label class="control">
-          <span>X scale</span>
-          <input type="range" v-model.number="scaleX" :min="50" :max="150" />
-          <input type="number" v-model.number="scaleX" class="num" />
-          <span>%</span>
+      </div>
+      <div class="slider-row">
+        <label class="slider-label">
+          <span class="label">X scale</span>
+          <input type="range" v-model.number="scaleX" :min="50" :max="150" class="slider" />
+          <span class="slider-value">{{ scaleX }}%</span>
         </label>
-        <label class="control">
-          <span>Y scale</span>
-          <input type="range" v-model.number="scaleY" :min="50" :max="150" />
-          <input type="number" v-model.number="scaleY" class="num" />
-          <span>%</span>
+        <label class="slider-label">
+          <span class="label">Y scale</span>
+          <input type="range" v-model.number="scaleY" :min="50" :max="150" class="slider" />
+          <span class="slider-value">{{ scaleY }}%</span>
         </label>
       </div>
 
-      <label class="control">
-        <span>Darken</span>
-        <input type="range" v-model.number="darkenAmount" :min="0" :max="80" />
-        <input type="number" v-model.number="darkenAmount" class="num" />
-        <span>%</span>
+      <label class="slider-label">
+        <span class="label">Darken</span>
+        <input type="range" v-model.number="darkenAmount" :min="0" :max="80" class="slider" />
+        <span class="slider-value">{{ darkenAmount }}%</span>
       </label>
-      <label class="control checkbox-control">
+      <label class="checkbox-control">
         <input type="checkbox" v-model="sharpen" />
         <span>Sharpen</span>
+      </label>
+      <label class="checkbox-control">
+        <input type="checkbox" v-model="reducePalette" />
+        <span>Reduce palette</span>
       </label>
 
       <div class="actions">
@@ -260,9 +275,9 @@ function handleConfirm() {
 }
 
 .preview-scroll {
-  max-width: 500px;
-  max-height: 300px;
   overflow: auto;
+  max-width: 600px;
+  max-height: 300px;
   border: 1px solid var(--border-accent-faint);
   border-radius: 4px;
   scrollbar-color: var(--background-dark) transparent;
@@ -274,46 +289,48 @@ function handleConfirm() {
   background: repeating-conic-gradient(#ccc 0% 25%, #eee 0% 50%) 0 0 / 16px 16px;
 }
 
-.controls {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+.slider-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px 16px;
 }
 
-.control {
+.slider-label {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 13px;
-  color: var(--primary);
 
-  span:first-child {
-    min-width: 55px;
+  .label {
+    font-family: Eternal;
+    font-size: 24px;
+    color: var(--primary);
+    min-width: 80px;
   }
 
-  input[type="range"] {
+  .slider {
     flex: 1;
     accent-color: var(--primary);
   }
 
-  .num {
-    width: 50px;
-    padding: 2px 4px;
-    font-size: 12px;
-    background: rgba(0, 0, 0, 0.1);
-    border: 1px solid var(--border-accent-faint);
-    border-radius: 3px;
-    color: var(--primary);
+  .slider-value {
+    min-width: 36px;
     text-align: right;
+    font-size: 13px;
   }
 }
 
 .checkbox-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   cursor: pointer;
+  font-family: Eternal;
+  font-size: 24px;
+  color: var(--primary);
 
   input[type="checkbox"] {
-    width: 16px;
-    height: 16px;
+    width: 18px;
+    height: 18px;
     accent-color: var(--primary);
     cursor: pointer;
   }

--- a/src/components/organisms/AiAlignDialog.vue
+++ b/src/components/organisms/AiAlignDialog.vue
@@ -126,6 +126,11 @@ function handleConfirm() {
   const aiData = aCtx.getImageData(0, 0, cropW, cropH);
 
   if (sharpen.value) {
+    // Denoise first: smooth noise before sharpening to avoid amplifying it
+    const denoised = selectiveAverage(aiData.data, cropW, cropH);
+    aiData.data.set(denoised);
+    aCtx.putImageData(aiData, 0, 0);
+
     const blurCanvas = new OffscreenCanvas(cropW, cropH);
     const blurCtx = blurCanvas.getContext("2d")!;
     blurCtx.filter = "blur(1px)";
@@ -138,10 +143,6 @@ function handleConfirm() {
       px[i + 1] = Math.min(255, Math.max(0, Math.round(px[i + 1] + (px[i + 1] - blurData[i + 1]) * amount)));
       px[i + 2] = Math.min(255, Math.max(0, Math.round(px[i + 2] + (px[i + 2] - blurData[i + 2]) * amount)));
     }
-
-    // Denoise: selective neighborhood average
-    const denoised = selectiveAverage(px, cropW, cropH);
-    aiData.data.set(denoised);
   }
 
   if (reducePalette.value) {

--- a/src/components/organisms/AiAlignDialog.vue
+++ b/src/components/organisms/AiAlignDialog.vue
@@ -206,7 +206,7 @@ function handleConfirm() {
   Promise.all([
     terrainCanvas.convertToBlob({ type: "image/webp", quality: WEBP_QUALITY }).then(blobToDataUrl),
     bgCanvas.convertToBlob({ type: "image/webp", quality: WEBP_QUALITY }).then(blobToDataUrl),
-    maskCanvas.convertToBlob({ type: "image/webp" }).then(blobToDataUrl),
+    maskCanvas.convertToBlob({ type: "image/png" }).then(blobToDataUrl),
   ]).then(([terrain, background, mask]) => {
     props.onConfirm({ terrain, background, mask, width: cropW, height: cropH });
   });

--- a/src/data/map/index.ts
+++ b/src/data/map/index.ts
@@ -52,6 +52,8 @@ const LADDERS_KEY = "ladders";
 const VERSION = 1;
 const THUMBNAIL_SIZE = 100;
 
+export const WEBP_QUALITY = 0.9;
+
 export class Map {
   public static defaultScale = 6;
 
@@ -179,10 +181,10 @@ export class Map {
 
   async toConfig(forceMask?: boolean): Promise<Config> {
     const [terrain, background, ...layers] = await Promise.all([
-      this._terrain!.convertToBlob({ type: "image/png" }),
-      this._background?.convertToBlob({ type: "image/png" }),
+      this._terrain!.convertToBlob({ type: "image/webp", quality: WEBP_QUALITY }),
+      this._background?.convertToBlob({ type: "image/webp", quality: WEBP_QUALITY }),
       ...this._layers!.map((layer) =>
-        layer.data.convertToBlob({ type: "image/png" })
+        layer.data.convertToBlob({ type: "image/webp", quality: WEBP_QUALITY })
       ),
     ]);
 

--- a/src/data/wfc/postProcess.ts
+++ b/src/data/wfc/postProcess.ts
@@ -113,7 +113,7 @@ export async function gridToBlob(
 ): Promise<{ blob: Blob; ladders: LadderInfo[] }> {
   const raw = renderGrid(grid);
   const output = postProcess(raw);
-  const blob = await output.convertToBlob({ type: "image/png" });
+  const blob = await output.convertToBlob({ type: "image/webp" });
   const ladders = detectLadders(grid);
   return { blob, ladders };
 }

--- a/src/data/wfc/postProcess.ts
+++ b/src/data/wfc/postProcess.ts
@@ -113,7 +113,7 @@ export async function gridToBlob(
 ): Promise<{ blob: Blob; ladders: LadderInfo[] }> {
   const raw = renderGrid(grid);
   const output = postProcess(raw);
-  const blob = await output.convertToBlob({ type: "image/webp" });
+  const blob = await output.convertToBlob({ type: "image/png" });
   const ladders = detectLadders(grid);
   return { blob, ladders };
 }

--- a/src/util/__spec__/denoise.spec.ts
+++ b/src/util/__spec__/denoise.spec.ts
@@ -1,0 +1,124 @@
+import { selectiveAverage, localModeSnap } from "../denoise";
+
+function makePixels(
+  width: number,
+  height: number,
+  fill: [number, number, number, number]
+): Uint8ClampedArray {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = fill[0];
+    data[i + 1] = fill[1];
+    data[i + 2] = fill[2];
+    data[i + 3] = fill[3];
+  }
+  return data;
+}
+
+function setPixel(
+  data: Uint8ClampedArray,
+  width: number,
+  x: number,
+  y: number,
+  r: number,
+  g: number,
+  b: number
+) {
+  const i = (y * width + x) * 4;
+  data[i] = r;
+  data[i + 1] = g;
+  data[i + 2] = b;
+}
+
+function getPixel(
+  data: Uint8ClampedArray,
+  width: number,
+  x: number,
+  y: number
+): [number, number, number] {
+  const i = (y * width + x) * 4;
+  return [data[i], data[i + 1], data[i + 2]];
+}
+
+describe("selectiveAverage", () => {
+  test("uniform region stays unchanged", () => {
+    const data = makePixels(5, 5, [100, 150, 200, 255]);
+    const result = selectiveAverage(data, 5, 5);
+    expect(getPixel(result, 5, 2, 2)).toEqual([100, 150, 200]);
+  });
+
+  test("slightly different pixel gets averaged toward neighbors", () => {
+    // 5x5 all (100,100,100) except center is (110,110,110) — within threshold 40
+    const data = makePixels(5, 5, [100, 100, 100, 255]);
+    setPixel(data, 5, 2, 2, 110, 110, 110);
+    const result = selectiveAverage(data, 5, 5);
+    const [r, g, b] = getPixel(result, 5, 2, 2);
+    // 24 neighbors at 100 + center at 110 = average 100.4, rounds to 100
+    expect(r).toBe(100);
+  });
+
+  test("edge pixel far from neighbors is preserved", () => {
+    // Left half red (200,0,0), right half blue (0,0,200) — distance ~283, well above threshold 40
+    const width = 6;
+    const height = 1;
+    const data = makePixels(width, height, [200, 0, 0, 255]);
+    for (let x = 3; x < 6; x++) {
+      setPixel(data, width, x, 0, 0, 0, 200);
+    }
+    const result = selectiveAverage(data, width, height);
+    // Boundary pixels should not bleed across the edge
+    expect(getPixel(result, width, 2, 0)).toEqual([200, 0, 0]);
+    expect(getPixel(result, width, 3, 0)).toEqual([0, 0, 200]);
+  });
+
+  test("does not modify alpha channel", () => {
+    const data = makePixels(3, 3, [100, 100, 100, 128]);
+    const result = selectiveAverage(data, 3, 3);
+    // Check alpha of center pixel
+    const i = (1 * 3 + 1) * 4;
+    expect(result[i + 3]).toBe(128);
+  });
+});
+
+describe("localModeSnap", () => {
+  test("uniform region stays unchanged", () => {
+    const data = makePixels(3, 3, [100, 150, 200, 255]);
+    const result = localModeSnap(data, 3, 3);
+    expect(getPixel(result, 3, 1, 1)).toEqual([100, 150, 200]);
+  });
+
+  test("near-identical pixels snap to same color", () => {
+    // 3x3 grid: 8 pixels at (100,100,100), center at (103,101,99)
+    // Neighbors bucket to (104,104,104), center to (104,104,96) — different bucket
+    // The 8-neighbor bucket dominates, so center gets replaced with neighbors' average
+    const data = makePixels(3, 3, [100, 100, 100, 255]);
+    setPixel(data, 3, 1, 1, 103, 101, 99);
+    const result = localModeSnap(data, 3, 3);
+    const [r, g] = getPixel(result, 3, 1, 1);
+    // Center should be snapped toward 100 (majority bucket average)
+    expect(r).toBeLessThan(103);
+    expect(g).toBeLessThanOrEqual(101);
+  });
+
+  test("distinct colors at boundary are preserved", () => {
+    // Left column (200,0,0), right columns (0,200,0) — different buckets
+    const width = 3;
+    const height = 3;
+    const data = makePixels(width, height, [0, 200, 0, 255]);
+    for (let y = 0; y < height; y++) {
+      setPixel(data, width, 0, y, 200, 0, 0);
+    }
+    const result = localModeSnap(data, width, height);
+    // Red column should stay red (it's its own bucket, outnumbered by green in center)
+    // But pixel (0,1) only has red neighbors + some green, the green bucket wins at center
+    // The corner (0,0) has limited neighbors — check it stays red
+    expect(getPixel(result, width, 0, 0)[0]).toBeGreaterThan(100);
+  });
+
+  test("does not modify alpha channel", () => {
+    const data = makePixels(3, 3, [100, 100, 100, 128]);
+    const result = localModeSnap(data, 3, 3);
+    const i = (1 * 3 + 1) * 4;
+    expect(result[i + 3]).toBe(128);
+  });
+});

--- a/src/util/__spec__/denoise.spec.ts
+++ b/src/util/__spec__/denoise.spec.ts
@@ -1,4 +1,4 @@
-import { selectiveAverage } from "../denoise";
+import { selectiveAverage, posterize } from "../denoise";
 
 function makePixels(
   width: number,
@@ -77,6 +77,70 @@ describe("selectiveAverage", () => {
     // Check alpha of center pixel
     const i = (1 * 3 + 1) * 4;
     expect(result[i + 3]).toBe(128);
+  });
+});
+
+describe("posterize", () => {
+  test("quantizes to nearest step of 16", () => {
+    // A single pixel with value 70 should quantize to round(70/16)*16 = 4*16 = 64
+    const data = makePixels(1, 1, [70, 130, 9, 255]);
+    const result = posterize(data, 1, 1);
+    const [r, g, b] = getPixel(result, 1, 0, 0);
+    expect(r).toBe(64); // round(70/16)*16 = 64
+    expect(g).toBe(128); // round(130/16)*16 = 128
+    expect(b).toBe(16); // round(9/16)*16 = 16
+  });
+
+  test("preserves alpha channel", () => {
+    const data = makePixels(3, 3, [100, 100, 100, 180]);
+    const result = posterize(data, 3, 3);
+    for (let i = 3; i < result.length; i += 4) {
+      expect(result[i]).toBe(180);
+    }
+  });
+
+  test("clamps output to 0-255", () => {
+    // Value 0 quantizes to 0, value 255 quantizes to 256 but clamps to 255
+    const data = makePixels(1, 1, [0, 255, 248, 255]);
+    const result = posterize(data, 1, 1);
+    const [r, g, b] = getPixel(result, 1, 0, 0);
+    expect(r).toBe(0);
+    expect(g).toBeLessThanOrEqual(255);
+    expect(b).toBeLessThanOrEqual(255);
+    expect(r).toBeGreaterThanOrEqual(0);
+  });
+
+  test("dithering distributes error to neighbors", () => {
+    // Row of pixels all at value 8 (exactly halfway between steps 0 and 16).
+    // Pixel 0 quantizes to 16, error = (8-16)*0.2 = -1.6, propagated right.
+    // Over many pixels the accumulated error should eventually flip a pixel
+    // to quantize to 0 instead of 16.
+    const width = 50;
+    const data = makePixels(width, 1, [8, 8, 8, 255]);
+    const result = posterize(data, width, 1);
+
+    const values = new Set<number>();
+    for (let x = 0; x < width; x++) {
+      values.add(getPixel(result, width, x, 0)[0]);
+    }
+    // Without dithering all pixels would quantize to the same step;
+    // with error diffusion we expect at least two distinct output levels
+    expect(values.size).toBeGreaterThanOrEqual(2);
+  });
+
+  test("uniform region stays mostly uniform", () => {
+    // All pixels identical — quantization should produce the same value everywhere
+    // (error is 0 so dithering has no effect)
+    const data = makePixels(5, 5, [96, 96, 96, 255]);
+    const result = posterize(data, 5, 5);
+    for (let y = 0; y < 5; y++) {
+      for (let x = 0; x < 5; x++) {
+        const [r, g, b] = getPixel(result, 5, x, y);
+        expect(r).toBe(96); // round(96/16)*16 = 96
+        expect(g).toBe(96);
+        expect(b).toBe(96);
+      }
+    }
   });
 });
 

--- a/src/util/__spec__/denoise.spec.ts
+++ b/src/util/__spec__/denoise.spec.ts
@@ -1,4 +1,4 @@
-import { selectiveAverage, localModeSnap } from "../denoise";
+import { selectiveAverage } from "../denoise";
 
 function makePixels(
   width: number,
@@ -80,45 +80,3 @@ describe("selectiveAverage", () => {
   });
 });
 
-describe("localModeSnap", () => {
-  test("uniform region stays unchanged", () => {
-    const data = makePixels(3, 3, [100, 150, 200, 255]);
-    const result = localModeSnap(data, 3, 3);
-    expect(getPixel(result, 3, 1, 1)).toEqual([100, 150, 200]);
-  });
-
-  test("near-identical pixels snap to same color", () => {
-    // 3x3 grid: 8 pixels at (100,100,100), center at (103,101,99)
-    // Neighbors bucket to (104,104,104), center to (104,104,96) — different bucket
-    // The 8-neighbor bucket dominates, so center gets replaced with neighbors' average
-    const data = makePixels(3, 3, [100, 100, 100, 255]);
-    setPixel(data, 3, 1, 1, 103, 101, 99);
-    const result = localModeSnap(data, 3, 3);
-    const [r, g] = getPixel(result, 3, 1, 1);
-    // Center should be snapped toward 100 (majority bucket average)
-    expect(r).toBeLessThan(103);
-    expect(g).toBeLessThanOrEqual(101);
-  });
-
-  test("distinct colors at boundary are preserved", () => {
-    // Left column (200,0,0), right columns (0,200,0) — different buckets
-    const width = 3;
-    const height = 3;
-    const data = makePixels(width, height, [0, 200, 0, 255]);
-    for (let y = 0; y < height; y++) {
-      setPixel(data, width, 0, y, 200, 0, 0);
-    }
-    const result = localModeSnap(data, width, height);
-    // Red column should stay red (it's its own bucket, outnumbered by green in center)
-    // But pixel (0,1) only has red neighbors + some green, the green bucket wins at center
-    // The corner (0,0) has limited neighbors — check it stays red
-    expect(getPixel(result, width, 0, 0)[0]).toBeGreaterThan(100);
-  });
-
-  test("does not modify alpha channel", () => {
-    const data = makePixels(3, 3, [100, 100, 100, 128]);
-    const result = localModeSnap(data, 3, 3);
-    const i = (1 * 3 + 1) * 4;
-    expect(result[i + 3]).toBe(128);
-  });
-});

--- a/src/util/denoise.ts
+++ b/src/util/denoise.ts
@@ -65,7 +65,7 @@ export function posterize(
   const buf = new Float32Array(data.length);
   for (let i = 0; i < data.length; i++) buf[i] = data[i];
 
-  const out = new Uint8ClampedArray(data);
+  const out = new Uint8ClampedArray(data.length);
 
   for (let y = 0; y < height; y++) {
     // Serpentine: alternate scan direction per row to break regular patterns
@@ -76,6 +76,7 @@ export function posterize(
       const dir = leftToRight ? 1 : -1;
       const i = (y * width + x) * 4;
 
+      out[i + 3] = data[i + 3];
       for (let c = 0; c < 3; c++) {
         const old = buf[i + c];
         const quantized = Math.round(old / POSTERIZE_STEP) * POSTERIZE_STEP;

--- a/src/util/denoise.ts
+++ b/src/util/denoise.ts
@@ -1,0 +1,102 @@
+const SIMILARITY_THRESHOLD = 40;
+const AVG_RADIUS = 2; // 5x5 kernel
+
+export function selectiveAverage(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number
+): Uint8ClampedArray {
+  const out = new Uint8ClampedArray(data);
+  const thresholdSq = SIMILARITY_THRESHOLD * SIMILARITY_THRESHOLD;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const ci = (y * width + x) * 4;
+      const cr = data[ci];
+      const cg = data[ci + 1];
+      const cb = data[ci + 2];
+
+      let sumR = 0;
+      let sumG = 0;
+      let sumB = 0;
+      let count = 0;
+
+      for (let dy = -AVG_RADIUS; dy <= AVG_RADIUS; dy++) {
+        const ny = y + dy;
+        if (ny < 0 || ny >= height) continue;
+        for (let dx = -AVG_RADIUS; dx <= AVG_RADIUS; dx++) {
+          const nx = x + dx;
+          if (nx < 0 || nx >= width) continue;
+
+          const ni = (ny * width + nx) * 4;
+          const dr = data[ni] - cr;
+          const dg = data[ni + 1] - cg;
+          const db = data[ni + 2] - cb;
+          const distSq = dr * dr + dg * dg + db * db;
+
+          if (distSq <= thresholdSq) {
+            sumR += data[ni];
+            sumG += data[ni + 1];
+            sumB += data[ni + 2];
+            count++;
+          }
+        }
+      }
+
+      out[ci] = Math.round(sumR / count);
+      out[ci + 1] = Math.round(sumG / count);
+      out[ci + 2] = Math.round(sumB / count);
+      // Alpha unchanged — already copied by new Uint8ClampedArray(data)
+    }
+  }
+
+  return out;
+}
+
+const POSTERIZE_STEP = 16;
+const DITHER_STRENGTH = 0.2;
+
+export function posterize(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number
+): Uint8ClampedArray {
+  // Work on float buffer so error diffusion can go negative
+  const buf = new Float32Array(data.length);
+  for (let i = 0; i < data.length; i++) buf[i] = data[i];
+
+  const out = new Uint8ClampedArray(data);
+
+  for (let y = 0; y < height; y++) {
+    // Serpentine: alternate scan direction per row to break regular patterns
+    const leftToRight = y % 2 === 0;
+
+    for (let xi = 0; xi < width; xi++) {
+      const x = leftToRight ? xi : width - 1 - xi;
+      const dir = leftToRight ? 1 : -1;
+      const i = (y * width + x) * 4;
+
+      for (let c = 0; c < 3; c++) {
+        const old = buf[i + c];
+        const quantized = Math.round(old / POSTERIZE_STEP) * POSTERIZE_STEP;
+        out[i + c] = Math.min(255, Math.max(0, quantized));
+        const error = (old - quantized) * DITHER_STRENGTH;
+
+        // Floyd-Steinberg error diffusion (mirrored on right-to-left rows)
+        const next = x + dir;
+        const prev = x - dir;
+        if (next >= 0 && next < width) buf[i + dir * 4 + c] += error * (7 / 16);
+        if (y + 1 < height) {
+          if (prev >= 0 && prev < width)
+            buf[i + (width - dir) * 4 + c] += error * (3 / 16);
+          buf[i + width * 4 + c] += error * (5 / 16);
+          if (next >= 0 && next < width)
+            buf[i + (width + dir) * 4 + c] += error * (1 / 16);
+        }
+      }
+      // Alpha unchanged
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Summary
- Add edge-preserving denoise (selective 5x5 neighborhood average) to the AI image sharpen pipeline
- Add optional palette reduction with Floyd-Steinberg dithered posterization (serpentine scan)
- Switch image encoding from PNG to WebP across map export, network sync, and AI import for smaller file sizes
- Restyle AI Align dialog controls to match WfcDialog (side-by-side sliders, Eternal font)
- Darken slider now drives mask preview opacity to emulate final terrain appearance

## Test plan
- [ ] Import an AI-generated terrain image in the builder
- [ ] Toggle Sharpen on — verify terrain looks cleaner without blurring edges
- [ ] Toggle Reduce palette on — verify colors are reduced with smooth dithered gradients
- [ ] Verify both checkboxes work independently
- [ ] Build a map and verify the exported .png file is smaller than before
- [ ] Load the exported map and verify it renders correctly
- [ ] Test WFC mask generation still works
- [ ] Verify network sync still works in multiplayer

🤖 Generated with [Claude Code](https://claude.com/claude-code)