### PR TITLE
Add lobby chat with parchment slide-up panel

### DIFF
--- a/src/components/molecules/ChatParticles.vue
+++ b/src/components/molecules/ChatParticles.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import arcane from "../../assets/icons/arcane_bright.png";
+import elemental from "../../assets/icons/elemental_bright.png";
+import life from "../../assets/icons/life_bright.png";
+import physical from "../../assets/icons/physical_bright.png";
+
+interface Particle {
+  id: number;
+  src: string;
+  left: number;
+  drift: number;
+  rise: number;
+  rotateStart: number;
+  rotateEnd: number;
+  duration: number;
+}
+
+const GLYPHS = [arcane, elemental, life, physical];
+const MAX_LIVE = 32;
+
+const particles = ref<Particle[]>([]);
+let nextId = 0;
+
+const pick = <T,>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)];
+const range = (min: number, max: number) =>
+  min + Math.random() * (max - min);
+
+const emit = () => {
+  const count = 6 + Math.floor(Math.random() * 3);
+
+  for (let i = 0; i < count; i++) {
+    const p: Particle = {
+      id: ++nextId,
+      src: pick(GLYPHS),
+      left: range(20, 320),
+      drift: range(-30, 30),
+      rise: range(60, 110),
+      rotateStart: range(-30, 30),
+      rotateEnd: range(-180, 180),
+      duration: range(900, 1200),
+    };
+    particles.value.push(p);
+
+    while (particles.value.length > MAX_LIVE) {
+      particles.value.shift();
+    }
+
+    window.setTimeout(() => {
+      const idx = particles.value.findIndex((q) => q.id === p.id);
+      if (idx !== -1) particles.value.splice(idx, 1);
+    }, p.duration);
+  }
+};
+
+defineExpose({ emit });
+</script>
+
+<template>
+  <div class="chat-particles">
+    <img
+      v-for="p in particles"
+      :key="p.id"
+      :src="p.src"
+      class="particle"
+      :style="{
+        left: p.left + 'px',
+        '--drift': p.drift + 'px',
+        '--rise': p.rise + 'px',
+        '--rot-start': p.rotateStart + 'deg',
+        '--rot-end': p.rotateEnd + 'deg',
+        animationDuration: p.duration + 'ms',
+      }"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.chat-particles {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 0;
+  pointer-events: none;
+  overflow: visible;
+}
+
+.particle {
+  position: absolute;
+  top: 0;
+  width: 24px;
+  height: 24px;
+  image-rendering: pixelated;
+  pointer-events: none;
+  filter: drop-shadow(0 0 4px rgba(255, 220, 140, 0.8));
+  animation-name: chat-particle-rise;
+  animation-timing-function: ease-out;
+  animation-fill-mode: forwards;
+  transform-origin: center;
+}
+
+@keyframes chat-particle-rise {
+  0% {
+    opacity: 0;
+    transform: translate(0, 0) rotate(var(--rot-start));
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(var(--drift), calc(-1 * var(--rise))) rotate(var(--rot-end));
+  }
+}
+</style>

--- a/src/components/organisms/LobbyChat.vue
+++ b/src/components/organisms/LobbyChat.vue
@@ -1,0 +1,307 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
+import { sound } from "@pixi/sound";
+import { Sound, getRandomSound } from "../../sound";
+import { Manager } from "../../data/network/manager";
+import type { ChatEntry } from "../../data/network/types";
+import ChatParticles from "../molecules/ChatParticles.vue";
+
+const props = defineProps<{
+  manager: Manager;
+}>();
+
+const isOpen = ref(false);
+const draft = ref("");
+const flash = ref(false);
+const messages = props.manager.chatLog;
+const messageList = ref<HTMLDivElement | null>(null);
+const particles = ref<InstanceType<typeof ChatParticles> | null>(null);
+const inputEl = ref<HTMLInputElement | null>(null);
+
+const wasAtBottom = ref(true);
+let lastSoundAt = 0;
+let flashTimeout: number | undefined;
+
+const handleScroll = () => {
+  const el = messageList.value;
+  if (!el) return;
+  wasAtBottom.value = el.scrollHeight - el.scrollTop - el.clientHeight < 10;
+};
+
+const scrollToBottom = () => {
+  const el = messageList.value;
+  if (el) el.scrollTop = el.scrollHeight;
+};
+
+const playPop = () => {
+  const now = performance.now();
+  if (now - lastSoundAt < 200) return;
+  lastSoundAt = now;
+  const data = getRandomSound(Sound.Pop);
+  sound.play(data.key, { volume: data.volume });
+};
+
+const triggerFlash = () => {
+  flash.value = true;
+  if (flashTimeout) window.clearTimeout(flashTimeout);
+  flashTimeout = window.setTimeout(() => (flash.value = false), 600);
+};
+
+const handleChatMessage = (_entry: ChatEntry, byMe: boolean) => {
+  particles.value?.emit();
+
+  if (!byMe) {
+    playPop();
+  }
+
+  if (!isOpen.value) {
+    triggerFlash();
+  }
+
+  nextTick(() => {
+    if (wasAtBottom.value) scrollToBottom();
+  });
+};
+
+onMounted(() => {
+  props.manager.onChatMessage = handleChatMessage;
+  nextTick(scrollToBottom);
+});
+
+onUnmounted(() => {
+  if (props.manager.onChatMessage === handleChatMessage) {
+    props.manager.onChatMessage = undefined;
+  }
+  if (flashTimeout) window.clearTimeout(flashTimeout);
+});
+
+watch(isOpen, (open) => {
+  if (open) {
+    nextTick(() => {
+      scrollToBottom();
+      inputEl.value?.focus();
+    });
+  }
+});
+
+const open = () => {
+  if (!isOpen.value) isOpen.value = true;
+};
+const close = () => {
+  isOpen.value = false;
+};
+
+const send = () => {
+  const text = draft.value.trim();
+  if (!text) return;
+  props.manager.sendChat(text);
+  draft.value = "";
+};
+
+const handleKey = (e: KeyboardEvent) => {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    send();
+  }
+};
+
+const containerClass = computed(() => ({
+  "lobby-chat": true,
+  "lobby-chat--open": isOpen.value,
+  "lobby-chat--flash": flash.value && !isOpen.value,
+}));
+</script>
+
+<template>
+  <div :class="containerClass">
+    <ChatParticles ref="particles" class="particles-layer" />
+
+    <button
+      v-if="!isOpen"
+      class="slice"
+      type="button"
+      @click="open"
+      title="Open chat"
+    >
+      <span class="slice-label">Chat</span>
+    </button>
+
+    <template v-else>
+      <div class="header">
+        <h3>Chat</h3>
+        <button class="close" type="button" @click="close" title="Close chat">×</button>
+      </div>
+      <div
+        ref="messageList"
+        class="messages"
+        @scroll="handleScroll"
+      >
+        <div
+          v-for="msg in messages"
+          :key="msg.id"
+          class="message"
+        >
+          <span class="author" :style="{ color: msg.color }">{{ msg.author }}</span>:
+          {{ msg.text }}
+        </div>
+      </div>
+      <div class="input-row">
+        <input
+          ref="inputEl"
+          v-model="draft"
+          class="input"
+          type="text"
+          maxlength="200"
+          placeholder="type a message…"
+          @keydown="handleKey"
+        />
+      </div>
+    </template>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.lobby-chat {
+  position: fixed;
+  right: 24px;
+  bottom: 0;
+  width: 340px;
+  height: 400px;
+  z-index: 50;
+
+  background: url("../../assets/parchment.png");
+  background-size: 256px;
+  image-rendering: pixelated;
+  border: 3px solid var(--border-accent);
+  border-radius: 4px 4px 0 0;
+  box-shadow:
+    0 0 20px inset rgba(64, 32, 32, 0.3),
+    0 -4px 20px rgba(0, 0, 0, 0.4),
+    0 0 0 1px var(--border-accent-faint);
+
+  transform: translateY(calc(100% - 28px));
+  transition: transform 0.3s ease-out;
+
+  display: flex;
+  flex-direction: column;
+}
+
+.lobby-chat--open {
+  transform: translateY(0);
+}
+
+.lobby-chat--flash {
+  animation: chat-flash 0.6s ease-in-out;
+}
+
+@keyframes chat-flash {
+  0%, 100% {
+    box-shadow:
+      0 0 20px inset rgba(64, 32, 32, 0.3),
+      0 -4px 20px rgba(0, 0, 0, 0.4),
+      0 0 0 1px var(--border-accent-faint);
+    transform: translateY(calc(100% - 28px));
+  }
+  50% {
+    box-shadow:
+      0 0 20px inset rgba(64, 32, 32, 0.3),
+      0 -4px 30px rgba(255, 220, 140, 0.5),
+      0 0 0 1px var(--border-accent-faint);
+    transform: translateY(calc(100% - 36px));
+  }
+}
+
+.particles-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  pointer-events: none;
+}
+
+.slice {
+  width: 100%;
+  height: 28px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: inherit;
+  color: var(--border-accent);
+  font-size: 14px;
+}
+
+.slice-label {
+  font-weight: bold;
+  letter-spacing: 1px;
+}
+
+.header {
+  flex: 0 0 auto;
+  height: 36px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border-accent-faint);
+}
+
+.header h3 {
+  margin: 0;
+  font-size: 16px;
+  color: var(--border-accent);
+}
+
+.close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--border-accent);
+  padding: 0 4px;
+}
+
+.messages {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 8px 12px;
+  scrollbar-color: var(--border-accent-faint) transparent;
+  scrollbar-width: thin;
+}
+
+.message {
+  margin-bottom: 4px;
+  word-wrap: break-word;
+  line-height: 1.3;
+}
+
+.author {
+  font-weight: bold;
+  text-shadow: 0 0 1px rgba(0, 0, 0, 0.4);
+}
+
+.input-row {
+  flex: 0 0 auto;
+  padding: 8px 12px;
+  border-top: 1px solid var(--border-accent-faint);
+}
+
+.input {
+  width: 100%;
+  padding: 6px 8px;
+  font-family: inherit;
+  font-size: 14px;
+  background: rgba(255, 250, 230, 0.6);
+  border: 1px solid var(--border-accent-faint);
+  border-radius: 2px;
+  color: inherit;
+  outline: none;
+
+  &:focus {
+    border-color: var(--border-accent);
+  }
+}
+</style>

--- a/src/components/organisms/LobbyChat.vue
+++ b/src/components/organisms/LobbyChat.vue
@@ -178,7 +178,6 @@ const containerClass = computed(() => ({
   height: 36px;
   box-sizing: border-box;
   z-index: 50;
-  overflow: hidden;
 
   background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
   border: 2px solid var(--border-accent);
@@ -249,7 +248,7 @@ const containerClass = computed(() => ({
 .messages {
   flex: 1 1 auto;
   overflow-y: auto;
-  padding: 8px 12px;
+  padding: 4px 12px;
   scrollbar-color: var(--border-accent-faint) transparent;
   scrollbar-width: thin;
 }
@@ -267,6 +266,10 @@ const containerClass = computed(() => ({
   word-wrap: break-word;
   line-height: 1.3;
   color: var(--primary);
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .author {

--- a/src/components/organisms/LobbyChat.vue
+++ b/src/components/organisms/LobbyChat.vue
@@ -23,6 +23,7 @@ const inputEl = ref<HTMLInputElement | null>(null);
 const wasAtBottom = ref(true);
 let lastSoundAt = 0;
 let flashTimeout: number | undefined;
+let resizeObserver: ResizeObserver | undefined;
 
 const handleScroll = () => {
   const el = messageList.value;
@@ -32,7 +33,10 @@ const handleScroll = () => {
 
 const scrollToBottom = () => {
   const el = messageList.value;
-  if (el) el.scrollTop = el.scrollHeight;
+  if (el) {
+    el.scrollTop = el.scrollHeight;
+    wasAtBottom.value = true;
+  }
 };
 
 const playPop = () => {
@@ -67,7 +71,22 @@ const handleChatMessage = (_entry: ChatEntry, byMe: boolean) => {
 
 onMounted(() => {
   props.manager.onChatMessage = handleChatMessage;
-  nextTick(scrollToBottom);
+  nextTick(() => {
+    scrollToBottom();
+    if (messageList.value && typeof ResizeObserver !== "undefined") {
+      // Re-pin to bottom on every clientHeight change (open/close
+      // transitions, hover, etc). Without this, growing the container
+      // (e.g. on hover) lets the browser clamp scrollTop down to fit
+      // the bigger window — and that smaller scrollTop sticks when the
+      // container shrinks back, leaving the last line off-center.
+      resizeObserver = new ResizeObserver(() => {
+        if (!isOpen.value || wasAtBottom.value) {
+          scrollToBottom();
+        }
+      });
+      resizeObserver.observe(messageList.value);
+    }
+  });
 });
 
 onUnmounted(() => {
@@ -75,6 +94,7 @@ onUnmounted(() => {
     props.manager.onChatMessage = undefined;
   }
   if (flashTimeout) window.clearTimeout(flashTimeout);
+  resizeObserver?.disconnect();
 });
 
 watch(isOpen, (open) => {
@@ -83,13 +103,6 @@ watch(isOpen, (open) => {
       scrollToBottom();
       inputEl.value?.focus();
     });
-  } else {
-    // The panel's height transitions from 400px → 36px over 300ms.
-    // scrollToBottom needs to run *after* the messages container has
-    // shrunk; otherwise scrollTop clamps to 0 against the open-state
-    // clientHeight and the latest line ends up off-screen.
-    nextTick(scrollToBottom);
-    window.setTimeout(scrollToBottom, 350);
   }
 });
 

--- a/src/components/organisms/LobbyChat.vue
+++ b/src/components/organisms/LobbyChat.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { sound } from "@pixi/sound";
+import closeIcon from "pixelarticons/svg/close.svg";
 import { Sound, getRandomSound } from "../../sound";
 import { Manager } from "../../data/network/manager";
 import type { ChatEntry } from "../../data/network/types";
 import ChatParticles from "../molecules/ChatParticles.vue";
+import IconButton from "../atoms/IconButton.vue";
 
 const props = defineProps<{
   manager: Manager;
@@ -118,45 +120,45 @@ const containerClass = computed(() => ({
 
     <button
       v-if="!isOpen"
-      class="slice"
+      class="open-trigger"
       type="button"
       @click="open"
       title="Open chat"
-    >
-      <span class="slice-label">Chat</span>
-    </button>
+    />
 
-    <template v-else>
-      <div class="header">
-        <h3>Chat</h3>
-        <button class="close" type="button" @click="close" title="Close chat">×</button>
-      </div>
+    <IconButton
+      v-else
+      class="close-btn"
+      :icon="closeIcon"
+      title="Close chat"
+      :onClick="close"
+    />
+
+    <div
+      ref="messageList"
+      class="messages"
+      @scroll="handleScroll"
+    >
       <div
-        ref="messageList"
-        class="messages"
-        @scroll="handleScroll"
+        v-for="msg in messages"
+        :key="msg.id"
+        class="message"
       >
-        <div
-          v-for="msg in messages"
-          :key="msg.id"
-          class="message"
-        >
-          <span class="author" :style="{ color: msg.color }">{{ msg.author }}</span>:
-          {{ msg.text }}
-        </div>
+        <span class="author" :style="{ color: msg.color }">{{ msg.author }}</span>:
+        {{ msg.text }}
       </div>
-      <div class="input-row">
-        <input
-          ref="inputEl"
-          v-model="draft"
-          class="input"
-          type="text"
-          maxlength="200"
-          placeholder="type a message…"
-          @keydown="handleKey"
-        />
-      </div>
-    </template>
+    </div>
+
+    <div v-if="isOpen" class="input-row">
+      <input
+        ref="inputEl"
+        v-model="draft"
+        class="input"
+        type="text"
+        maxlength="200"
+        @keydown="handleKey"
+      />
+    </div>
   </div>
 </template>
 
@@ -170,21 +172,22 @@ const containerClass = computed(() => ({
   box-sizing: border-box;
   z-index: 50;
 
-  background: url("../../assets/parchment.png");
-  background-size: 256px;
-  image-rendering: pixelated;
-  border: 3px solid var(--border-accent);
+  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
+  border: 2px solid var(--border-accent);
   border-radius: 4px 4px 0 0;
   box-shadow:
-    0 0 20px inset rgba(64, 32, 32, 0.3),
-    0 -4px 20px rgba(0, 0, 0, 0.4),
-    0 0 0 1px var(--border-accent-faint);
+    0 2px 5px rgba(30, 15, 5, 0.3),
+    0 -4px 20px rgba(0, 0, 0, 0.3);
 
-  transform: translateY(calc(100% - 28px));
+  transform: translateY(calc(100% - 18px));
   transition: transform 0.3s ease-out;
 
   display: flex;
   flex-direction: column;
+
+  &:not(.lobby-chat--open):hover {
+    transform: translateY(calc(100% - 24px));
+  }
 }
 
 .lobby-chat--open {
@@ -198,17 +201,15 @@ const containerClass = computed(() => ({
 @keyframes chat-flash {
   0%, 100% {
     box-shadow:
-      0 0 20px inset rgba(64, 32, 32, 0.3),
-      0 -4px 20px rgba(0, 0, 0, 0.4),
-      0 0 0 1px var(--border-accent-faint);
-    transform: translateY(calc(100% - 28px));
+      0 2px 5px rgba(30, 15, 5, 0.3),
+      0 -4px 20px rgba(0, 0, 0, 0.3);
+    transform: translateY(calc(100% - 18px));
   }
   50% {
     box-shadow:
-      0 0 20px inset rgba(64, 32, 32, 0.3),
-      0 -4px 30px rgba(255, 220, 140, 0.5),
-      0 0 0 1px var(--border-accent-faint);
-    transform: translateY(calc(100% - 36px));
+      0 2px 5px rgba(30, 15, 5, 0.3),
+      0 -4px 30px rgba(255, 220, 140, 0.6);
+    transform: translateY(calc(100% - 28px));
   }
 }
 
@@ -220,49 +221,24 @@ const containerClass = computed(() => ({
   pointer-events: none;
 }
 
-.slice {
+.open-trigger {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
-  height: 28px;
+  height: 18px;
   background: none;
   border: none;
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: inherit;
-  color: var(--border-accent);
-  font-size: 14px;
+  padding: 0;
+  z-index: 2;
 }
 
-.slice-label {
-  font-weight: bold;
-  letter-spacing: 1px;
-}
-
-.header {
-  flex: 0 0 auto;
-  height: 36px;
-  padding: 0 12px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border-bottom: 1px solid var(--border-accent-faint);
-}
-
-.header h3 {
-  margin: 0;
-  font-size: 16px;
-  color: var(--border-accent);
-}
-
-.close {
-  background: none;
-  border: none;
-  font-size: 24px;
-  line-height: 1;
-  cursor: pointer;
-  color: var(--border-accent);
-  padding: 0 4px;
+.close-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 2;
 }
 
 .messages {
@@ -277,6 +253,7 @@ const containerClass = computed(() => ({
   margin-bottom: 4px;
   word-wrap: break-word;
   line-height: 1.3;
+  color: var(--primary);
 }
 
 .author {
@@ -292,13 +269,14 @@ const containerClass = computed(() => ({
 
 .input {
   width: 100%;
+  box-sizing: border-box;
   padding: 6px 8px;
   font-family: inherit;
   font-size: 14px;
   background: rgba(255, 250, 230, 0.6);
   border: 1px solid var(--border-accent-faint);
   border-radius: 2px;
-  color: inherit;
+  color: var(--primary);
   outline: none;
 
   &:focus {

--- a/src/components/organisms/LobbyChat.vue
+++ b/src/components/organisms/LobbyChat.vue
@@ -167,6 +167,7 @@ const containerClass = computed(() => ({
   bottom: 0;
   width: 340px;
   height: 400px;
+  box-sizing: border-box;
   z-index: 50;
 
   background: url("../../assets/parchment.png");

--- a/src/components/organisms/LobbyChat.vue
+++ b/src/components/organisms/LobbyChat.vue
@@ -61,7 +61,7 @@ const handleChatMessage = (_entry: ChatEntry, byMe: boolean) => {
   }
 
   nextTick(() => {
-    if (wasAtBottom.value) scrollToBottom();
+    if (!isOpen.value || wasAtBottom.value) scrollToBottom();
   });
 };
 
@@ -83,6 +83,13 @@ watch(isOpen, (open) => {
       scrollToBottom();
       inputEl.value?.focus();
     });
+  } else {
+    // The panel's height transitions from 400px → 36px over 300ms.
+    // scrollToBottom needs to run *after* the messages container has
+    // shrunk; otherwise scrollTop clamps to 0 against the open-state
+    // clientHeight and the latest line ends up off-screen.
+    nextTick(scrollToBottom);
+    window.setTimeout(scrollToBottom, 350);
   }
 });
 
@@ -168,9 +175,10 @@ const containerClass = computed(() => ({
   right: 24px;
   bottom: 0;
   width: 340px;
-  height: 400px;
+  height: 36px;
   box-sizing: border-box;
   z-index: 50;
+  overflow: hidden;
 
   background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
   border: 2px solid var(--border-accent);
@@ -179,19 +187,18 @@ const containerClass = computed(() => ({
     0 2px 5px rgba(30, 15, 5, 0.3),
     0 -4px 20px rgba(0, 0, 0, 0.3);
 
-  transform: translateY(calc(100% - 18px));
-  transition: transform 0.3s ease-out;
+  transition: height 0.3s ease-out;
 
   display: flex;
   flex-direction: column;
 
   &:not(.lobby-chat--open):hover {
-    transform: translateY(calc(100% - 24px));
+    height: 42px;
   }
 }
 
 .lobby-chat--open {
-  transform: translateY(0);
+  height: 400px;
 }
 
 .lobby-chat--flash {
@@ -203,13 +210,11 @@ const containerClass = computed(() => ({
     box-shadow:
       0 2px 5px rgba(30, 15, 5, 0.3),
       0 -4px 20px rgba(0, 0, 0, 0.3);
-    transform: translateY(calc(100% - 18px));
   }
   50% {
     box-shadow:
       0 2px 5px rgba(30, 15, 5, 0.3),
       0 -4px 30px rgba(255, 220, 140, 0.6);
-    transform: translateY(calc(100% - 28px));
   }
 }
 
@@ -226,7 +231,7 @@ const containerClass = computed(() => ({
   top: 0;
   left: 0;
   width: 100%;
-  height: 18px;
+  height: 100%;
   background: none;
   border: none;
   cursor: pointer;
@@ -247,6 +252,14 @@ const containerClass = computed(() => ({
   padding: 8px 12px;
   scrollbar-color: var(--border-accent-faint) transparent;
   scrollbar-width: thin;
+}
+
+.lobby-chat:not(.lobby-chat--open) .messages {
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .message {

--- a/src/components/pages/Host.vue
+++ b/src/components/pages/Host.vue
@@ -21,6 +21,7 @@ import {
   LobbyAnnouncement,
   type LobbyEntry,
 } from "../../data/network/lobbyAnnouncement";
+import LobbyChat from "../organisms/LobbyChat.vue";
 
 const { onPlay } = defineProps<{
   onPlay: (key: string, map: Map | Config, settings: GameSettings) => void;
@@ -275,6 +276,8 @@ const handleSelectMap = async (config: Config, name: string) => {
       <button @click="handleStart" class="primary">Start</button>
       <button @click="handleBack" class="secondary">Back</button>
     </div>
+
+    <LobbyChat v-if="getServer()" :manager="getServer()!" />
   </div>
 </template>
 

--- a/src/components/pages/Join.vue
+++ b/src/components/pages/Join.vue
@@ -15,6 +15,7 @@ import TeamDialog from "../organisms/TeamDialog.vue";
 import { IPlayer } from "../types";
 import GameSettingsComponent from "../organisms/GameSettings.vue";
 import { Team } from "../../data/team";
+import LobbyChat from "../organisms/LobbyChat.vue";
 
 const { onPlay } = defineProps<{
   onPlay: (key: string, map: Map | Config, settings: GameSettings) => void;
@@ -185,6 +186,8 @@ const handleSave = (name: string, characters: string[]) => {
       </div>
 
       <GameSettingsComponent :settings="gameSettings" :map="map" />
+
+      <LobbyChat v-if="Client.instance" :manager="Client.instance" />
     </template>
 
     <div v-else class="options flex-list">

--- a/src/components/pages/Join.vue
+++ b/src/components/pages/Join.vue
@@ -78,6 +78,10 @@ const handleConnect = () => {
           team.value.setSize(message.settings.teamSize);
           break;
 
+        case MessageType.Chat:
+          Client.instance.ingestChat(message);
+          break;
+
         case MessageType.StartGame:
           onPlay(
             key.value,

--- a/src/data/network/__spec__/chat.spec.ts
+++ b/src/data/network/__spec__/chat.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../context", () => ({
+  getContextOrNull: () => null,
+  setFallbackManager: vi.fn(),
+  getLevel: vi.fn(),
+}));
+
+import { Manager } from "../manager";
+import { ChatEntry } from "../types";
+import { Character } from "../../entity/character";
+
+class TestManager extends Manager {
+  dealFallDamage(): void {}
+  isTrusted(_: Character): boolean {
+    return true;
+  }
+  sendChat(text: string): void {
+    this.appendChat("Tester", "#ffffff", text, true);
+  }
+  publicAppend(author: string, color: string, text: string, byMe: boolean) {
+    this.appendChat(author, color, text, byMe);
+  }
+}
+
+describe("Manager.appendChat", () => {
+  it("assigns incrementing ids and pushes entries in order", () => {
+    const m = new TestManager();
+    m.publicAppend("Alice", "#ff0000", "hello", false);
+    m.publicAppend("Bob", "#00ff00", "hi", false);
+
+    expect(m.chatLog.value).toHaveLength(2);
+    expect(m.chatLog.value[0]).toMatchObject({
+      author: "Alice",
+      color: "#ff0000",
+      text: "hello",
+    });
+    expect(m.chatLog.value[1].id).toBe(m.chatLog.value[0].id + 1);
+  });
+
+  it("caps history at 200 entries (oldest dropped)", () => {
+    const m = new TestManager();
+    for (let i = 0; i < 205; i++) {
+      m.publicAppend("U", "#fff", `msg ${i}`, false);
+    }
+    expect(m.chatLog.value).toHaveLength(200);
+    expect(m.chatLog.value[0].text).toBe("msg 5");
+    expect(m.chatLog.value[199].text).toBe("msg 204");
+  });
+
+  it("invokes onChatMessage hook with byMe flag", () => {
+    const m = new TestManager();
+    const calls: Array<[ChatEntry, boolean]> = [];
+    m.onChatMessage = (entry, byMe) => calls.push([entry, byMe]);
+
+    m.publicAppend("Alice", "#f00", "hi", false);
+    m.publicAppend("Me", "#0f0", "hi back", true);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0][1]).toBe(false);
+    expect(calls[1][1]).toBe(true);
+    expect(calls[1][0].text).toBe("hi back");
+  });
+});

--- a/src/data/network/client.ts
+++ b/src/data/network/client.ts
@@ -404,10 +404,6 @@ export class Client extends Manager {
         }
         break;
 
-      case MessageType.Chat:
-        this.ingestChat(message);
-        break;
-
       default:
         console.error("invalid message", message);
     }
@@ -431,9 +427,7 @@ export class Client extends Manager {
       return;
     }
     this.connection?.send({
-      type: MessageType.Chat,
-      author: "",
-      color: "",
+      type: MessageType.ChatRequest,
       text: trimmed,
     });
   }

--- a/src/data/network/client.ts
+++ b/src/data/network/client.ts
@@ -404,6 +404,15 @@ export class Client extends Manager {
         }
         break;
 
+      case MessageType.Chat: {
+        const byMe =
+          !!this._self &&
+          message.author === this._self.name &&
+          message.color === this._self.color;
+        this.appendChat(message.author, message.color, message.text, byMe);
+        break;
+      }
+
       default:
         console.error("invalid message", message);
     }
@@ -411,6 +420,19 @@ export class Client extends Manager {
 
   broadcast(message: Message) {
     this.connection?.send(message);
+  }
+
+  sendChat(text: string): void {
+    const trimmed = text.trim().slice(0, 200);
+    if (!trimmed) {
+      return;
+    }
+    this.connection?.send({
+      type: MessageType.Chat,
+      author: "",
+      color: "",
+      text: trimmed,
+    });
   }
 
   isTrusted(character: Character) {

--- a/src/data/network/client.ts
+++ b/src/data/network/client.ts
@@ -404,18 +404,21 @@ export class Client extends Manager {
         }
         break;
 
-      case MessageType.Chat: {
-        const byMe =
-          !!this._self &&
-          message.author === this._self.name &&
-          message.color === this._self.color;
-        this.appendChat(message.author, message.color, message.text, byMe);
+      case MessageType.Chat:
+        this.ingestChat(message);
         break;
-      }
 
       default:
         console.error("invalid message", message);
     }
+  }
+
+  ingestChat(message: Extract<Message, { type: MessageType.Chat }>): void {
+    const byMe =
+      !!this._self &&
+      message.author === this._self.name &&
+      message.color === this._self.color;
+    this.appendChat(message.author, message.color, message.text, byMe);
   }
 
   broadcast(message: Message) {

--- a/src/data/network/manager.ts
+++ b/src/data/network/manager.ts
@@ -1,6 +1,7 @@
 import Peer from "peerjs";
+import { ref, type Ref } from "vue";
 import { Player } from "./player";
-import { Popup, TurnState } from "./types";
+import { Popup, TurnState, ChatEntry } from "./types";
 import { KeyboardController } from "../controller/keyboardController";
 import { Spell, getSpellCost } from "../spells";
 import { Cursor } from "../../graphics/cursor/types";
@@ -49,6 +50,11 @@ export abstract class Manager {
   protected cursor: Cursor | null = null;
   private popups: Popup[] = [];
   protected stats: AccumulatedStat<unknown>[] | null = null;
+
+  public readonly chatLog: Ref<ChatEntry[]> = ref([]);
+  public onChatMessage?: (entry: ChatEntry, byMe: boolean) => void;
+  private chatIdCounter = 0;
+  private static readonly CHAT_HISTORY_LIMIT = 200;
 
   constructor(public readonly peer?: Peer) {
     Manager._instance = this;
@@ -344,6 +350,24 @@ export abstract class Manager {
       getLevel().setBrowserCursorVisibility(true);
     }
   }
+
+  protected appendChat(author: string, color: string, text: string, byMe: boolean) {
+    const entry: ChatEntry = {
+      id: ++this.chatIdCounter,
+      author,
+      color,
+      text,
+    };
+
+    this.chatLog.value.push(entry);
+    if (this.chatLog.value.length > Manager.CHAT_HISTORY_LIMIT) {
+      this.chatLog.value.shift();
+    }
+
+    this.onChatMessage?.(entry, byMe);
+  }
+
+  abstract sendChat(text: string): void;
 
   abstract isTrusted(character: Character): boolean;
 }

--- a/src/data/network/server.ts
+++ b/src/data/network/server.ts
@@ -527,7 +527,7 @@ export class Server extends Manager {
         player.resolveReady();
         break;
 
-      case MessageType.Chat: {
+      case MessageType.ChatRequest: {
         const text = (message.text ?? "").trim().slice(0, 200);
         if (!text || !player.color) {
           return;

--- a/src/data/network/server.ts
+++ b/src/data/network/server.ts
@@ -525,6 +525,23 @@ export class Server extends Manager {
 
       case MessageType.ClientReady:
         player.resolveReady();
+        break;
+
+      case MessageType.Chat: {
+        const text = (message.text ?? "").trim().slice(0, 200);
+        if (!text || !player.color) {
+          return;
+        }
+        const stamped: Message = {
+          type: MessageType.Chat,
+          author: player.name,
+          color: player.color,
+          text,
+        };
+        this.broadcast(stamped);
+        this.appendChat(stamped.author, stamped.color, stamped.text, player === this._self);
+        break;
+      }
     }
   }
 
@@ -726,6 +743,22 @@ export class Server extends Manager {
     for (let player of this.players) {
       player.connection?.send(message);
     }
+  }
+
+  sendChat(text: string): void {
+    const trimmed = text.trim().slice(0, 200);
+    if (!trimmed || !this._self) {
+      return;
+    }
+
+    const stamped: Message = {
+      type: MessageType.Chat,
+      author: this._self.name,
+      color: this._self.color,
+      text: trimmed,
+    };
+    this.broadcast(stamped);
+    this.appendChat(stamped.author, stamped.color, stamped.text, true);
   }
 
   create<T extends Spawnable>(entity: T) {

--- a/src/data/network/types.ts
+++ b/src/data/network/types.ts
@@ -29,6 +29,7 @@ export enum MessageType {
   Cast,
   EndGame,
   Chat,
+  ChatRequest,
 }
 
 export type Message =
@@ -171,6 +172,10 @@ export type Message =
       type: MessageType.Chat;
       author: string;
       color: string;
+      text: string;
+    }
+  | {
+      type: MessageType.ChatRequest;
       text: string;
     };
 

--- a/src/data/network/types.ts
+++ b/src/data/network/types.ts
@@ -28,6 +28,7 @@ export enum MessageType {
   Sink,
   Cast,
   EndGame,
+  Chat,
 }
 
 export type Message =
@@ -165,6 +166,12 @@ export type Message =
   | {
       type: MessageType.EndGame;
       stats: any[];
+    }
+  | {
+      type: MessageType.Chat;
+      author: string;
+      color: string;
+      text: string;
     };
 
 export interface Popup {
@@ -181,4 +188,11 @@ export enum TurnState {
   Killing,
   Finished,
   Rising,
+}
+
+export interface ChatEntry {
+  id: number;
+  author: string;
+  color: string;
+  text: string;
 }


### PR DESCRIPTION
### Description

Adds a chat to the host/join lobby. Messages route over the existing PeerJS connection through the host (which stamps author + color from the sending peer's `Player` record to prevent spoofing) and broadcast to all clients. Both `Server` and `Client` share a reactive `chatLog` on the `Manager` base class.

The UI is a parchment-style panel fixed at the bottom-right of the lobby. Closed it shows a 36px slice with the most recent line; clicking it slides up to a 400px panel with input + close. Magical glyph particles drift above the panel and a pop sound plays on every received message (except your own).

History is in-memory only, capped at 200 entries, and cleared when leaving the lobby.

### Manual check

- Run `yarn dev` and open http://localhost:3000 in two browser windows (one regular, one private/incognito)
- In window A click **Host**, note the room code shown
- In window B click **Join**, enter the room code, click **Connect**
- A parchment slice with a single line is visible at the bottom-right of both lobbies
- [ ] Hovering the closed slice in either window slides it up a few px and snaps back when you move away — the visible line stays centered before, during, and after the hover
- [ ] Clicking the slice slides the panel up to its full height with the input focused
- [ ] Type a message and press Enter on the host — it appears in both lobbies as `<HostName>: <text>`, with the host's player color on the name
- [ ] Type a message from the client side — same behavior, client's player color on the name
- [ ] Sending an empty/whitespace-only message does nothing
- [ ] The input cuts off at 200 characters (HTML maxlength)
- [ ] On every received message a pop sound plays and magical glyph particles drift up above the panel; no sound plays for messages you sent yourself
- [ ] Close the panel (× icon) — the closed slice shows the most recent line, vertically centered
- [ ] With the panel closed, send a message from the other peer — the closed panel briefly glows/flashes and the new line is what's shown
- [ ] Send 10+ messages while the panel is open — the message list scrolls; new messages auto-pin to the bottom
- [ ] While open, scroll up to read history, then have the other peer send a message — your scroll position is preserved (no auto-jump)
- [ ] Close the panel after scrolling up — closed slice still shows the latest line (not whatever you were reading)
- [ ] Leaving the lobby (Back / Disconnect) clears the chat history; rejoining starts fresh

<p align="right">ℹ️ Created with Claude Code</p>