### PR TITLE
Add public game announcements and main-menu server browser

### DIFF
--- a/src/components/organisms/GameSettings.vue
+++ b/src/components/organisms/GameSettings.vue
@@ -58,6 +58,10 @@ const numberFormatter = new Intl.NumberFormat("en");
         <h3>Item spawn chance</h3>
         {{ `${numberFormatter.format(settings.itemSpawnChance)}%` }}
       </li>
+      <li>
+        <h3>Visibility</h3>
+        {{ settings.isPrivate ? "Private" : "Public" }}
+      </li>
     </ul>
     <Dialog :open="isEditing" :onClose="handleClose" title="Edit settings">
       <div class="inputs">

--- a/src/components/organisms/GameSettings.vue
+++ b/src/components/organisms/GameSettings.vue
@@ -90,14 +90,14 @@ const numberFormatter = new Intl.NumberFormat("en");
           :max="400"
         />
         <label class="input-label checkbox-label">
-          <input type="checkbox" v-model="editedSettings.isPublic" />
+          <input type="checkbox" v-model="editedSettings.isPrivate" />
           <span class="checkmark"></span>
           <Tooltip
-            text="Lists this game in the main menu server browser"
+            text="Hides this game from the main menu server browser"
             direction="center-right"
             to="#dialog"
           >
-            <span class="label">Public game</span>
+            <span class="label">Private game</span>
           </Tooltip>
         </label>
         <label class="input-label checkbox-label">

--- a/src/components/organisms/GameSettings.vue
+++ b/src/components/organisms/GameSettings.vue
@@ -90,6 +90,17 @@ const numberFormatter = new Intl.NumberFormat("en");
           :max="400"
         />
         <label class="input-label checkbox-label">
+          <input type="checkbox" v-model="editedSettings.isPublic" />
+          <span class="checkmark"></span>
+          <Tooltip
+            text="Lists this game in the main menu server browser"
+            direction="center-right"
+            to="#dialog"
+          >
+            <span class="label">Public game</span>
+          </Tooltip>
+        </label>
+        <label class="input-label checkbox-label">
           <input type="checkbox" v-model="editedSettings.trustClient" />
           <span class="checkmark"></span>
           <Tooltip

--- a/src/components/organisms/JoinDialog.vue
+++ b/src/components/organisms/JoinDialog.vue
@@ -3,20 +3,17 @@ import { ref, watch } from "vue";
 import Dialog from "../molecules/Dialog.vue";
 import Input from "../atoms/Input.vue";
 import { createClient } from "../../data/network";
-import { LAST_GAME_KEY, PEER_ID_PREFIX } from "../../data/network/constants";
-import { defaults } from "../../util/localStorage/settings";
-import { get } from "../../util/localStorage";
+import { LAST_GAME_KEY } from "../../data/network/constants";
 import { Client } from "../../data/network/client";
-import { Team } from "../../data/team";
 import Tooltip from "../atoms/Tooltip.vue";
 import { useRouter } from "vue-router";
+import { joinByKey } from "../../data/network/joinByKey";
 
 const props = defineProps<{
   open: boolean;
   onClose: () => void;
 }>();
 
-const settings = defaults(get("Settings"));
 const key = ref(sessionStorage.getItem(LAST_GAME_KEY) || ("" as string));
 const status = ref("");
 const error = ref(false);
@@ -43,17 +40,15 @@ const handleConnect = async () => {
   error.value = false;
 
   try {
-    await Client.instance.join(
-      PEER_ID_PREFIX + key.value,
-      settings.name || "Player",
-      settings.team || Team.random()
-    );
-
-    sessionStorage.setItem(LAST_GAME_KEY, key.value);
-    router.replace(`/join/${key.value}`);
+    await joinByKey(key.value, {
+      router,
+      onError: () => {
+        status.value = "";
+        error.value = true;
+      },
+    });
   } catch {
-    status.value = "";
-    error.value = true;
+    // onError already updated state
   }
 };
 </script>

--- a/src/components/organisms/ServerList.vue
+++ b/src/components/organisms/ServerList.vue
@@ -39,23 +39,26 @@ const numberFormatter = new Intl.NumberFormat("en");
 </script>
 
 <template>
-  <ul v-if="lobbies.length > 0" class="server-list">
-    <li v-for="entry in lobbies" :key="entry.joinKey">
-      <button
-        class="primary entry"
-        :disabled="entry.playerCount >= entry.maxPlayers"
-        @click="handleJoin(entry)"
-      >
-        <span class="host">{{ entry.hostName }}</span>
-        <span class="map">{{ entry.mapName.replace("_", " ") || "—" }}</span>
-        <span class="meta">
-          {{ entry.playerCount }}/{{ entry.maxPlayers }} ·
-          team {{ entry.gameSettings.teamSize }} ·
-          {{ numberFormatter.format(entry.gameSettings.turnLength) }}s turn
-        </span>
-      </button>
-    </li>
-  </ul>
+  <section v-if="lobbies.length > 0" class="server-list">
+    <h2>Public games</h2>
+    <ul>
+      <li v-for="entry in lobbies" :key="entry.joinKey">
+        <button
+          class="primary entry"
+          :disabled="entry.playerCount >= entry.maxPlayers"
+          @click="handleJoin(entry)"
+        >
+          <span class="host">{{ entry.hostName }}</span>
+          <span class="map">{{ entry.mapName.replace("_", " ") || "—" }}</span>
+          <span class="meta">
+            {{ entry.playerCount }}/{{ entry.maxPlayers }} ·
+            team {{ entry.gameSettings.teamSize }} ·
+            {{ numberFormatter.format(entry.gameSettings.turnLength) }}s turn
+          </span>
+        </button>
+      </li>
+    </ul>
+  </section>
 </template>
 
 <style lang="scss" scoped>
@@ -63,12 +66,13 @@ const numberFormatter = new Intl.NumberFormat("en");
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 30px;
   min-width: 320px;
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
-  border: 2px solid var(--border-accent);
-  box-shadow: 0 2px 8px rgba(30, 15, 5, 0.3), inset 0 0 15px rgba(180, 120, 40, 0.08);
-  border-radius: 4px;
+
+  ul {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
 
   .entry {
     display: flex;

--- a/src/components/organisms/ServerList.vue
+++ b/src/components/organisms/ServerList.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from "vue";
+import { useRouter } from "vue-router";
+import {
+  subscribeToPublicLobbies,
+  sweepStaleLobbies,
+  type LobbyEntry,
+} from "../../data/network/lobbyAnnouncement";
+import { joinByKey } from "../../data/network/joinByKey";
+
+const router = useRouter();
+const lobbies = ref<LobbyEntry[]>([]);
+let unsubscribe: (() => void) | null = null;
+
+onMounted(async () => {
+  await sweepStaleLobbies();
+  unsubscribe = subscribeToPublicLobbies((entries) => {
+    lobbies.value = [...entries].sort((a, b) =>
+      a.hostName.localeCompare(b.hostName)
+    );
+  });
+});
+
+onUnmounted(() => {
+  unsubscribe?.();
+  unsubscribe = null;
+});
+
+const handleJoin = async (entry: LobbyEntry) => {
+  if (entry.playerCount >= entry.maxPlayers) return;
+  try {
+    await joinByKey(entry.joinKey, { router });
+  } catch (e) {
+    console.error("Failed to join lobby", e);
+  }
+};
+
+const numberFormatter = new Intl.NumberFormat("en");
+</script>
+
+<template>
+  <ul v-if="lobbies.length > 0" class="server-list">
+    <li v-for="entry in lobbies" :key="entry.joinKey">
+      <button
+        class="primary entry"
+        :disabled="entry.playerCount >= entry.maxPlayers"
+        @click="handleJoin(entry)"
+      >
+        <span class="host">{{ entry.hostName }}</span>
+        <span class="map">{{ entry.mapName.replace("_", " ") || "—" }}</span>
+        <span class="meta">
+          {{ entry.playerCount }}/{{ entry.maxPlayers }} ·
+          team {{ entry.gameSettings.teamSize }} ·
+          {{ numberFormatter.format(entry.gameSettings.turnLength) }}s turn
+        </span>
+      </button>
+    </li>
+  </ul>
+</template>
+
+<style lang="scss" scoped>
+.server-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 30px;
+  min-width: 320px;
+  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
+  border: 2px solid var(--border-accent);
+  box-shadow: 0 2px 8px rgba(30, 15, 5, 0.3), inset 0 0 15px rgba(180, 120, 40, 0.08);
+  border-radius: 4px;
+
+  .entry {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    width: 100%;
+    text-align: left;
+    padding: 8px 16px;
+    font-family: Eternal;
+
+    .host {
+      font-size: 24px;
+      letter-spacing: 1px;
+    }
+
+    .map {
+      font-size: 18px;
+      color: var(--highlight);
+    }
+
+    .meta {
+      font-size: 14px;
+      color: var(--primary);
+      opacity: 0.8;
+      font-family: system-ui;
+    }
+  }
+}
+</style>

--- a/src/components/pages/Host.vue
+++ b/src/components/pages/Host.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from "vue";
+import { onMounted, onUnmounted, ref, watch } from "vue";
 import { get, set } from "../../util/localStorage";
 import { GameSettings, defaults } from "../../util/localStorage/settings";
 import { MessageType } from "../../data/network/types";
@@ -17,6 +17,10 @@ import IconButton from "../atoms/IconButton.vue";
 import plus from "pixelarticons/svg/plus.svg";
 import { useHostServer } from "./composables/useHostServer";
 import { useHostPlayers } from "./composables/useHostPlayers";
+import {
+  LobbyAnnouncement,
+  type LobbyEntry,
+} from "../../data/network/lobbyAnnouncement";
 
 const { onPlay } = defineProps<{
   onPlay: (key: string, map: Map | Config, settings: GameSettings) => void;
@@ -72,6 +76,8 @@ const updateLobby = debounce(() => {
       settings: gameSettings.value,
     });
   }
+
+  pushAnnouncement();
 }, 200);
 
 const {
@@ -85,6 +91,49 @@ const {
   handleSave,
 } = useHostPlayers(updateLobby, gameSettings);
 
+const announcement = new LobbyAnnouncement();
+let announced = false;
+
+const buildEntry = (): LobbyEntry => ({
+  joinKey: key.value,
+  hostName: players.value[0]?.name ?? settings.name,
+  mapName: mapContainer.name,
+  playerCount: players.value.length,
+  maxPlayers: COLORS.length,
+  gameSettings: {
+    turnLength: gameSettings.value.turnLength,
+    gameLength: gameSettings.value.gameLength,
+    teamSize: gameSettings.value.teamSize,
+    manaMultiplier: gameSettings.value.manaMultiplier,
+    itemSpawnChance: gameSettings.value.itemSpawnChance,
+    trustClient: gameSettings.value.trustClient,
+  },
+  lastUpdatedAt: 0,
+});
+
+const startAnnouncement = async () => {
+  if (announced) return;
+  announced = true;
+  await announcement.start(buildEntry());
+};
+const stopAnnouncement = async () => {
+  if (!announced) return;
+  announced = false;
+  await announcement.stop();
+};
+const pushAnnouncement = () => {
+  if (!announced) return;
+  announcement.update(buildEntry());
+};
+
+watch(
+  () => gameSettings.value.isPublic,
+  (isPublic) => {
+    if (isPublic) startAnnouncement();
+    else stopAnnouncement();
+  }
+);
+
 onMounted(async () => {
   promise.value = createServer(settings.name, team.value, (server) => {
     const player = server.addPlayer(settings.name, team.value);
@@ -94,12 +143,21 @@ onMounted(async () => {
 
   await promise.value;
   updateLobby();
+
+  if (gameSettings.value.isPublic) {
+    await startAnnouncement();
+  }
+});
+
+onUnmounted(() => {
+  stopAnnouncement();
 });
 
 const handleBack = () => {
   if (serverStarting.value) {
     return;
   }
+  stopAnnouncement();
   destroyServer();
   router.replace("/");
 };
@@ -111,6 +169,7 @@ const handleStart = async () => {
   await promise.value;
 
   serverStarting.value = true;
+  await stopAnnouncement();
   set("Settings", {
     ...settings,
     name: players.value[0].name,
@@ -130,6 +189,7 @@ const handleSaveSettings = (settings: GameSettings) => {
   gameSettings.value = settings;
 
   updateLobby();
+  pushAnnouncement();
 };
 
 const handleSelectMap = async (config: Config, name: string) => {
@@ -137,6 +197,7 @@ const handleSelectMap = async (config: Config, name: string) => {
   mapContainer.name = name;
 
   updateLobby();
+  pushAnnouncement();
 };
 </script>
 

--- a/src/components/pages/Host.vue
+++ b/src/components/pages/Host.vue
@@ -127,10 +127,10 @@ const pushAnnouncement = () => {
 };
 
 watch(
-  () => gameSettings.value.isPublic,
-  (isPublic) => {
-    if (isPublic) startAnnouncement();
-    else stopAnnouncement();
+  () => gameSettings.value.isPrivate,
+  (isPrivate) => {
+    if (isPrivate) stopAnnouncement();
+    else startAnnouncement();
   }
 );
 
@@ -144,7 +144,7 @@ onMounted(async () => {
   await promise.value;
   updateLobby();
 
-  if (gameSettings.value.isPublic) {
+  if (!gameSettings.value.isPrivate) {
     await startAnnouncement();
   }
 });

--- a/src/components/pages/Host.vue
+++ b/src/components/pages/Host.vue
@@ -113,13 +113,21 @@ const buildEntry = (): LobbyEntry => ({
 
 const startAnnouncement = async () => {
   if (announced) return;
-  announced = true;
-  await announcement.start(buildEntry());
+  try {
+    await announcement.start(buildEntry());
+    announced = true;
+  } catch (e) {
+    console.error("Failed to announce lobby", e);
+  }
 };
 const stopAnnouncement = async () => {
   if (!announced) return;
   announced = false;
-  await announcement.stop();
+  try {
+    await announcement.stop();
+  } catch (e) {
+    console.error("Failed to stop lobby announcement", e);
+  }
 };
 const pushAnnouncement = () => {
   if (!announced) return;
@@ -129,8 +137,7 @@ const pushAnnouncement = () => {
 watch(
   () => gameSettings.value.isPrivate,
   (isPrivate) => {
-    if (isPrivate) stopAnnouncement();
-    else startAnnouncement();
+    (isPrivate ? stopAnnouncement() : startAnnouncement()).catch(() => {});
   }
 );
 

--- a/src/components/pages/MainMenu.vue
+++ b/src/components/pages/MainMenu.vue
@@ -5,40 +5,44 @@ import { RouterLink } from "vue-router";
 import Tooltip from "../atoms/Tooltip.vue";
 import { ref } from "vue";
 import JoinDialog from "../organisms/JoinDialog.vue";
+import ServerList from "../organisms/ServerList.vue";
 import github from "pixelarticons/svg/github-2.svg";
 
 const joinDialogOpen = ref(false);
 </script>
 
 <template>
-  <div class="mainMenu">
-    <ul class="list flex-list">
-      <li>
-        <RouterLink to="/host" class="primary menu-button">Host</RouterLink>
-      </li>
-      <li>
-        <button class="primary menu-button" @click="joinDialogOpen = true">
-          Join game
-        </button>
-      </li>
-      <li>
-        <RouterLink to="/builder" class="primary menu-button">Builder</RouterLink>
-      </li>
-      <li>
-        <RouterLink to="/credits" class="primary menu-button">Credits</RouterLink>
-      </li>
-      <li>
-        <a
-          href="https://github.com/lorgan3/sorcerers"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="primary menu-button"
-        >
-          Issues/Feedback
-          <img class="github-icon" :src="github" />
-        </a>
-      </li>
-    </ul>
+  <div class="main-menu-row">
+    <div class="mainMenu">
+      <ul class="list flex-list">
+        <li>
+          <RouterLink to="/host" class="primary menu-button">Host</RouterLink>
+        </li>
+        <li>
+          <button class="primary menu-button" @click="joinDialogOpen = true">
+            Join game
+          </button>
+        </li>
+        <li>
+          <RouterLink to="/builder" class="primary menu-button">Builder</RouterLink>
+        </li>
+        <li>
+          <RouterLink to="/credits" class="primary menu-button">Credits</RouterLink>
+        </li>
+        <li>
+          <a
+            href="https://github.com/lorgan3/sorcerers"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="primary menu-button"
+          >
+            Issues/Feedback
+            <img class="github-icon" :src="github" />
+          </a>
+        </li>
+      </ul>
+    </div>
+    <ServerList />
   </div>
   <div class="spellbooks">
     <Tooltip text="Spellbook" direction="top-center">
@@ -59,6 +63,13 @@ const joinDialogOpen = ref(false);
 </template>
 
 <style lang="scss" scoped>
+.main-menu-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 30px;
+  flex-wrap: wrap;
+}
+
 .mainMenu {
   .list {
     background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));

--- a/src/data/network/__spec__/lobbyAnnouncement.spec.ts
+++ b/src/data/network/__spec__/lobbyAnnouncement.spec.ts
@@ -121,3 +121,96 @@ describe("LobbyAnnouncement", () => {
     expect(fbDb.remove).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("subscribeToPublicLobbies", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("filters out entries older than 30s and entries with missing fields", async () => {
+    const { subscribeToPublicLobbies, STALE_THRESHOLD_MS } = await import(
+      "../lobbyAnnouncement"
+    );
+
+    const now = Date.now();
+    const snapshot = {
+      val: () => ({
+        "1111": { ...baseEntry, joinKey: "1111", lastUpdatedAt: now },
+        "2222": {
+          ...baseEntry,
+          joinKey: "2222",
+          lastUpdatedAt: now - STALE_THRESHOLD_MS - 5_000,
+        },
+        "3333": null,
+      }),
+    };
+
+    const onValueMock = fbDb.onValue as unknown as ReturnType<typeof vi.fn>;
+    onValueMock.mockImplementation((_ref, cb: any) => {
+      cb(snapshot);
+      return () => {};
+    });
+
+    const received: any[] = [];
+    const unsub = subscribeToPublicLobbies((lobbies) => received.push(lobbies));
+    expect(received[0]).toHaveLength(1);
+    expect(received[0][0].joinKey).toBe("1111");
+    unsub();
+  });
+
+  it("returns the unsubscribe handler from onValue", async () => {
+    const { subscribeToPublicLobbies } = await import("../lobbyAnnouncement");
+    const unsubInner = vi.fn();
+    (fbDb.onValue as any).mockImplementation(() => unsubInner);
+
+    const unsub = subscribeToPublicLobbies(() => {});
+    unsub();
+    expect(unsubInner).toHaveBeenCalled();
+  });
+});
+
+describe("sweepStaleLobbies", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("removes only entries older than 30s, runs once per process", async () => {
+    const { sweepStaleLobbies, STALE_THRESHOLD_MS } = await import(
+      "../lobbyAnnouncement"
+    );
+
+    const now = Date.now();
+    const data = {
+      "1111": { ...baseEntry, joinKey: "1111", lastUpdatedAt: now },
+      "2222": {
+        ...baseEntry,
+        joinKey: "2222",
+        lastUpdatedAt: now - STALE_THRESHOLD_MS - 1_000,
+      },
+      "3333": {
+        ...baseEntry,
+        joinKey: "3333",
+        lastUpdatedAt: now - STALE_THRESHOLD_MS - 60_000,
+      },
+    };
+
+    (fbDb.get as any).mockResolvedValue({ val: () => data });
+    const refMock = fbDb.ref as unknown as ReturnType<typeof vi.fn>;
+    refMock.mockClear();
+    refMock.mockReturnValue(fakeRef);
+
+    await sweepStaleLobbies();
+
+    // ref called for: lobbies root + 2 stale children
+    const removedPaths = refMock.mock.calls.map((c) => c[1]);
+    expect(removedPaths).toContain("lobbies/2222");
+    expect(removedPaths).toContain("lobbies/3333");
+    expect(removedPaths).not.toContain("lobbies/1111");
+
+    // Second invocation does nothing (idempotent guard)
+    refMock.mockClear();
+    (fbDb.get as any).mockClear();
+    await sweepStaleLobbies();
+    expect(fbDb.get).not.toHaveBeenCalled();
+  });
+});

--- a/src/data/network/__spec__/lobbyAnnouncement.spec.ts
+++ b/src/data/network/__spec__/lobbyAnnouncement.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  LobbyAnnouncement,
+  type LobbyEntry,
+  HEARTBEAT_INTERVAL_MS,
+} from "../lobbyAnnouncement";
+
+const fakeRef = { __ref: true };
+const onDisconnectMock = {
+  remove: vi.fn().mockResolvedValue(undefined),
+  cancel: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock("firebase/database", () => ({
+  ref: vi.fn(() => fakeRef),
+  set: vi.fn().mockResolvedValue(undefined),
+  remove: vi.fn().mockResolvedValue(undefined),
+  onDisconnect: vi.fn(() => onDisconnectMock),
+  serverTimestamp: vi.fn(() => "STAMP"),
+  onValue: vi.fn(),
+  get: vi.fn(),
+  child: vi.fn(),
+}));
+
+vi.mock("../../../util/firebase", () => ({
+  database: { __db: true },
+}));
+
+import * as fbDb from "firebase/database";
+
+const baseEntry: LobbyEntry = {
+  joinKey: "1234",
+  hostName: "Frodo",
+  mapName: "Playground",
+  playerCount: 1,
+  maxPlayers: 5,
+  gameSettings: {
+    turnLength: 45,
+    gameLength: 10,
+    teamSize: 4,
+    manaMultiplier: 100,
+    itemSpawnChance: 100,
+    trustClient: true,
+  },
+  lastUpdatedAt: 0,
+};
+
+describe("LobbyAnnouncement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("start writes entry, registers onDisconnect, schedules heartbeat", async () => {
+    const a = new LobbyAnnouncement();
+    await a.start(baseEntry);
+
+    expect(fbDb.ref).toHaveBeenCalledWith({ __db: true }, "lobbies/1234");
+    expect(fbDb.set).toHaveBeenCalledWith(fakeRef, {
+      ...baseEntry,
+      lastUpdatedAt: "STAMP",
+    });
+    expect(fbDb.onDisconnect).toHaveBeenCalledWith(fakeRef);
+    expect(onDisconnectMock.remove).toHaveBeenCalled();
+  });
+
+  it("heartbeat re-writes entry every HEARTBEAT_INTERVAL_MS", async () => {
+    const a = new LobbyAnnouncement();
+    await a.start(baseEntry);
+
+    expect(fbDb.set).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+    expect(fbDb.set).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+    expect(fbDb.set).toHaveBeenCalledTimes(3);
+  });
+
+  it("update merges patch, writes immediately, resets heartbeat", async () => {
+    const a = new LobbyAnnouncement();
+    await a.start(baseEntry);
+
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS - 1000);
+    a.update({ playerCount: 3 });
+
+    expect(fbDb.set).toHaveBeenCalledTimes(2);
+    expect(fbDb.set).toHaveBeenLastCalledWith(fakeRef, {
+      ...baseEntry,
+      playerCount: 3,
+      lastUpdatedAt: "STAMP",
+    });
+
+    vi.advanceTimersByTime(1000);
+    expect(fbDb.set).toHaveBeenCalledTimes(2); // heartbeat reset, no extra write
+  });
+
+  it("stop removes entry, cancels onDisconnect and heartbeat", async () => {
+    const a = new LobbyAnnouncement();
+    await a.start(baseEntry);
+
+    await a.stop();
+
+    expect(fbDb.remove).toHaveBeenCalledWith(fakeRef);
+    expect(onDisconnectMock.cancel).toHaveBeenCalled();
+
+    const setCallsBefore = (fbDb.set as any).mock.calls.length;
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 3);
+    expect((fbDb.set as any).mock.calls.length).toBe(setCallsBefore);
+  });
+
+  it("stop is idempotent", async () => {
+    const a = new LobbyAnnouncement();
+    await a.start(baseEntry);
+    await a.stop();
+    await a.stop(); // should not throw
+    expect(fbDb.remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/data/network/joinByKey.ts
+++ b/src/data/network/joinByKey.ts
@@ -1,0 +1,37 @@
+import { Client } from "./client";
+import { createClient } from "./index";
+import { LAST_GAME_KEY, PEER_ID_PREFIX } from "./constants";
+import { defaults } from "../../util/localStorage/settings";
+import { get } from "../../util/localStorage";
+import { Team } from "../team";
+import type { Router } from "vue-router";
+
+export interface JoinByKeyOptions {
+  router: Router;
+  onError?: () => void;
+}
+
+export async function joinByKey(
+  key: string,
+  { router, onError }: JoinByKeyOptions
+): Promise<void> {
+  const settings = defaults(get("Settings"));
+
+  if (!Client.instance) {
+    await createClient();
+  }
+
+  try {
+    await Client.instance.join(
+      PEER_ID_PREFIX + key,
+      settings.name || "Player",
+      settings.team || Team.random()
+    );
+
+    sessionStorage.setItem(LAST_GAME_KEY, key);
+    router.replace(`/join/${key}`);
+  } catch (e) {
+    onError?.();
+    throw e;
+  }
+}

--- a/src/data/network/joinByKey.ts
+++ b/src/data/network/joinByKey.ts
@@ -15,13 +15,13 @@ export async function joinByKey(
   key: string,
   { router, onError }: JoinByKeyOptions
 ): Promise<void> {
-  const settings = defaults(get("Settings"));
-
-  if (!Client.instance) {
-    await createClient();
-  }
-
   try {
+    const settings = defaults(get("Settings"));
+
+    if (!Client.instance) {
+      await createClient();
+    }
+
     await Client.instance.join(
       PEER_ID_PREFIX + key,
       settings.name || "Player",

--- a/src/data/network/lobbyAnnouncement.ts
+++ b/src/data/network/lobbyAnnouncement.ts
@@ -1,0 +1,85 @@
+import {
+  ref as dbRef,
+  set,
+  remove,
+  onDisconnect,
+  serverTimestamp,
+  type DatabaseReference,
+} from "firebase/database";
+import { database } from "../../util/firebase";
+
+export const LOBBIES_PATH = "lobbies";
+export const HEARTBEAT_INTERVAL_MS = 10_000;
+export const STALE_THRESHOLD_MS = 30_000;
+
+export interface LobbyEntry {
+  joinKey: string;
+  hostName: string;
+  mapName: string;
+  playerCount: number;
+  maxPlayers: number;
+  gameSettings: {
+    turnLength: number;
+    gameLength: number;
+    teamSize: number;
+    manaMultiplier: number;
+    itemSpawnChance: number;
+    trustClient: boolean;
+  };
+  lastUpdatedAt: number;
+}
+
+export class LobbyAnnouncement {
+  private snapshot: LobbyEntry | null = null;
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+  private ref: DatabaseReference | null = null;
+  private disconnectHandler: ReturnType<typeof onDisconnect> | null = null;
+
+  async start(initial: LobbyEntry): Promise<void> {
+    this.snapshot = { ...initial };
+    this.ref = dbRef(database, `${LOBBIES_PATH}/${initial.joinKey}`);
+    this.disconnectHandler = onDisconnect(this.ref);
+
+    await this.disconnectHandler.remove();
+    await this.write();
+    this.scheduleHeartbeat();
+  }
+
+  update(patch: Partial<LobbyEntry>): void {
+    if (!this.snapshot || !this.ref) return;
+    this.snapshot = { ...this.snapshot, ...patch };
+    this.write();
+    this.scheduleHeartbeat();
+  }
+
+  async stop(): Promise<void> {
+    if (this.intervalHandle !== null) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+    if (this.disconnectHandler) {
+      await this.disconnectHandler.cancel();
+      this.disconnectHandler = null;
+    }
+    if (this.ref) {
+      await remove(this.ref);
+      this.ref = null;
+    }
+    this.snapshot = null;
+  }
+
+  private write(): void {
+    if (!this.snapshot || !this.ref) return;
+    set(this.ref, {
+      ...this.snapshot,
+      lastUpdatedAt: serverTimestamp() as unknown as number,
+    });
+  }
+
+  private scheduleHeartbeat(): void {
+    if (this.intervalHandle !== null) {
+      clearInterval(this.intervalHandle);
+    }
+    this.intervalHandle = setInterval(() => this.write(), HEARTBEAT_INTERVAL_MS);
+  }
+}

--- a/src/data/network/lobbyAnnouncement.ts
+++ b/src/data/network/lobbyAnnouncement.ts
@@ -38,19 +38,31 @@ export class LobbyAnnouncement {
   private disconnectHandler: ReturnType<typeof onDisconnect> | null = null;
 
   async start(initial: LobbyEntry): Promise<void> {
-    this.snapshot = { ...initial };
-    this.ref = dbRef(database, `${LOBBIES_PATH}/${initial.joinKey}`);
-    this.disconnectHandler = onDisconnect(this.ref);
+    if (this.ref) return;
 
-    await this.disconnectHandler.remove();
-    await this.write();
-    this.scheduleHeartbeat();
+    const ref = dbRef(database, `${LOBBIES_PATH}/${initial.joinKey}`);
+    const handler = onDisconnect(ref);
+
+    try {
+      await handler.remove();
+      this.snapshot = { ...initial };
+      this.ref = ref;
+      this.disconnectHandler = handler;
+      await this.write();
+      this.scheduleHeartbeat();
+    } catch (e) {
+      this.snapshot = null;
+      this.ref = null;
+      this.disconnectHandler = null;
+      handler.cancel().catch(() => {});
+      throw e;
+    }
   }
 
   update(patch: Partial<LobbyEntry>): void {
     if (!this.snapshot || !this.ref) return;
     this.snapshot = { ...this.snapshot, ...patch };
-    this.write();
+    this.write().catch((e) => console.error("Lobby announcement update failed", e));
     this.scheduleHeartbeat();
   }
 
@@ -59,20 +71,27 @@ export class LobbyAnnouncement {
       clearInterval(this.intervalHandle);
       this.intervalHandle = null;
     }
-    if (this.disconnectHandler) {
-      await this.disconnectHandler.cancel();
-      this.disconnectHandler = null;
-    }
-    if (this.ref) {
-      await remove(this.ref);
-      this.ref = null;
-    }
+    const handler = this.disconnectHandler;
+    const ref = this.ref;
+    this.disconnectHandler = null;
+    this.ref = null;
     this.snapshot = null;
+
+    // Run cleanup steps independently — one failing must not prevent the others.
+    const results = await Promise.allSettled([
+      handler ? handler.cancel() : Promise.resolve(),
+      ref ? remove(ref) : Promise.resolve(),
+    ]);
+    for (const r of results) {
+      if (r.status === "rejected") {
+        console.error("Lobby announcement stop failed", r.reason);
+      }
+    }
   }
 
-  private write(): void {
+  private async write(): Promise<void> {
     if (!this.snapshot || !this.ref) return;
-    set(this.ref, {
+    await set(this.ref, {
       ...this.snapshot,
       lastUpdatedAt: serverTimestamp() as unknown as number,
     });
@@ -82,7 +101,11 @@ export class LobbyAnnouncement {
     if (this.intervalHandle !== null) {
       clearInterval(this.intervalHandle);
     }
-    this.intervalHandle = setInterval(() => this.write(), HEARTBEAT_INTERVAL_MS);
+    this.intervalHandle = setInterval(() => {
+      this.write().catch((e) =>
+        console.error("Lobby announcement heartbeat failed", e)
+      );
+    }, HEARTBEAT_INTERVAL_MS);
   }
 }
 
@@ -126,6 +149,10 @@ export async function sweepStaleLobbies(): Promise<void> {
         typeof entry.lastUpdatedAt !== "number" ||
         entry.lastUpdatedAt < cutoff
     )
-    .map(([key]) => remove(dbRef(database, `${LOBBIES_PATH}/${key}`)));
+    .map(([key]) =>
+      remove(dbRef(database, `${LOBBIES_PATH}/${key}`)).catch((e) =>
+        console.error(`Failed to sweep stale lobby ${key}`, e)
+      )
+    );
   await Promise.all(removals);
 }

--- a/src/data/network/lobbyAnnouncement.ts
+++ b/src/data/network/lobbyAnnouncement.ts
@@ -3,6 +3,8 @@ import {
   set,
   remove,
   onDisconnect,
+  onValue,
+  get,
   serverTimestamp,
   type DatabaseReference,
 } from "firebase/database";
@@ -82,4 +84,48 @@ export class LobbyAnnouncement {
     }
     this.intervalHandle = setInterval(() => this.write(), HEARTBEAT_INTERVAL_MS);
   }
+}
+
+export function subscribeToPublicLobbies(
+  callback: (lobbies: LobbyEntry[]) => void
+): () => void {
+  const lobbiesRef = dbRef(database, LOBBIES_PATH);
+  return onValue(lobbiesRef, (snapshot) => {
+    const value = snapshot.val() as Record<string, LobbyEntry | null> | null;
+    if (!value) {
+      callback([]);
+      return;
+    }
+    const cutoff = Date.now() - STALE_THRESHOLD_MS;
+    const lobbies = Object.values(value).filter(
+      (entry): entry is LobbyEntry =>
+        !!entry &&
+        typeof entry.lastUpdatedAt === "number" &&
+        entry.lastUpdatedAt > cutoff
+    );
+    callback(lobbies);
+  });
+}
+
+let hasSwept = false;
+
+export async function sweepStaleLobbies(): Promise<void> {
+  if (hasSwept) return;
+  hasSwept = true;
+
+  const lobbiesRef = dbRef(database, LOBBIES_PATH);
+  const snapshot = await get(lobbiesRef);
+  const value = snapshot.val() as Record<string, LobbyEntry | null> | null;
+  if (!value) return;
+
+  const cutoff = Date.now() - STALE_THRESHOLD_MS;
+  const removals = Object.entries(value)
+    .filter(
+      ([, entry]) =>
+        !entry ||
+        typeof entry.lastUpdatedAt !== "number" ||
+        entry.lastUpdatedAt < cutoff
+    )
+    .map(([key]) => remove(dbRef(database, `${LOBBIES_PATH}/${key}`)));
+  await Promise.all(removals);
 }

--- a/src/util/__spec__/settings.spec.ts
+++ b/src/util/__spec__/settings.spec.ts
@@ -3,27 +3,27 @@ import { defaults, settingsReviver } from "../localStorage/settings";
 
 describe("settings", () => {
   describe("defaults", () => {
-    it("defaults isPublic to false when no settings stored", () => {
+    it("defaults isPrivate to false (public) when no settings stored", () => {
       const s = defaults();
-      expect(s.gameSettings.isPublic).toBe(false);
+      expect(s.gameSettings.isPrivate).toBe(false);
     });
 
-    it("preserves isPublic when stored as true", () => {
-      const s = defaults({ gameSettings: { isPublic: true } as any });
-      expect(s.gameSettings.isPublic).toBe(true);
+    it("preserves isPrivate when stored as true", () => {
+      const s = defaults({ gameSettings: { isPrivate: true } as any });
+      expect(s.gameSettings.isPrivate).toBe(true);
     });
   });
 
   describe("settingsReviver", () => {
-    it("coerces non-boolean isPublic to false", () => {
-      expect(settingsReviver("isPublic", "yes")).toBe(false);
-      expect(settingsReviver("isPublic", 1)).toBe(false);
-      expect(settingsReviver("isPublic", null)).toBe(false);
+    it("coerces non-boolean isPrivate to false", () => {
+      expect(settingsReviver("isPrivate", "yes")).toBe(false);
+      expect(settingsReviver("isPrivate", 1)).toBe(false);
+      expect(settingsReviver("isPrivate", null)).toBe(false);
     });
 
-    it("preserves boolean isPublic", () => {
-      expect(settingsReviver("isPublic", true)).toBe(true);
-      expect(settingsReviver("isPublic", false)).toBe(false);
+    it("preserves boolean isPrivate", () => {
+      expect(settingsReviver("isPrivate", true)).toBe(true);
+      expect(settingsReviver("isPrivate", false)).toBe(false);
     });
   });
 });

--- a/src/util/__spec__/settings.spec.ts
+++ b/src/util/__spec__/settings.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { defaults, settingsReviver } from "../localStorage/settings";
+
+describe("settings", () => {
+  describe("defaults", () => {
+    it("defaults isPublic to false when no settings stored", () => {
+      const s = defaults();
+      expect(s.gameSettings.isPublic).toBe(false);
+    });
+
+    it("preserves isPublic when stored as true", () => {
+      const s = defaults({ gameSettings: { isPublic: true } as any });
+      expect(s.gameSettings.isPublic).toBe(true);
+    });
+  });
+
+  describe("settingsReviver", () => {
+    it("coerces non-boolean isPublic to false", () => {
+      expect(settingsReviver("isPublic", "yes")).toBe(false);
+      expect(settingsReviver("isPublic", 1)).toBe(false);
+      expect(settingsReviver("isPublic", null)).toBe(false);
+    });
+
+    it("preserves boolean isPublic", () => {
+      expect(settingsReviver("isPublic", true)).toBe(true);
+      expect(settingsReviver("isPublic", false)).toBe(false);
+    });
+  });
+});

--- a/src/util/firebase.ts
+++ b/src/util/firebase.ts
@@ -5,7 +5,8 @@ import { getDatabase } from "firebase/database";
 const firebaseConfig = {
   apiKey: "AIzaSyCLAKR-zmb0Mk_mBFLIIZhSDYU8kdv-vKw",
   authDomain: "sorcerers-9534c.firebaseapp.com",
-  databaseURL: "https://sorcerers-9534c-default-rtdb.firebaseio.com",
+  databaseURL:
+    "https://sorcerers-9534c-default-rtdb.europe-west1.firebasedatabase.app",
   projectId: "sorcerers-9534c",
   storageBucket: "sorcerers-9534c.appspot.com",
   messagingSenderId: "788369848487",

--- a/src/util/firebase.ts
+++ b/src/util/firebase.ts
@@ -1,13 +1,11 @@
 import { initializeApp } from "firebase/app";
 import { getAnalytics, logEvent as log } from "firebase/analytics";
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
+import { getDatabase } from "firebase/database";
 
-// Your web app's Firebase configuration
-// For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
   apiKey: "AIzaSyCLAKR-zmb0Mk_mBFLIIZhSDYU8kdv-vKw",
   authDomain: "sorcerers-9534c.firebaseapp.com",
+  databaseURL: "https://sorcerers-9534c-default-rtdb.firebaseio.com",
   projectId: "sorcerers-9534c",
   storageBucket: "sorcerers-9534c.appspot.com",
   messagingSenderId: "788369848487",
@@ -15,9 +13,10 @@ const firebaseConfig = {
   measurementId: "G-GM8MJB2T40",
 };
 
-// Initialize Firebase
 const app = initializeApp(firebaseConfig);
 const analytics = getAnalytics(app);
+
+export const database = getDatabase(app);
 
 export const logEvent = (
   eventName: string,

--- a/src/util/localStorage/settings.ts
+++ b/src/util/localStorage/settings.ts
@@ -8,6 +8,7 @@ export interface GameSettings {
   teamSize: number;
   manaMultiplier: number;
   itemSpawnChance: number;
+  isPublic: boolean;
 }
 
 export interface Settings {
@@ -48,6 +49,10 @@ export const settingsReviver = (key: string, value: any): any => {
     return assertNumber(value, 0, 500);
   }
 
+  if (key === "isPublic") {
+    return typeof value === "boolean" ? value : false;
+  }
+
   return value;
 };
 
@@ -78,6 +83,7 @@ export const defaults = (settings?: Partial<Settings> | null): Settings => {
       teamSize: 4,
       manaMultiplier: 100,
       itemSpawnChance: 100,
+      isPublic: false,
       ...gameSettings,
     },
     ...rest,

--- a/src/util/localStorage/settings.ts
+++ b/src/util/localStorage/settings.ts
@@ -8,7 +8,7 @@ export interface GameSettings {
   teamSize: number;
   manaMultiplier: number;
   itemSpawnChance: number;
-  isPublic: boolean;
+  isPrivate: boolean;
 }
 
 export interface Settings {
@@ -49,7 +49,7 @@ export const settingsReviver = (key: string, value: any): any => {
     return assertNumber(value, 0, 500);
   }
 
-  if (key === "isPublic") {
+  if (key === "isPrivate") {
     return typeof value === "boolean" ? value : false;
   }
 
@@ -83,7 +83,7 @@ export const defaults = (settings?: Partial<Settings> | null): Settings => {
       teamSize: 4,
       manaMultiplier: 100,
       itemSpawnChance: 100,
-      isPublic: false,
+      isPrivate: false,
       ...gameSettings,
     },
     ...rest,


### PR DESCRIPTION
### Description

Hosts can opt their lobby into a public server browser. Public games announce themselves to Firebase Realtime Database (`/lobbies/{joinKey}`) with host name, map, player count, settings, and a 10s heartbeat. Clients on the main menu see a live-updating "Public games" list to the right of the menu and can click an entry to join.

Lifecycle:
- Heartbeat every 10s, immediate write on player join/leave/setting/map change.
- `onDisconnect().remove()` cleans up the entry server-side if the host's tab closes.
- Entries older than 30s are filtered client-side and swept once on app load.
- Visibility defaults to public; can be toggled to private in the host settings dialog.

### Manual check

- Make sure Realtime Database is enabled in the Firebase console for `sorcerers-9534c` and rules allow read/write on `/lobbies`
- Open two browser windows
- Window 1: go to `/host`, pick a map
- Window 2: go to `/`
- [ ] In Window 1, the settings summary shows "Visibility: Public" by default
- [ ] In Window 2, a "Public games" title appears to the right of the menu with one entry — no parchment box around it
- [ ] The entry shows host name, map name, "1/5", team size, turn duration
- Click the entry in Window 2
- [ ] Navigates to \`/join/<code>\` and joins the lobby
- [ ] In Window 1 the player count goes from 1 to 2 (live update)
- In Window 1, open Settings → toggle "Private game" on → Save
- [ ] The entry disappears from Window 2
- [ ] Settings summary now shows "Visibility: Private"
- Toggle "Private game" off → Save
- [ ] Entry reappears in Window 2
- In Window 1 click "Back"
- [ ] Entry disappears from Window 2
- Re-open Host in Window 1, wait for the entry to show in Window 2, then close Window 1's tab outright
- [ ] Entry disappears from Window 2 within ~10s (Firebase \`onDisconnect\`)
- [ ] With no public games, the right side of the main menu is hidden (menu sits centered)

<p align="right">ℹ️ Created with Claude Code</p>