### PR TITLE
Tune platformer physics and ladder controls

### DIFF
--- a/src/data/bot/path.ts
+++ b/src/data/bot/path.ts
@@ -3,7 +3,13 @@ import { Command, CommandType, Key } from "../controller/controller";
 import { Character } from "../entity/character";
 import { getLevel } from "../context";
 import { Edge, EdgeType } from "./edge";
-import { MIN_LAUNCH_SPEED, runUpDistanceFromRest } from "./physics";
+import {
+  MIN_LAUNCH_SPEED,
+  WALK_TERMINAL_VELOCITY,
+  runUpDistanceFromRest,
+} from "./physics";
+
+const REVERSE_INPUT_SPEED = WALK_TERMINAL_VELOCITY / 2;
 
 export class Path {
   private static WALKING_NEXT_DISTANCE = 12;
@@ -101,10 +107,13 @@ export class Path {
         }
       } else if (
         destination.to.x > x + offset &&
-        (sameDirection || this.character.body.xVelocity < 0.35)
+        (sameDirection || this.character.body.xVelocity < REVERSE_INPUT_SPEED)
       ) {
         commands.push({ type: CommandType.KeyDown, key: Key.Right });
-      } else if (sameDirection || this.character.body.xVelocity > -0.35) {
+      } else if (
+        sameDirection ||
+        this.character.body.xVelocity > -REVERSE_INPUT_SPEED
+      ) {
         commands.push({ type: CommandType.KeyDown, key: Key.Left });
       }
 
@@ -183,11 +192,10 @@ export class Path {
           ) {
             // Walk backwards until we have enough room to accelerate.
             const needed = runUpDistanceFromRest() - Math.max(0, distToLaunch);
-            // Convert pixels-to-walk-back into frames. Terminal velocity is ~0.667 px/frame,
-            // so `needed / 0.667 ≈ needed * 1.5` frames at top speed.
+            // Convert pixels-to-walk-back into frames by dividing by terminal velocity.
             // We're walking backwards from rest so the average velocity is lower — this
             // conversion already accounts for that, no extra margin needed.
-            this.prerollFrames = Math.ceil(needed * 1.5);
+            this.prerollFrames = Math.ceil(needed / WALK_TERMINAL_VELOCITY);
           }
         }
       }

--- a/src/data/collision/__spec__/body.spec.ts
+++ b/src/data/collision/__spec__/body.spec.ts
@@ -23,7 +23,7 @@ describe("body", () => {
     }
 
     const [x, y] = body.precisePosition;
-    const [expectedX, expectedY] = [14, -1];
+    const [expectedX, expectedY] = [16, -1];
     expect(x).toBeCloseTo(expectedX, 0);
     expect(y).toBeCloseTo(expectedY, 0);
   });

--- a/src/data/collision/body.ts
+++ b/src/data/collision/body.ts
@@ -18,6 +18,7 @@ const MIN_MOVEMENT = 0.01;
 const JUMP_COOLDOWN = 15;
 const JUMP_CHARGE_TIME = 5;
 const LADDER_SPEED = 0.6;
+const LADDER_X_CONTROL = 0.5;
 
 interface Config {
   mask: CollisionMask;
@@ -77,7 +78,7 @@ export class Body implements PhysicsBody {
       onCollide,
       roundness = 0,
       bounciness = 0,
-    }: Config
+    }: Config,
   ) {
     this.mask = mask;
     this.gravity = gravity;
@@ -176,7 +177,13 @@ export class Body implements PhysicsBody {
     let yAcc = this._onLadder ? 0 : this.gravity;
     let yDiff = this.yVelocity * dt + yAcc * idt;
     let xAcc =
-      this.walkDirection * SPEED * (this._grounded ? 1 : this.airControl);
+      this.walkDirection *
+      SPEED *
+      (this._grounded
+        ? 1
+        : this._onLadder
+          ? LADDER_X_CONTROL
+          : this.airControl);
 
     if (
       this.lastRollDirection &&
@@ -204,7 +211,7 @@ export class Body implements PhysicsBody {
       this._grounded = this.surface.collidesWith(
         this.mask,
         this.rX,
-        alignY(this.y + yDiff)
+        alignY(this.y + yDiff),
       );
 
       if (this._grounded) {
@@ -260,7 +267,7 @@ export class Body implements PhysicsBody {
       const ceiled = this.surface.collidesWith(
         this.mask,
         this.rX,
-        alignY(this.y + yDiff)
+        alignY(this.y + yDiff),
       );
 
       if (ceiled) {
@@ -341,6 +348,33 @@ export class Body implements PhysicsBody {
     this.x += xDiff;
     this.xVelocity += xAcc * dt;
     this.rX = alignX(this.x);
+
+    // Snap down to ground when walking off small downhill slopes (<=45° per
+    // tick), so the character stays grounded and can keep jumping. Drop budget
+    // is bounded by horizontal step taken this tick — cliffs and steep ledges
+    // exceed the budget and fall through normally.
+    if (
+      this._grounded &&
+      !this._onLadder &&
+      xDiff !== 0 &&
+      this.yVelocity >= 0 &&
+      !this.surface.collidesWith(this.mask, this.rX, this.rY + 1)
+    ) {
+      const maxSnap = Math.max(1, Math.ceil(Math.abs(xDiff)));
+      let snapTo = 0;
+      for (let step = 2; step <= maxSnap + 1; step++) {
+        if (this.surface.collidesWith(this.mask, this.rX, this.rY + step)) {
+          snapTo = step - 1;
+          break;
+        }
+      }
+      if (snapTo > 0) {
+        this.y += snapTo;
+        this.rY = alignY(this.y);
+      } else {
+        this._grounded = false;
+      }
+    }
 
     // If we're on the ground and barely moving, go to sleep.
     if (

--- a/src/data/collision/physicsConstants.ts
+++ b/src/data/collision/physicsConstants.ts
@@ -2,8 +2,8 @@
 // Imported by Body itself, by the bot's `physics.ts` (which derives jump
 // reachability from these), and by physics tests.
 export const GRAVITY = 0.2;
-export const AIR_CONTROL = 0.3;
+export const AIR_CONTROL = 0.4;
 export const GROUND_FRICTION = 0.88;
 export const AIR_FRICTION = 0.98;
-export const SPEED = 0.08;
+export const SPEED = 0.09;
 export const JUMP_STRENGTH = 3.3;

--- a/src/data/entity/character.ts
+++ b/src/data/entity/character.ts
@@ -35,8 +35,10 @@ import { CharacterHealth } from "./characterHealth";
 import { CharacterCombat } from "./characterCombat";
 import { CharacterMovement } from "./characterMovement";
 
-// Start bouncing when impact is greater than this value
-const BOUNCE_TRIGGER = 3.8;
+// Start bouncing when impact is greater than this value. The active character
+// gets a slightly more forgiving threshold than the rest of the team.
+const BOUNCE_TRIGGER_ACTIVE = 4;
+const BOUNCE_TRIGGER_PASSIVE = 3.6;
 const SMOKE_TRIGGER = 2;
 const KICK_VELOCITY_THRESHOLD_SQUARED = 0.04;
 const KICK_RADIUS = 30;
@@ -345,9 +347,14 @@ export class Character extends Container implements HurtableEntity, Syncable {
       getLevel().add(new SmokePuff(x * 6 + 18, y * 6 + 72));
     }
 
+    const bounceTrigger =
+      getManager().getActiveCharacter() === this
+        ? BOUNCE_TRIGGER_ACTIVE
+        : BOUNCE_TRIGGER_PASSIVE;
+
     if (
-      Math.abs(this.body.xVelocity) > BOUNCE_TRIGGER ||
-      Math.abs(this.body.yVelocity) > BOUNCE_TRIGGER
+      Math.abs(this.body.xVelocity) > bounceTrigger ||
+      Math.abs(this.body.yVelocity) > bounceTrigger
     ) {
       getManager().dealFallDamage(x, y, this);
     }

--- a/src/data/entity/characterMovement.ts
+++ b/src/data/entity/characterMovement.ts
@@ -4,13 +4,17 @@ import { Wings } from "./wings";
 import { getLevel, getManager } from "../context";
 import type { Character } from "./character";
 
-const MAX_LADDER_MOUNT_SPEED = 1;
+const MAX_LADDER_MOUNT_SPEED = 1.5;
 const JUMP_GRACE_TIME = 3;
+const LADDER_DISMOUNT_BOOST = 0.6;
 
 export class CharacterMovement {
   private wasUp = false;
+  private wasLeft = false;
+  private wasRight = false;
   public lastGroundedTime = 0;
   private wings?: Wings;
+  private lastFoundLadder: BBox | null = null;
 
   constructor(private character: Character) {}
 
@@ -64,16 +68,67 @@ export class CharacterMovement {
       this.character.body.mountLadder();
     }
 
+    const leftHeld =
+      controller.isKeyDown(Key.Left) || controller.isKeyDown(Key.A);
+    const rightHeld =
+      controller.isKeyDown(Key.Right) || controller.isKeyDown(Key.D);
+
+    if (foundLadder) this.lastFoundLadder = foundLadder;
+
     if (this.character.body.onLadder) {
-      if (!foundLadder) {
+      const ladder = foundLadder ?? this.lastFoundLadder;
+      if (!ladder) {
         if (getManager().isTrusted(this.character)) {
           this.character.body.unmountLadder();
         }
+        this.wasLeft = leftHeld;
+        this.wasRight = rightHeld;
         return;
       }
 
+      const [px, py] = this.character.body.precisePosition;
+      const atLeftEdge = px <= ladder.left - 6 + 0.5;
+      const atRightEdge = px >= ladder.right - 0.5;
+
+      if (
+        leftHeld &&
+        !this.wasLeft &&
+        atLeftEdge &&
+        getManager().isTrusted(this.character)
+      ) {
+        this.character.move(ladder.left - 6 - 1, py);
+        this.character.body.unmountLadder();
+        this.character.body.addVelocity(-LADDER_DISMOUNT_BOOST, 0);
+        this.wasUp = isUp;
+        this.wasLeft = leftHeld;
+        this.wasRight = rightHeld;
+        return;
+      }
+      if (
+        rightHeld &&
+        !this.wasRight &&
+        atRightEdge &&
+        getManager().isTrusted(this.character)
+      ) {
+        this.character.move(ladder.right + 1, py);
+        this.character.body.unmountLadder();
+        this.character.body.addVelocity(LADDER_DISMOUNT_BOOST, 0);
+        this.wasUp = isUp;
+        this.wasLeft = leftHeld;
+        this.wasRight = rightHeld;
+        return;
+      }
+
+      if (px > ladder.right) {
+        this.character.move(ladder.right, py);
+        this.character.body.xVelocity = 0;
+      } else if (px < ladder.left - 6) {
+        this.character.move(ladder.left - 6, py);
+        this.character.body.xVelocity = 0;
+      }
+
       if (isUp) {
-        if (this.character.body.precisePosition[1] + 8 > foundLadder.top) {
+        if (this.character.body.precisePosition[1] + 8 > ladder.top) {
           this.character.body.setLadderDirection(-1);
           this.character.animate("Climb");
         } else {
@@ -97,8 +152,13 @@ export class CharacterMovement {
       }
 
       this.wasUp = isUp;
+      this.wasLeft = leftHeld;
+      this.wasRight = rightHeld;
       return;
     }
+
+    this.wasLeft = leftHeld;
+    this.wasRight = rightHeld;
 
     if (!isUp) {
       return;
@@ -130,7 +190,15 @@ export class CharacterMovement {
 
     this.character.updateLookDirection(controller);
 
-    if (controller.isKeyDown(Key.Left) || controller.isKeyDown(Key.A)) {
+    const ladder = this.character.body.onLadder ? this.lastFoundLadder : null;
+    const [px] = this.character.body.precisePosition;
+    const atLeftEdge = !!ladder && px <= ladder.left - 6;
+    const atRightEdge = !!ladder && px >= ladder.right;
+
+    if (
+      (controller.isKeyDown(Key.Left) || controller.isKeyDown(Key.A)) &&
+      !atLeftEdge
+    ) {
       this.character.body.walk(-1);
       this.character.player.stats.distanceWalked++;
 
@@ -140,7 +208,10 @@ export class CharacterMovement {
       }
     }
 
-    if (controller.isKeyDown(Key.Right) || controller.isKeyDown(Key.D)) {
+    if (
+      (controller.isKeyDown(Key.Right) || controller.isKeyDown(Key.D)) &&
+      !atRightEdge
+    ) {
       this.character.body.walk(1);
       this.character.player.stats.distanceWalked++;
 

--- a/src/data/entity/characterMovement.ts
+++ b/src/data/entity/characterMovement.ts
@@ -142,7 +142,7 @@ export class CharacterMovement {
         }
       } else if (
         controller.isKeyDown(Key.Down) ||
-        controller.isKeyDown(Key.D)
+        controller.isKeyDown(Key.S)
       ) {
         this.character.body.setLadderDirection(1);
         this.character.animate("Climb");


### PR DESCRIPTION
### Description

Iterative tuning to make the character feel less brittle in the air and to give ladders proper "wall" behaviour at the edges.

- Higher `AIR_CONTROL` and a slightly higher walking `SPEED`; snap-to-floor on shallow downhill bumps so the character stays grounded.
- Faster horizontal motion on ladders via `LADDER_X_CONTROL` (between air and ground control).
- Ladder edges act as walls — body is clamped to the ladder bounds and `walk()` is suppressed when held into the edge. Dismount requires releasing and re-pressing the direction, mirroring the existing `wasUp` jump-off-top pattern; the dismount nudges the body just past the bound (so the auto-mount in `Body.tick` doesn't immediately catch it again) and applies a small `LADDER_DISMOUNT_BOOST`.
- More forgiving `MAX_LADDER_MOUNT_SPEED` so faster falls still grab the ladder.
- Fall-damage threshold split: the active character (`BOUNCE_TRIGGER_ACTIVE = 4`) gets slightly more headroom than off-turn teammates (`BOUNCE_TRIGGER_PASSIVE = 3.6`).
- Bot path thresholds now derive from `WALK_TERMINAL_VELOCITY` instead of stale 0.667-era constants.

### Manual check

- [ ] Walk off a 1px downhill step without going briefly airborne; jump should still work.
- [ ] Walk off a cliff (drop greater than horizontal step) — character falls normally, no snap.
- [ ] Mount a ladder, hold a direction key — character walks to the edge and stops there (no fling-off).
- [ ] At the ladder edge, release the direction key and press it again — character dismounts with a small horizontal boost.
- [ ] Jump-mount a ladder mid-fall — the grab should now work at noticeably higher fall speeds than before.
- [ ] Active character survives a fall that would damage an off-turn character (compare a worm in mid-turn vs. one waiting).
- [ ] Bot still pathfinds correctly and reaches jump take-off points.