### PR TITLE
Make gibs react to spells; refactor kick via withNearbyGibs

### DIFF
--- a/src/data/__spec__/mockContext.ts
+++ b/src/data/__spec__/mockContext.ts
@@ -12,9 +12,11 @@ export interface MockLevel {
   entities: Set<TickingEntity>;
   entityMap: Map<number, TickingEntity>;
   hurtables: Set<HurtableEntity>;
+  gibs: Set<unknown>;
   add: ReturnType<typeof vi.fn>;
   remove: ReturnType<typeof vi.fn>;
   withNearbyEntities: ReturnType<typeof vi.fn>;
+  withNearbyGibs: ReturnType<typeof vi.fn>;
   particleContainer: {
     addEmitter: ReturnType<typeof vi.fn>;
     destroyEmitter: ReturnType<typeof vi.fn>;
@@ -49,9 +51,11 @@ export function createMockLevel(): MockLevel {
     entities: new Set(),
     entityMap: new Map(),
     hurtables: new Set(),
+    gibs: new Set(),
     add: vi.fn(),
     remove: vi.fn(),
     withNearbyEntities: vi.fn(),
+    withNearbyGibs: vi.fn(),
     particleContainer: {
       addEmitter: vi.fn(),
       destroyEmitter: vi.fn(),

--- a/src/data/damage/__spec__/explosiveDamage.spec.ts
+++ b/src/data/damage/__spec__/explosiveDamage.spec.ts
@@ -1,7 +1,19 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../../sound/controllableSound", () => ({
+  ControllableSound: {
+    fromEntity: vi.fn(),
+  },
+}));
+
 import { ExplosiveDamage } from "../explosiveDamage";
 import { HurtableEntity } from "../../entity/types";
 import { Level } from "../../map/level";
+import {
+  installMockContext,
+  clearMockContext,
+  MockLevel,
+} from "../../__spec__/mockContext";
 
 function createMockEntity(
   id: number,
@@ -156,6 +168,57 @@ describe("ExplosiveDamage", () => {
       expect(restored.x).toBe(15);
       expect(restored.y).toBe(25);
       expect(restored.serialize()[2]).toBe(8);
+    });
+  });
+
+  describe("gib push", () => {
+    let level: MockLevel;
+
+    beforeEach(() => {
+      const mocks = installMockContext();
+      level = mocks.level;
+      level.terrain.subtractCircle.mockReturnValue(false);
+      level.terrain.draw.mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      clearMockContext();
+    });
+
+    it("queries level.withNearbyGibs with the explosion epicenter", () => {
+      level.withNearbyGibs.mockImplementation(() => {});
+      const damage = new ExplosiveDamage(10, 20, 16, 5, 1);
+      damage.damage();
+
+      expect(level.withNearbyGibs).toHaveBeenCalledWith(
+        10 * 6,
+        20 * 6,
+        (16 + 5) * 6,
+        expect.any(Function)
+      );
+    });
+
+    it("applies force to gibs scaled by distance falloff", () => {
+      const gib = {
+        getCenter: () => [10 * 6 + 30, 20 * 6],
+        applyForce: vi.fn(),
+      };
+      level.withNearbyGibs.mockImplementation(
+        (x: number, y: number, range: number, fn: Function) => {
+          fn(gib, 30 * 30);
+        }
+      );
+
+      const damage = new ExplosiveDamage(10, 20, 16, 8, 1);
+      damage.damage();
+
+      expect(gib.applyForce).toHaveBeenCalledTimes(1);
+      const force = gib.applyForce.mock.calls[0][1];
+      // Direction is rightward (gib east of epicenter)
+      expect(force.direction).toBeCloseTo(0, 1);
+      // Power is positive and less than full (distance > 0)
+      expect(force.power).toBeGreaterThan(0);
+      expect(force.power).toBeLessThan(8);
     });
   });
 });

--- a/src/data/damage/__spec__/impactDamage.spec.ts
+++ b/src/data/damage/__spec__/impactDamage.spec.ts
@@ -147,4 +147,53 @@ describe("ImpactDamage", () => {
       expect(serialized[0][3]).toBe(direction);
     });
   });
+
+  describe("gib push", () => {
+    let level: MockLevel;
+
+    beforeEach(() => {
+      const mocks = installMockContext();
+      level = mocks.level;
+      level.terrain.subtractCircle.mockReturnValue(false);
+    });
+
+    afterEach(() => {
+      clearMockContext();
+    });
+
+    it("queries level.withNearbyGibs at the impact center", () => {
+      level.withNearbyGibs.mockImplementation(() => {});
+      const damage = new ImpactDamage(10, 20, 0, 15);
+      damage.damage();
+
+      expect(level.withNearbyGibs).toHaveBeenCalledWith(
+        (10 + 3) * 6,
+        (20 + 8) * 6,
+        16 * 6,
+        expect.any(Function)
+      );
+    });
+
+    it("applies radial outward force to nearby gibs", () => {
+      const cx = (10 + 3) * 6;
+      const cy = (20 + 8) * 6;
+      const gib = {
+        getCenter: () => [cx + 30, cy],
+        applyForce: vi.fn(),
+      };
+      level.withNearbyGibs.mockImplementation(
+        (x: number, y: number, range: number, fn: Function) => {
+          fn(gib, 900);
+        }
+      );
+
+      const damage = new ImpactDamage(10, 20, 0, 15);
+      damage.damage();
+
+      expect(gib.applyForce).toHaveBeenCalledTimes(1);
+      const force = gib.applyForce.mock.calls[0][1];
+      expect(force.direction).toBeCloseTo(0, 1);
+      expect(force.power).toBeGreaterThan(0);
+    });
+  });
 });

--- a/src/data/damage/explosiveDamage.ts
+++ b/src/data/damage/explosiveDamage.ts
@@ -101,6 +101,22 @@ export class ExplosiveDamage implements DamageSource {
     }
 
     this.getTargets().damage(this);
+
+    const gibRange = (this.range + 5) * 6;
+    getLevel().withNearbyGibs(
+      this.x * 6,
+      this.y * 6,
+      gibRange,
+      (gib, distSq) => {
+        const [gx, gy] = gib.getCenter();
+        const distance = Math.sqrt(distSq);
+        const falloff = (gibRange - distance) / gibRange;
+        gib.applyForce(this, {
+          power: this.power * falloff,
+          direction: Math.atan2(gy - this.y * 6, gx - this.x * 6),
+        });
+      }
+    );
   }
 
   serialize() {

--- a/src/data/damage/fallDamage.ts
+++ b/src/data/damage/fallDamage.ts
@@ -121,6 +121,14 @@ export class FallDamage implements DamageSource {
     );
 
     this.getTargets().damage(this);
+
+    const sx = (this.x + data.xOffset) * 6;
+    const sy = (this.y + data.yOffset) * 6;
+    getLevel().withNearbyGibs(sx, sy, data.range, (gib) => {
+      const [gx] = gib.getCenter();
+      const direction = sx < gx ? -Math.PI / 3 : Math.PI + Math.PI / 3;
+      gib.applyForce(this, { power: data.power, direction });
+    });
   }
 
   getTargets() {

--- a/src/data/damage/impactDamage.ts
+++ b/src/data/damage/impactDamage.ts
@@ -7,6 +7,9 @@ import { Sound } from "../../sound";
 import { Player } from "../network/player";
 import { getLevel } from "../context";
 
+const IMPACT_GIB_POWER = 2;
+const IMPACT_GIB_RANGE = 16 * 6;
+
 export class ImpactDamage implements DamageSource {
   public readonly type = DamageSourceType.Impact;
 
@@ -26,6 +29,16 @@ export class ImpactDamage implements DamageSource {
     }
 
     this.getTargets().damage(this);
+
+    const cx = (this.x + 3) * 6;
+    const cy = (this.y + 8) * 6;
+    getLevel().withNearbyGibs(cx, cy, IMPACT_GIB_RANGE, (gib) => {
+      const [gx, gy] = gib.getCenter();
+      gib.applyForce(this, {
+        power: IMPACT_GIB_POWER,
+        direction: Math.atan2(gy - cy, gx - cx),
+      });
+    });
   }
 
   serialize() {

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -34,13 +34,12 @@ import { getLevel, getManager, getServer } from "../context";
 import { CharacterHealth } from "./characterHealth";
 import { CharacterCombat } from "./characterCombat";
 import { CharacterMovement } from "./characterMovement";
-import { Gib } from "./gib";
 
 // Start bouncing when impact is greater than this value
 const BOUNCE_TRIGGER = 3.8;
 const SMOKE_TRIGGER = 2;
 const KICK_VELOCITY_THRESHOLD_SQUARED = 0.04;
-const KICK_RADIUS_SQUARED = 30 * 30;
+const KICK_RADIUS = 30;
 const KICK_SCALE = 0.5;
 const KICK_LIFT = 0.6;
 const KICK_SPIN = 0.3;
@@ -369,18 +368,11 @@ export class Character extends Container implements HurtableEntity, Syncable {
     const xV = this.body.xVelocity;
     const xVAbs = Math.abs(xV);
 
-    for (const entity of getLevel().entities) {
-      if (!(entity instanceof Gib)) continue;
-
-      const dx = entity.position.x - cx;
-      const dy = entity.position.y - cy;
-      const distSquared = dx * dx + dy * dy;
-      if (distSquared >= KICK_RADIUS_SQUARED) continue;
-
-      entity.body.addVelocity(xV * KICK_SCALE, -xVAbs * KICK_LIFT);
-      entity.spin(Math.sign(xV) * xVAbs * KICK_SPIN);
-      entity.bleed();
-    }
+    getLevel().withNearbyGibs(cx, cy, KICK_RADIUS, (gib) => {
+      gib.body.addVelocity(xV * KICK_SCALE, -xVAbs * KICK_LIFT);
+      gib.spin(Math.sign(xV) * xVAbs * KICK_SPIN);
+      gib.bleed();
+    });
   }
 
   tick(dt: number) {

--- a/src/data/entity/gib/index.ts
+++ b/src/data/entity/gib/index.ts
@@ -98,7 +98,11 @@ export class Gib extends Sprite implements TickingEntity {
   }
 
   getCenter(): [number, number] {
-    return [this.position.x, this.position.y];
+    // Read from body.precisePosition so callers get a stable center before
+    // tick() has run (e.g. a spell hitting on the spawn frame). this.position
+    // is only authoritative once tick() writes it.
+    const [bx, by] = this.body.precisePosition;
+    return [bx * 6 + this.width / 2, by * 6 + this.height / 2];
   }
 
   applyForce(_source: DamageSource | null, force: Force) {

--- a/src/data/entity/gib/index.ts
+++ b/src/data/entity/gib/index.ts
@@ -3,6 +3,8 @@ import { CollisionMask } from "../../collision/collisionMask";
 import { SimpleBody } from "../../collision/simpleBody";
 import { TickingEntity } from "../types";
 import { getLevel } from "../../context";
+import { Force } from "../../damage/targetList";
+import { DamageSource } from "../../damage/types";
 
 export interface GibConfig {
   texture: Texture;
@@ -31,6 +33,7 @@ const AIR_SPIN_DRAG = 0.99;
 const WATER_SPIN_DRAG = 0.92;
 const GROUND_SPIN_DRAG = 0.6;
 const GROUND_CONTACT_TICKS = 3;
+const SPIN_FROM_FORCE = 0.3;
 
 export class Gib extends Sprite implements TickingEntity {
   public readonly body: SimpleBody;
@@ -92,6 +95,18 @@ export class Gib extends Sprite implements TickingEntity {
 
   spin(amount: number) {
     this.angularVelocity += amount;
+  }
+
+  getCenter(): [number, number] {
+    return [this.position.x, this.position.y];
+  }
+
+  applyForce(_source: DamageSource | null, force: Force) {
+    const vx = Math.cos(force.direction) * force.power;
+    const vy = Math.sin(force.direction) * force.power;
+    this.body.addVelocity(vx, vy);
+    this.angularVelocity += vx * SPIN_FROM_FORCE;
+    this.bleed();
   }
 
   tick(dt: number) {

--- a/src/data/map/level.ts
+++ b/src/data/map/level.ts
@@ -27,6 +27,7 @@ import { Viewport } from "./viewport";
 import { Manager } from "../network/manager";
 import { ellipse9x16 } from "../collision/precomputed/circles";
 import { getContextOrNull } from "../context";
+import { Gib } from "../entity/gib";
 
 TextureStyle.defaultOptions.scaleMode = "nearest";
 
@@ -62,6 +63,7 @@ export class Level {
   public readonly entities = new Set<TickingEntity>();
   public readonly entityMap = new Map<number, TickingEntity>();
   public readonly hurtables = new Set<HurtableEntity>();
+  public readonly gibs = new Set<Gib>();
   public readonly syncables: Record<Priority, Syncable[]> = {
     [Priority.Dynamic]: [],
     [Priority.Low]: [],
@@ -267,6 +269,10 @@ export class Level {
       if ("priority" in object) {
         this.syncables[object.priority].push(object);
       }
+
+      if (object instanceof Gib) {
+        this.gibs.add(object);
+      }
     }
   }
 
@@ -303,6 +309,10 @@ export class Level {
           arr.splice(index, 1);
         }
       }
+
+      if (object instanceof Gib) {
+        this.gibs.delete(object);
+      }
     }
   }
 
@@ -318,6 +328,24 @@ export class Level {
       const distanceSquared = (ex - x) ** 2 + (ey - y) ** 2;
       if (distanceSquared < rangeSquared) {
         if (fn(entity, distanceSquared)) {
+          return;
+        }
+      }
+    }
+  }
+
+  withNearbyGibs(
+    x: number,
+    y: number,
+    range: number,
+    fn: (gib: Gib, distanceSquared: number) => void | boolean
+  ) {
+    const rangeSquared = range ** 2;
+    for (let gib of this.gibs) {
+      const [gx, gy] = gib.getCenter();
+      const distanceSquared = (gx - x) ** 2 + (gy - y) ** 2;
+      if (distanceSquared < rangeSquared) {
+        if (fn(gib, distanceSquared)) {
           return;
         }
       }

--- a/src/data/spells/windBlast.ts
+++ b/src/data/spells/windBlast.ts
@@ -4,6 +4,7 @@ import { Character } from "../entity/character";
 import { EntityType, HurtableEntity, Spawnable } from "../entity/types";
 import { TurnState } from "../network/types";
 import { rotatedRectangle6x24 } from "../collision/precomputed/rectangles";
+import { CollisionMask } from "../collision/collisionMask";
 import { getIndexFromAngle } from "../collision/util";
 import { TargetList } from "../damage/targetList";
 import { GenericDamage } from "../damage/genericDamage";
@@ -20,6 +21,10 @@ export class WindBlast extends Container implements Spawnable {
 
   private rx = 0;
   private ry = 0;
+  private targetX: number;
+  private targetY: number;
+  private adjustedDirection: number;
+  private rect: CollisionMask;
   private triggered = false;
   private gibsTriggered = false;
 
@@ -38,6 +43,17 @@ export class WindBlast extends Container implements Spawnable {
     this.position.set(x * 6, y * 6);
     this.rx = Math.round(x);
     this.ry = Math.round(y);
+
+    this.targetX = this.rx + (character.direction === 1 ? 0 : -24);
+    this.targetY = this.ry - 12;
+
+    // Bias the push direction upward — characters have a lot of friction
+    // with the ground, so a purely horizontal blast barely moves them.
+    const diff = angleDiff(direction, -Math.PI / 2);
+    const max = Math.PI / 6;
+    this.adjustedDirection = direction + Math.max(-max, Math.min(max, diff));
+
+    this.rect = rotatedRectangle6x24[getIndexFromAngle(direction - Math.PI / 2)];
 
     const atlas = AssetsContainer.instance.assets!["atlas"];
 
@@ -75,35 +91,31 @@ export class WindBlast extends Container implements Spawnable {
     const triggerFrameReached =
       this.sprite.currentFrame > WindBlast.triggerFrame;
 
-    // Change the direction a bit upwards for a better effect (Characters have a lot of friction with the ground)
-    const diff = angleDiff(this.direction, -Math.PI / 2);
-    const max = Math.PI / 6;
-    const adjustedDirection =
-      this.direction + Math.max(-max, Math.min(max, diff));
-
-    const x = this.rx + (this.character.direction === 1 ? 0 : -24);
-    const y = this.ry - 12;
-
     if (triggerFrameReached && !this.gibsTriggered) {
       this.gibsTriggered = true;
 
       const gibPower =
         this.power *
         (0.7 + getManager().getElementValue(Element.Elemental) * 0.3);
-      const rect =
-        rotatedRectangle6x24[
-          getIndexFromAngle(this.direction - Math.PI / 2)
-        ];
 
-      getLevel().withNearbyGibs(x * 6, y * 6, 32 * 6, (gib) => {
-        const [gx, gy] = gib.body.position;
-        if (rect.collidesWith(gib.body.mask, gx - x, gy - y)) {
-          gib.applyForce(null, {
-            direction: adjustedDirection,
-            power: gibPower,
-          });
+      // withNearbyGibs filters in pixel space (×6); rect.collidesWith works
+      // in tile space, so the predicate uses gib.body.position directly.
+      getLevel().withNearbyGibs(
+        this.targetX * 6,
+        this.targetY * 6,
+        32 * 6,
+        (gib) => {
+          const [gx, gy] = gib.body.position;
+          if (
+            this.rect.collidesWith(gib.body.mask, gx - this.targetX, gy - this.targetY)
+          ) {
+            gib.applyForce(null, {
+              direction: this.adjustedDirection,
+              power: gibPower,
+            });
+          }
         }
-      });
+      );
     }
 
     if (!getServer()) {
@@ -114,17 +126,24 @@ export class WindBlast extends Container implements Spawnable {
       this.triggered = true;
 
       const entities: HurtableEntity[] = [];
-      getLevel().withNearbyEntities(x * 6, y * 6, 32 * 6, (entity) => {
-        const [ex, ey] = entity.body.position;
+      getLevel().withNearbyEntities(
+        this.targetX * 6,
+        this.targetY * 6,
+        32 * 6,
+        (entity) => {
+          const [ex, ey] = entity.body.position;
 
-        if (
-          rotatedRectangle6x24[
-            getIndexFromAngle(this.direction - Math.PI / 2)
-          ].collidesWith(entity.body.mask, ex - x, ey - y)
-        ) {
-          entities.push(entity);
+          if (
+            this.rect.collidesWith(
+              entity.body.mask,
+              ex - this.targetX,
+              ey - this.targetY
+            )
+          ) {
+            entities.push(entity);
+          }
         }
-      });
+      );
 
       const targetList = new TargetList(
         entities
@@ -147,7 +166,7 @@ export class WindBlast extends Container implements Spawnable {
             entityId: entity.id,
             damage: 0,
             force: {
-              direction: adjustedDirection,
+              direction: this.adjustedDirection,
               power:
                 this.power *
                 (0.7 +

--- a/src/data/spells/windBlast.ts
+++ b/src/data/spells/windBlast.ts
@@ -21,6 +21,7 @@ export class WindBlast extends Container implements Spawnable {
   private rx = 0;
   private ry = 0;
   private triggered = false;
+  private gibsTriggered = false;
 
   public id = -1;
   public readonly type = EntityType.WindBlast;
@@ -71,21 +72,46 @@ export class WindBlast extends Container implements Spawnable {
   }
 
   tick(dt: number) {
+    const triggerFrameReached =
+      this.sprite.currentFrame > WindBlast.triggerFrame;
+
+    // Change the direction a bit upwards for a better effect (Characters have a lot of friction with the ground)
+    const diff = angleDiff(this.direction, -Math.PI / 2);
+    const max = Math.PI / 6;
+    const adjustedDirection =
+      this.direction + Math.max(-max, Math.min(max, diff));
+
+    const x = this.rx + (this.character.direction === 1 ? 0 : -24);
+    const y = this.ry - 12;
+
+    if (triggerFrameReached && !this.gibsTriggered) {
+      this.gibsTriggered = true;
+
+      const gibPower =
+        this.power *
+        (0.7 + getManager().getElementValue(Element.Elemental) * 0.3);
+      const rect =
+        rotatedRectangle6x24[
+          getIndexFromAngle(this.direction - Math.PI / 2)
+        ];
+
+      getLevel().withNearbyGibs(x * 6, y * 6, 32 * 6, (gib) => {
+        const [gx, gy] = gib.body.position;
+        if (rect.collidesWith(gib.body.mask, gx - x, gy - y)) {
+          gib.applyForce(null, {
+            direction: adjustedDirection,
+            power: gibPower,
+          });
+        }
+      });
+    }
+
     if (!getServer()) {
       return;
     }
 
-    if (this.sprite.currentFrame > WindBlast.triggerFrame && !this.triggered) {
+    if (triggerFrameReached && !this.triggered) {
       this.triggered = true;
-
-      const x = this.rx + (this.character.direction === 1 ? 0 : -24);
-      const y = this.ry - 12;
-
-      // Change the direction a bit upwards for a better effect (Characters have a lot of friction with the ground)
-      const diff = angleDiff(this.direction, -Math.PI / 2);
-      const max = Math.PI / 6;
-      const adjustedDirection =
-        this.direction + Math.max(-max, Math.min(max, diff));
 
       const entities: HurtableEntity[] = [];
       getLevel().withNearbyEntities(x * 6, y * 6, 32 * 6, (entity) => {


### PR DESCRIPTION
## Summary

- Gibs gain `applyForce(source, force)` and join a new `level.gibs` spatial index queried via `level.withNearbyGibs(...)` — parallel to `hurtables`, not part of it, so existing spell targeting is unchanged.
- `ExplosiveDamage`, `ImpactDamage`, and `FallDamage` now push nearby gibs from their `damage()` pass (runs on every client after deserialization). No gib state crosses the wire — each client resolves its own hits locally.
- `WindBlast` pushes gibs in `tick()` **before** the server-only early return so every client participates, gated by a new `gibsTriggered` flag.
- `Character.kickNearbyGibs` refactored to use `withNearbyGibs` instead of iterating every ticking entity + `instanceof Gib`.

## Design notes

- Gibs are **force-only**: no HP, no destruction from spells, killbox still keeps them floating. They die only via the existing off-map cleanup.
- Gibs are intentionally **not synced** — `level.gibs` is per-client and positions drift between clients. That's accepted for cosmetic body parts and avoids ~7 extra `Spawn` messages per character death.
- Subtle gotcha: placing `if (object instanceof Gib)` before the `"priority" in object` check in `Level.add`/`Level.remove` widened `object.priority` to `unknown`. Moved the Gib check to after the priority block. No type assertions needed.

## Test plan

- [x] `yarn check-types` — clean (only pre-existing scripts/Jimp errors that also exist on `main`)
- [x] `yarn test --run` — 237/237 passing (4 new gib-push tests: 2 for `ExplosiveDamage`, 2 for `ImpactDamage`)
- [ ] **Manual / visual** (recommended before merge):
  - [ ] Fireball / bomb near gibs — radial scatter, falloff visible
  - [ ] WindBlast across a pile of gibs — directional blow
  - [ ] Character running through gibs — kick still works (regression)
  - [ ] Sword landing impact — gibs hop outward
  - [ ] Killbox — gibs still float, not destroyed

🤖 Generated with [Claude Code](https://claude.com/claude-code)