### PR TITLE
Persistent floating gibs with physics interactions

### DIFF
--- a/src/data/collision/simpleBody.ts
+++ b/src/data/collision/simpleBody.ts
@@ -15,8 +15,8 @@ interface Config {
 }
 
 export class SimpleBody implements PhysicsBody {
-  public xVelocity = 0;
-  public yVelocity = 0;
+  private xVelocity = 0;
+  private yVelocity = 0;
 
   private x = 0;
   private y = 0;
@@ -90,6 +90,11 @@ export class SimpleBody implements PhysicsBody {
     this.xVelocity = Math.cos(direction) * power;
     this.yVelocity = Math.sin(direction) * power;
     this.active = 1;
+  }
+
+  damp(xFactor: number, yFactor: number, dt: number) {
+    this.xVelocity *= Math.pow(xFactor, dt);
+    this.yVelocity *= Math.pow(yFactor, dt);
   }
 
   move(x: number, y: number) {

--- a/src/data/collision/simpleBody.ts
+++ b/src/data/collision/simpleBody.ts
@@ -15,8 +15,8 @@ interface Config {
 }
 
 export class SimpleBody implements PhysicsBody {
-  private xVelocity = 0;
-  private yVelocity = 0;
+  public xVelocity = 0;
+  public yVelocity = 0;
 
   private x = 0;
   private y = 0;

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -42,7 +42,8 @@ const SMOKE_TRIGGER = 2;
 const KICK_VELOCITY_THRESHOLD_SQUARED = 0.04;
 const KICK_RADIUS_SQUARED = 30 * 30;
 const KICK_SCALE = 0.5;
-const KICK_LIFT = 0.08;
+const KICK_LIFT = 0.6;
+const KICK_SPIN = 0.3;
 const WALK_DURATION = 20;
 const MELEE_DURATION = 50;
 const PAGE_READ_DURATION = 60;
@@ -358,14 +359,15 @@ export class Character extends Container implements HurtableEntity, Syncable {
   }
 
   private kickNearbyGibs() {
-    const speedSquared =
-      this.body.xVelocity ** 2 + this.body.yVelocity ** 2;
-    if (speedSquared < KICK_VELOCITY_THRESHOLD_SQUARED) {
+    const xSpeedSquared = this.body.xVelocity ** 2;
+    if (xSpeedSquared < KICK_VELOCITY_THRESHOLD_SQUARED) {
       return;
     }
 
     const cx = this.position.x + 18;
     const cy = this.position.y + 72;
+    const xV = this.body.xVelocity;
+    const xVAbs = Math.abs(xV);
 
     for (const entity of getLevel().entities) {
       if (!(entity instanceof Gib)) continue;
@@ -375,10 +377,8 @@ export class Character extends Container implements HurtableEntity, Syncable {
       const distSquared = dx * dx + dy * dy;
       if (distSquared >= KICK_RADIUS_SQUARED) continue;
 
-      entity.body.addVelocity(
-        this.body.xVelocity * KICK_SCALE,
-        this.body.yVelocity * KICK_SCALE - KICK_LIFT
-      );
+      entity.body.addVelocity(xV * KICK_SCALE, -xVAbs * KICK_LIFT);
+      entity.spin(Math.sign(xV) * xVAbs * KICK_SPIN);
       entity.bleed();
     }
   }

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -34,10 +34,15 @@ import { getLevel, getManager, getServer } from "../context";
 import { CharacterHealth } from "./characterHealth";
 import { CharacterCombat } from "./characterCombat";
 import { CharacterMovement } from "./characterMovement";
+import { Gib } from "./gib";
 
 // Start bouncing when impact is greater than this value
 const BOUNCE_TRIGGER = 3.8;
 const SMOKE_TRIGGER = 2;
+const KICK_VELOCITY_THRESHOLD_SQUARED = 0.04;
+const KICK_RADIUS_SQUARED = 30 * 30;
+const KICK_SCALE = 0.5;
+const KICK_LIFT = 0.08;
 const WALK_DURATION = 20;
 const MELEE_DURATION = 50;
 const PAGE_READ_DURATION = 60;
@@ -352,6 +357,32 @@ export class Character extends Container implements HurtableEntity, Syncable {
     return [this.position.x + 18, this.position.y + 48];
   }
 
+  private kickNearbyGibs() {
+    const speedSquared =
+      this.body.xVelocity ** 2 + this.body.yVelocity ** 2;
+    if (speedSquared < KICK_VELOCITY_THRESHOLD_SQUARED) {
+      return;
+    }
+
+    const cx = this.position.x + 18;
+    const cy = this.position.y + 72;
+
+    for (const entity of getLevel().entities) {
+      if (!(entity instanceof Gib)) continue;
+
+      const dx = entity.position.x - cx;
+      const dy = entity.position.y - cy;
+      const distSquared = dx * dx + dy * dy;
+      if (distSquared >= KICK_RADIUS_SQUARED) continue;
+
+      entity.body.addVelocity(
+        this.body.xVelocity * KICK_SCALE,
+        this.body.yVelocity * KICK_SCALE - KICK_LIFT
+      );
+      entity.bleed();
+    }
+  }
+
   tick(dt: number) {
     this._time += dt;
     if (this._time > this.lastActiveTime + Character.maxInactiveTime) {
@@ -394,6 +425,8 @@ export class Character extends Container implements HurtableEntity, Syncable {
         this.body.mask,
         ...this.body.position,
       );
+
+      this.kickNearbyGibs();
     }
 
     this.animator.tick(dt);

--- a/src/data/entity/gib/index.ts
+++ b/src/data/entity/gib/index.ts
@@ -13,14 +13,26 @@ export interface GibConfig {
   bloody?: boolean;
 }
 
-const LIFETIME = 80;
+const OFF_MAP_BUFFER = 20;
+const SURFACE_BAND = 2;
+const SURFACE_X_DRAG = 0.92;
+const SURFACE_LERP = 0.1;
+const SURFACE_YV_DAMP = 0.5;
+const SURFACE_BOB_SPEED = 0.05;
+const SURFACE_BOB_AMPLITUDE = 3;
+const DEEP_BUOYANCY = 0.35;
+const DEEP_Y_DRAG = 0.85;
+const DEEP_X_DRAG = 0.85;
+const BLEED_DURATION = 90;
 
 export class Gib extends Sprite implements TickingEntity {
   public readonly body: SimpleBody;
-  private time = LIFETIME;
   private bloody: boolean;
   private offsetX: number;
   private offsetY: number;
+  private bleedTime: number;
+  private bobTime = Math.random() * Math.PI * 2;
+  private inSurface = false;
 
   constructor({
     texture,
@@ -32,6 +44,7 @@ export class Gib extends Sprite implements TickingEntity {
   }: GibConfig) {
     super(texture);
     this.bloody = bloody;
+    this.bleedTime = bloody ? BLEED_DURATION : 0;
     this.offsetX = -offsetX * 2;
     this.offsetY = -offsetY * 2;
 
@@ -51,23 +64,65 @@ export class Gib extends Sprite implements TickingEntity {
     }
   }
 
+  bleed() {
+    if (this.bloody) {
+      this.bleedTime = BLEED_DURATION;
+    }
+  }
+
   tick(dt: number) {
     this.body.tick(dt);
-    const [x, y] = this.body.precisePosition;
-    this.position.set(x * 6, y * 6);
 
-    if (this.bloody && Math.random() > 0.8) {
-      getLevel().bloodEmitter.spawn(
-        x * 6 + this.offsetX + (Math.random() - 0.5) * 4,
-        y * 6 + this.offsetY + (Math.random() - 0.5) * 4,
-        0,
-        0
-      );
+    const level = getLevel();
+    const killboxLevel = level.terrain.killbox.level;
+    let [x, y] = this.body.precisePosition;
+
+    const depth = y + this.body.mask.height - killboxLevel;
+    if (depth > SURFACE_BAND) {
+      this.inSurface = false;
+      this.body.yVelocity -= DEEP_BUOYANCY * dt;
+      this.body.yVelocity *= DEEP_Y_DRAG;
+      this.body.xVelocity *= DEEP_X_DRAG;
+      this.body.active = 1;
+    } else if (depth > 0) {
+      this.inSurface = true;
+      const targetY = killboxLevel - this.body.mask.height;
+      this.body.yVelocity -= this.body.gravity * dt;
+      this.body.yVelocity *= SURFACE_YV_DAMP;
+      y = y + (targetY - y) * SURFACE_LERP * dt;
+      this.body.move(x, y);
+      this.body.xVelocity *= SURFACE_X_DRAG;
+      this.body.active = 1;
+    } else {
+      this.inSurface = false;
     }
 
-    this.time -= dt;
-    if (this.time <= 0) {
-      getLevel().remove(this);
+    let displayY = y * 6;
+    if (depth > 0) {
+      this.bobTime += dt * SURFACE_BOB_SPEED;
+      displayY += Math.sin(this.bobTime) * SURFACE_BOB_AMPLITUDE;
+    }
+
+    this.position.set(x * 6, displayY);
+
+    if (
+      x < -OFF_MAP_BUFFER ||
+      x > level.terrain.width + OFF_MAP_BUFFER
+    ) {
+      level.remove(this);
+      return;
+    }
+
+    if (this.bleedTime > 0) {
+      this.bleedTime -= dt;
+      if (Math.random() > 0.8) {
+        level.bloodEmitter.spawn(
+          x * 6 + this.offsetX + (Math.random() - 0.5) * 4,
+          y * 6 + this.offsetY + (Math.random() - 0.5) * 4,
+          0,
+          0
+        );
+      }
     }
   }
 }

--- a/src/data/entity/gib/index.ts
+++ b/src/data/entity/gib/index.ts
@@ -13,6 +13,7 @@ export interface GibConfig {
   bloody?: boolean;
 }
 
+const NORMAL_GRAVITY = 0.25;
 const OFF_MAP_BUFFER = 20;
 const SURFACE_BAND = 2;
 const SURFACE_X_DRAG = 0.92;
@@ -61,7 +62,7 @@ export class Gib extends Sprite implements TickingEntity {
     this.body = new SimpleBody(getLevel().terrain.collisionMask, {
       mask,
       bounciness: -0.7,
-      gravity: 0.25,
+      gravity: NORMAL_GRAVITY,
       friction: 0.96,
       onCollide: () => {
         this.groundContactTime = GROUND_CONTACT_TICKS;
@@ -72,7 +73,12 @@ export class Gib extends Sprite implements TickingEntity {
     this.position.set(offsetX, offsetY);
 
     if (maskSprite) {
-      maskSprite.position.set(-offsetX, -offsetY);
+      // Compensate for the parent's center anchor so the mask sprite still
+      // aligns with the gib's top-left.
+      maskSprite.position.set(
+        -offsetX - this.width / 2,
+        -offsetY - this.height / 2
+      );
 
       this.addChild(maskSprite);
     }
@@ -89,27 +95,30 @@ export class Gib extends Sprite implements TickingEntity {
   }
 
   tick(dt: number) {
-    this.body.tick(dt);
-
     const level = getLevel();
     const killboxLevel = level.terrain.killbox.level;
+
+    // Decide regime from pre-tick position so gravity is correct *during*
+    // body.tick — avoids applying then cancelling it.
+    const [, preY] = this.body.precisePosition;
+    const depth = preY + this.body.mask.height - killboxLevel;
+    const inSurfaceBand = depth > 0 && depth <= SURFACE_BAND;
+    this.body.gravity = inSurfaceBand ? 0 : NORMAL_GRAVITY;
+
+    this.body.tick(dt);
+
     let [x, y] = this.body.precisePosition;
 
-    const depth = y + this.body.mask.height - killboxLevel;
     if (depth > SURFACE_BAND) {
       this.inSurface = false;
-      this.body.yVelocity -= this.deepBuoyancy * dt;
-      this.body.yVelocity *= DEEP_Y_DRAG;
-      this.body.xVelocity *= DEEP_X_DRAG;
-      this.body.active = 1;
+      this.body.addVelocity(0, -this.deepBuoyancy * dt);
+      this.body.damp(DEEP_X_DRAG, DEEP_Y_DRAG, dt);
     } else if (depth > 0) {
       this.inSurface = true;
       const targetY = killboxLevel - this.body.mask.height;
-      this.body.yVelocity -= this.body.gravity * dt;
-      this.body.yVelocity *= SURFACE_YV_DAMP;
-      y = y + (targetY - y) * SURFACE_LERP * dt;
+      y = y + (targetY - y) * (1 - Math.pow(1 - SURFACE_LERP, dt));
       this.body.move(x, y);
-      this.body.xVelocity *= SURFACE_X_DRAG;
+      this.body.damp(SURFACE_X_DRAG, SURFACE_YV_DAMP, dt);
       this.body.active = 1;
     } else {
       this.inSurface = false;
@@ -122,7 +131,7 @@ export class Gib extends Sprite implements TickingEntity {
       : depth > 0
         ? WATER_SPIN_DRAG
         : AIR_SPIN_DRAG;
-    this.angularVelocity *= spinDrag;
+    this.angularVelocity *= Math.pow(spinDrag, dt);
     this.rotation += this.angularVelocity * dt;
     if (this.groundContactTime > 0) {
       this.groundContactTime -= dt;

--- a/src/data/entity/gib/index.ts
+++ b/src/data/entity/gib/index.ts
@@ -20,10 +20,16 @@ const SURFACE_LERP = 0.1;
 const SURFACE_YV_DAMP = 0.5;
 const SURFACE_BOB_SPEED = 0.05;
 const SURFACE_BOB_AMPLITUDE = 3;
-const DEEP_BUOYANCY = 0.35;
+const DEEP_BUOYANCY_MIN = 0.3;
+const DEEP_BUOYANCY_MAX = 0.4;
 const DEEP_Y_DRAG = 0.85;
 const DEEP_X_DRAG = 0.85;
 const BLEED_DURATION = 90;
+const SPIN_RANGE = 0.25;
+const AIR_SPIN_DRAG = 0.99;
+const WATER_SPIN_DRAG = 0.92;
+const GROUND_SPIN_DRAG = 0.6;
+const GROUND_CONTACT_TICKS = 3;
 
 export class Gib extends Sprite implements TickingEntity {
   public readonly body: SimpleBody;
@@ -33,6 +39,10 @@ export class Gib extends Sprite implements TickingEntity {
   private bleedTime: number;
   private bobTime = Math.random() * Math.PI * 2;
   private inSurface = false;
+  private angularVelocity = (Math.random() - 0.5) * 2 * SPIN_RANGE;
+  private groundContactTime = 0;
+  private deepBuoyancy =
+    DEEP_BUOYANCY_MIN + Math.random() * (DEEP_BUOYANCY_MAX - DEEP_BUOYANCY_MIN);
 
   constructor({
     texture,
@@ -53,7 +63,11 @@ export class Gib extends Sprite implements TickingEntity {
       bounciness: -0.7,
       gravity: 0.25,
       friction: 0.96,
+      onCollide: () => {
+        this.groundContactTime = GROUND_CONTACT_TICKS;
+      },
     });
+    this.anchor.set(0.5, 0.5);
     this.scale.set(2);
     this.position.set(offsetX, offsetY);
 
@@ -70,6 +84,10 @@ export class Gib extends Sprite implements TickingEntity {
     }
   }
 
+  spin(amount: number) {
+    this.angularVelocity += amount;
+  }
+
   tick(dt: number) {
     this.body.tick(dt);
 
@@ -80,7 +98,7 @@ export class Gib extends Sprite implements TickingEntity {
     const depth = y + this.body.mask.height - killboxLevel;
     if (depth > SURFACE_BAND) {
       this.inSurface = false;
-      this.body.yVelocity -= DEEP_BUOYANCY * dt;
+      this.body.yVelocity -= this.deepBuoyancy * dt;
       this.body.yVelocity *= DEEP_Y_DRAG;
       this.body.xVelocity *= DEEP_X_DRAG;
       this.body.active = 1;
@@ -97,13 +115,28 @@ export class Gib extends Sprite implements TickingEntity {
       this.inSurface = false;
     }
 
-    let displayY = y * 6;
+    const grounded =
+      this.groundContactTime > 0 || this.body.active === 0;
+    const spinDrag = grounded
+      ? GROUND_SPIN_DRAG
+      : depth > 0
+        ? WATER_SPIN_DRAG
+        : AIR_SPIN_DRAG;
+    this.angularVelocity *= spinDrag;
+    this.rotation += this.angularVelocity * dt;
+    if (this.groundContactTime > 0) {
+      this.groundContactTime -= dt;
+    }
+
+    const halfW = this.width / 2;
+    const halfH = this.height / 2;
+    let displayY = y * 6 + halfH;
     if (depth > 0) {
       this.bobTime += dt * SURFACE_BOB_SPEED;
       displayY += Math.sin(this.bobTime) * SURFACE_BOB_AMPLITUDE;
     }
 
-    this.position.set(x * 6, displayY);
+    this.position.set(x * 6 + halfW, displayY);
 
     if (
       x < -OFF_MAP_BUFFER ||


### PR DESCRIPTION
## Summary
- Drop the gib lifetime so corpses linger; cull off-map and float on the killbox via deep buoyancy + smooth surface settle + visible bob.
- Walking characters kick nearby gibs (squared-distance, horizontal-only) — jumping no longer launches them up. Lift scales with char xVelocity for a consistent diagonal arc, plus a spin impulse.
- Gibs tumble in flight (random initial spin), with separate drag regimes for air, water, and ground contact.
- Per-gib randomized deep-water buoyancy (0.30–0.40) so a batch surfaces at staggered rates.
- Bleed becomes a 1.5s timer refreshed on spawn and on each kick, instead of running until despawn.

## Test plan
- [ ] Kill a character on land — gibs fall, bounce, settle, stop bleeding after 1.5s.
- [ ] Walk through gibs on the ground — they get kicked diagonally in the walk direction and refresh their bleed.
- [ ] Jump straight up over gibs — gibs are NOT pushed up.
- [ ] Kill a character into the killbox — gibs plunge, bob to surface, drift with sine wave.
- [ ] Watch a batch of gibs together — they reach the surface at noticeably different rates.
- [ ] Confirm spinning looks natural (random direction, decays slowly in air, fast on ground).
- [ ] Check off-map cull: explosion launches gibs off-screen, no perf leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)