### PR TITLE
Fix several networking and physics desync bugs

### DIFF
--- a/src/data/collision/body.ts
+++ b/src/data/collision/body.ts
@@ -98,6 +98,7 @@ export class Body implements PhysicsBody {
       this.x,
       this.y,
       this._onLadder,
+      this.lastRollDirection,
     ];
   }
 
@@ -107,6 +108,7 @@ export class Body implements PhysicsBody {
     this.yVelocity = data[2];
     this.move(data[3], data[4]);
     this._onLadder = data[5];
+    this.lastRollDirection = data[6];
   }
 
   walk(direction: 1 | -1) {

--- a/src/data/damage/targetList.ts
+++ b/src/data/damage/targetList.ts
@@ -26,6 +26,10 @@ export class TargetList {
     return this;
   }
 
+  filter(predicate: (target: Target) => boolean) {
+    this.targets = this.targets.filter(predicate);
+  }
+
   damage(
     source: DamageSource,
     entityMap: Map<number, TickingEntity> = getLevel().entityMap

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -480,6 +480,10 @@ export class Character extends Container implements HurtableEntity, Syncable {
     this.health.damage(source, damage, force);
   }
 
+  isInvulnerable() {
+    return this.health.isInvulnerable();
+  }
+
   setSpellSource(source: any, toggle = true) {
     this.combat.setSpellSource(source, toggle);
   }

--- a/src/data/entity/characterHealth.ts
+++ b/src/data/entity/characterHealth.ts
@@ -78,15 +78,19 @@ export class CharacterHealth {
     }
   }
 
-  damage(source: DamageSource, damage: number, force?: Force): void {
-    if (
+  isInvulnerable(): boolean {
+    return (
       this.lastDamageTime !== -1 &&
       this.character.time <=
         this.lastDamageTime + CharacterHealth.invulnerableTime
-    ) {
-      return;
-    }
+    );
+  }
 
+  damage(source: DamageSource, damage: number, force?: Force): void {
+    // Invulnerability filtering is applied server-side in Server.damage so
+    // that all peers receive a target list that already excludes invulnerable
+    // characters. Filtering here too would let server and client disagree
+    // about which damages "stuck" depending on local character.time.
     this.character.player.stats.registerDamage(
       source,
       this.character,

--- a/src/data/map/level.ts
+++ b/src/data/map/level.ts
@@ -275,11 +275,14 @@ export class Level {
       }
 
       if ("priority" in object) {
+        // Stable removal: joining clients rebuild syncables in insertion
+        // order (SyncPlayers + Spawn handshake), so the server must keep
+        // insertion order too. Swap-and-pop would silently desync the
+        // index-keyed EntityUpdate stream.
         const arr = this.syncables[object.priority];
         const index = arr.indexOf(object);
         if (index !== -1) {
-          arr[index] = arr[arr.length - 1];
-          arr.pop();
+          arr.splice(index, 1);
         }
       }
     }

--- a/src/data/network/server.ts
+++ b/src/data/network/server.ts
@@ -327,7 +327,10 @@ export class Server extends Manager {
         console.log("closed");
 
         if (!this._started) {
-          this.players.splice(this.players.indexOf(player));
+          const index = this.players.indexOf(player);
+          if (index !== -1) {
+            this.players.splice(index, 1);
+          }
           player.destroy();
           this.availableColors.push(player.color);
 
@@ -336,7 +339,10 @@ export class Server extends Manager {
           if (player.color) {
             this.disconnectedPlayers.push(player);
           } else {
-            this.players.splice(this.players.indexOf(player));
+            const index = this.players.indexOf(player);
+            if (index !== -1) {
+              this.players.splice(index, 1);
+            }
           }
 
           player.disconnect();

--- a/src/data/network/server.ts
+++ b/src/data/network/server.ts
@@ -188,7 +188,7 @@ export class Server extends Manager {
     }
 
     let damageSource: DamageSource | undefined;
-    while ((damageSource = this.damageQueue.pop())) {
+    while ((damageSource = this.damageQueue.shift())) {
       this.damage(damageSource);
     }
 

--- a/src/data/network/server.ts
+++ b/src/data/network/server.ts
@@ -252,9 +252,13 @@ export class Server extends Manager {
 
       connection.on("open", async () => {
         console.log("open");
-        player.reconnect(connection);
 
         if (this._started) {
+          // Defer player.reconnect(connection) until the snapshot has been
+          // sent. While player.connection is undefined, broadcast() and the
+          // tick loop skip this player, so no events can interleave with
+          // the handshake and arrive before the joining client has the
+          // entities they reference.
           connection.send({
             type: MessageType.StartGame,
             map: await getLevel().terrain.serialize(),
@@ -262,7 +266,8 @@ export class Server extends Manager {
           } satisfies Message);
 
           await player.ready;
-          this.syncSinglePlayer(player);
+
+          connection.send(this.buildSyncMessage(player));
 
           const activePlayerIndex = this.players.indexOf(this.activePlayer!);
           connection.send({
@@ -287,12 +292,17 @@ export class Server extends Manager {
             });
           }
 
-          this.broadcast({
+          connection.send({
             type: MessageType.Sink,
             level: getLevel().terrain.killbox.level,
-          });
-        } else if (onUpdate) {
-          onUpdate();
+          } satisfies Message);
+
+          player.reconnect(connection);
+        } else {
+          player.reconnect(connection);
+          if (onUpdate) {
+            onUpdate();
+          }
         }
       });
 
@@ -504,15 +514,15 @@ export class Server extends Manager {
     }
   }
 
-  private syncSinglePlayer(player: Player) {
-    const response: Message = {
+  private buildSyncMessage(receiver: Player): Message {
+    return {
       type: MessageType.SyncPlayers,
       time: this.time,
       players: this.players.map((p) => ({
         name: p.name,
         team: p.team.serialize(),
         color: p.color,
-        you: p === player,
+        you: p === receiver,
         spell:
           p.selectedSpell === null ? null : SPELLS.indexOf(p.selectedSpell),
         characters: p.characters.map((character) => {
@@ -527,8 +537,10 @@ export class Server extends Manager {
         }),
       })),
     };
+  }
 
-    player.connection?.send(response);
+  private syncSinglePlayer(player: Player) {
+    player.connection?.send(this.buildSyncMessage(player));
   }
 
   private syncPlayers() {

--- a/src/data/network/server.ts
+++ b/src/data/network/server.ts
@@ -371,11 +371,19 @@ export class Server extends Manager {
   }
 
   damage(damageSource: DamageSource, cause?: Player | null) {
-    if (
-      damageSource
-        .getTargets()
-        .hasEntity(this.getActiveCharacter()!)
-    ) {
+    const targets = damageSource.getTargets();
+
+    // Server is authoritative on invulnerability so the broadcast carries
+    // the same target list that was applied here. Filtering on each peer
+    // independently desynced HP when adjacent damages straddled the 1-tick
+    // window differently across peers.
+    const entityMap = getLevel().entityMap;
+    targets.filter((target) => {
+      const entity = entityMap.get(target.entityId);
+      return !(entity instanceof Character) || !entity.isInvulnerable();
+    });
+
+    if (targets.hasEntity(this.getActiveCharacter()!)) {
       this.setTurnState(TurnState.Ending);
     }
 


### PR DESCRIPTION
### Description

Several independent networking/physics desync fixes from a deep dive into the multiplayer code path:

- **Late-join state misalignment.** `EntityUpdate` is index-keyed against `syncables[priority]`, but `Level.remove` used swap-and-pop while joining clients rebuild that array in insertion order from the handshake — any death or item pickup before a join made every subsequent `EntityUpdate` write positions onto the wrong entities. Switched to stable `splice`. Also deferred `player.reconnect(connection)` until after the snapshot is fully sent so the tick loop can't broadcast `EntityUpdate`/`Spawn`/`Die` to a peer that hasn't received `SyncPlayers` yet.
- **Slope physics drift.** `Body.serialize` was missing `lastRollDirection`. The flag is set when a body lands on a slope and consumed at the top of the next tick to roll it downhill — without it on the wire, server and client could pick opposite roll directions, producing the "item rolls off the ledge, server snaps it back, item rolls off again" loop.
- **HP desync from invulnerability filter race.** `CharacterHealth.damage` filtered the 1-tick post-damage invulnerability window using each peer's local `character.time`. Two `SyncDamage` events ~1 tick apart (meteor bounces, chain death explosions) could be filtered on one side and applied on the other, leaving HP permanently mismatched. Moved the filter into `Server.damage` so the broadcast already excludes invulnerable targets and clients apply the pre-filtered list verbatim.
- **`players.splice(indexOf(player))` missing `deleteCount`.** Two call sites in the connection close handler removed every player from the leaver's index onward (lobby-disconnect and partial-handshake-disconnect). Pass `1` and guard against `indexOf` returning `-1`.
- **Damage queue drained LIFO.** `damageQueue.pop()` processed simultaneous damages in reverse insertion order, flipping `lastDamageDealer` attribution and terrain-mod stacking. Switched to `shift()`.

### Manual check

- Open the game in two browsers; host on browser A, join on browser B
- Play one full turn so something dies, then have browser C join browser A's room mid-game
- [ ] C sees character positions and items in the same places as A (was breaking after any death/pickup)
- Drop an item on a sloped tile or near a ledge
- [ ] The item settles in the same spot on host and client (no roll-back-and-forth)
- Cast Meteor near a low-HP character so it bounces and explodes multiple times
- [ ] HP for each affected character is identical on host and client after the meteor finishes
- Kill a character with damage that's also dealt to another low-HP nearby character so the death explosion hits them
- [ ] Both characters' final HP / dead-or-alive state matches across host and client
- In the lobby with three peers connected, have the middle peer close their tab
- [ ] The remaining peers stay in the player list (was being truncated)

<p align="right">ℹ️ Created with Claude Code</p>