### PR TITLE
Fix WFC mask determinism and improve bot graph + path follower

### DIFF
--- a/src/data/bot/graph.ts
+++ b/src/data/bot/graph.ts
@@ -5,7 +5,7 @@ import { Terrain } from "../map/terrain";
 import { probeX } from "../map/utils";
 import { Edge, EdgeType } from "./edge";
 import { Node, NodeType } from "./node";
-import { MAX_JUMP_DISTANCE, MAX_JUMP_HEIGHT } from "./physics";
+import { MAX_JUMP_DISTANCE, jumpReaches } from "./physics";
 
 interface EdgeWithCost {
   edge: Edge;
@@ -14,8 +14,9 @@ interface EdgeWithCost {
 
 export class Graph {
   // Use Math.floor for a conservative upper bound: don't let the graph generate
-  // jumps that exceed what the body can actually clear.
-  public static JUMP_HEIGHT = Math.floor(MAX_JUMP_HEIGHT);
+  // jumps that exceed what the body can actually clear. Jump reachability itself
+  // is gated by physics.jumpReaches (couples height and distance); these caps
+  // bound the candidate-pair search and the diagonal climb/ladder range.
   public static JUMP_DISTANCE = MAX_JUMP_DISTANCE;
   public static DIAGONAL_DISTANCE = MAX_JUMP_DISTANCE + 4;
 
@@ -173,9 +174,21 @@ export class Graph {
       yDiff = -yDiff;
       [from, to] = [to, from];
     }
+    // `from` is now the lower node, `to` the upper.
 
     if (this.surface.collidesWithLine(from.x, from.y, to.x, to.y)) {
-      return;
+      // The straight line clips terrain. For a near-vertical jump that's the
+      // wrong model: the bot rises in its own column and steps onto the ledge,
+      // and the diagonal only clips the ledge's wall corner. Allow it if the
+      // vertical rise at the launch column is itself clear. Stays rejected for
+      // shallower jumps/falls/walks, where the straight line is a fair proxy.
+      const steep = yDiff > xDiff;
+      if (
+        !steep ||
+        this.surface.collidesWithLine(from.x, from.y, from.x, to.y)
+      ) {
+        return;
+      }
     }
 
     if (
@@ -185,8 +198,17 @@ export class Graph {
     ) {
       if (xDiff <= Graph.RESOLUTION + 1) {
         to.connect(from, EdgeType.Walk);
+        return;
       }
-      return;
+      // Too far to walk. If both ends are interior (Regular) ground, a long
+      // flat span is already covered by the walk chain between the intermediate
+      // checkpoint nodes, so don't add a redundant jump. But if either end is an
+      // Edge node, this is a gap boundary (a cliff edge facing another ledge at
+      // the same height) — fall through to the jump logic so the bot can clear
+      // it, instead of being forced into a fall-then-jump detour.
+      if (from.type === NodeType.Regular && to.type === NodeType.Regular) {
+        return;
+      }
     }
 
     const distance = getDistance(from.x, from.y, to.x, to.y);
@@ -197,7 +219,11 @@ export class Graph {
       return;
     }
 
-    if (xDiff <= 1) {
+    // Only reject perfectly-stacked nodes (dx 0): their jump cost is infinite
+    // (50/xDiff) and they're degenerate. A 1px horizontal offset is a genuine
+    // near-vertical jump — the bot can hop almost straight up onto a ledge — so
+    // let it through to the jump logic, gated by jumpReaches on height.
+    if (xDiff === 0) {
       return;
     }
 
@@ -210,9 +236,8 @@ export class Graph {
     }
 
     if (
-      yDiff < Graph.JUMP_HEIGHT &&
       (from.y > to.y || distance > 6) &&
-      distance < Graph.DIAGONAL_DISTANCE
+      jumpReaches(xDiff, yDiff)
     ) {
       // The character can only jump from a surface, not from the middle of a
       // ladder (sideways dismount only fires at ladder.left/ladder.right edges

--- a/src/data/bot/path.ts
+++ b/src/data/bot/path.ts
@@ -11,6 +11,18 @@ import {
 
 const REVERSE_INPUT_SPEED = WALK_TERMINAL_VELOCITY / 2;
 
+// Horizontal speed cap while a Fall edge is current or imminent. Falls are
+// steep drops onto a target platform; arriving fast (especially airborne, after
+// a ramp climb) makes the body sail over the platform into whatever is below.
+// Braking toward this cap keeps the descent near-vertical so the body lands on
+// the intended node instead of overshooting it.
+const SAFE_DESCENT_SPEED = 0.6;
+
+// Max obstacle the body climbs while walking, in pixels — mirrors body.ts's
+// MAX_STEP. Rises up to this are auto-stepped (so the bot walks ramps); taller
+// ones need a hop.
+const MAX_STEP = 3;
+
 export class Path {
   private static WALKING_NEXT_DISTANCE = 12;
   private static BUSTED_TIMER = 120;
@@ -159,6 +171,47 @@ export class Path {
         (distance > this.lastDistance && this.shouldContinuePath());
     }
 
+    // Horizontal run-in jump: a launch node can sit on a down-slope the body
+    // skims over (passing above it, then dropping past it) so it never lands
+    // within arrival range. If the next edge is a roughly-horizontal jump and
+    // the bot has already reached the launch x moving into it at launch speed,
+    // commit now — advance and let the jump fire in motion (within jump-grace
+    // of leaving the ledge) rather than walking off and falling past the node.
+    if (!hasArrived && nextDestination?.type === EdgeType.Jump) {
+      const jdx = Math.abs(nextDestination.to.x - nextDestination.from.x);
+      const jdy = Math.abs(nextDestination.to.y - nextDestination.from.y);
+      const jumpDir = Math.sign(nextDestination.to.x - nextDestination.from.x);
+      const speedAlong = this.character.body.xVelocity * jumpDir;
+      const pastLaunch = (x + 3 - nextDestination.from.x) * jumpDir >= 0;
+      if (jdx >= jdy && speedAlong >= MIN_LAUNCH_SPEED && pastLaunch) {
+        hasArrived = true;
+      }
+    }
+
+    // Don't advance into a Jump edge until the bot is grounded at the launch
+    // node. Otherwise the path index races ahead while the body is still
+    // airborne — e.g. tumbling up a steep staircase — so the jump fires from a
+    // mid-air position and the bot launches from the wrong place.
+    //
+    // Exception: the horizontal run-in jump above — there the bot SHOULD commit
+    // in motion. (Vertical staircase jumps stay gated: they're taken from a
+    // near-standstill and need clean footing.)
+    if (
+      hasArrived &&
+      nextDestination?.type === EdgeType.Jump &&
+      !this.character.body.grounded
+    ) {
+      const jdx = Math.abs(nextDestination.to.x - nextDestination.from.x);
+      const jdy = Math.abs(nextDestination.to.y - nextDestination.from.y);
+      const jumpDir = Math.sign(nextDestination.to.x - nextDestination.from.x);
+      const speedAlong = this.character.body.xVelocity * jumpDir;
+      const runningIntoHorizontalJump =
+        jdx >= jdy && speedAlong >= MIN_LAUNCH_SPEED;
+      if (!runningIntoHorizontalJump) {
+        hasArrived = false;
+      }
+    }
+
     // While on a ladder, suppress the horizontal direction key every 4th tick.
     // characterMovement's dismount-via-edge rule needs a Left/Right rising edge
     // (`!wasRight && rightHeld`); a held key never triggers it.
@@ -169,6 +222,46 @@ export class Path {
       this.ladderTicks = 0;
     }
     const suppressForRisingEdge = onLadder && Math.floor(this.ladderTicks) % 4 === 0;
+
+    // If a Fall edge is current (or the next edge), brake when moving too fast
+    // in the fall direction so the body drops onto the target platform rather
+    // than overshooting it. Applies in-air too (air control still decelerates).
+    const fallAhead =
+      destination.type === EdgeType.Fall
+        ? destination
+        : nextDestination?.type === EdgeType.Fall
+          ? nextDestination
+          : null;
+    let brakeKey: Key | null = null;
+    if (fallAhead) {
+      const fallDir = Math.sign(fallAhead.to.x - fallAhead.from.x) || 1;
+      const speedAlong = this.character.body.xVelocity * fallDir;
+      if (speedAlong > SAFE_DESCENT_SPEED) {
+        brakeKey = fallDir > 0 ? Key.Left : Key.Right;
+      }
+    }
+
+    // Steep/vertical jumps are taken from near-standstill — air-control drifts
+    // the body the small horizontal distance during the arc. Carrying run-up
+    // momentum into them (e.g. after sprinting along a platform into a stair
+    // climb) overshoots the tiny launch nodes and the body races ahead of the
+    // path. Brake excess horizontal speed when a steep jump is current or next.
+    const isSteepJump = (e: Edge | undefined) =>
+      !!e &&
+      e.type === EdgeType.Jump &&
+      Math.abs(e.to.y - e.from.y) > Math.abs(e.to.x - e.from.x);
+    const steepJump = isSteepJump(destination)
+      ? destination
+      : isSteepJump(nextDestination)
+        ? nextDestination
+        : null;
+    if (!brakeKey && steepJump) {
+      const jumpDir = Math.sign(steepJump.to.x - steepJump.from.x) || 1;
+      const speedAlong = this.character.body.xVelocity * jumpDir;
+      if (speedAlong > REVERSE_INPUT_SPEED) {
+        brakeKey = jumpDir > 0 ? Key.Left : Key.Right;
+      }
+    }
 
     if (!hasArrived) {
       // During pre-roll, walk OPPOSITE to the jump direction to build run-up.
@@ -183,6 +276,8 @@ export class Path {
         }
       } else if (suppressForRisingEdge) {
         // intentionally no horizontal input this tick
+      } else if (brakeKey !== null) {
+        commands.push({ type: CommandType.KeyDown, key: brakeKey });
       } else if (
         targetX > x + offset &&
         (sameDirection || this.character.body.xVelocity < REVERSE_INPUT_SPEED)
@@ -229,8 +324,14 @@ export class Path {
         const speedAlong = this.character.body.xVelocity * md;
 
         // Launch when at-or-past the edge AND moving along the path at enough speed.
+        // A steep/vertical jump needs no horizontal run-up (air-control covers the
+        // small offset during the arc), so fire as soon as we're at the launch —
+        // requiring run-up there would fight the steep-jump brake above and stall.
         const atLaunchPoint = pastEdge >= -1;
-        const fastEnough = speedAlong >= MIN_LAUNCH_SPEED;
+        const steep =
+          Math.abs(destination.to.y - destination.from.y) >
+          Math.abs(destination.to.x - destination.from.x);
+        const fastEnough = steep || speedAlong >= MIN_LAUNCH_SPEED;
 
         // Panic-fire fallback: if we've overshot the edge AND are still going
         // forward, jump anyway. Don't fire when reversed — that'd just launch
@@ -244,9 +345,25 @@ export class Path {
         destination.type === EdgeType.Walk &&
         destination.from.y - destination.to.y > 4
       ) {
-        // Walk edge with a step-up taller than the body's auto-step (MAX_STEP=3px).
-        // Need to jump to clear the obstacle.
-        commands.push({ type: CommandType.KeyDown, key: Key.Up });
+        // Rising Walk edge. Press Up (hop / ladder-mount) only when needed:
+        //  - the edge climbs onto a ladder node — Up mounts it, or
+        //  - a step too tall for the body's auto-step (MAX_STEP=3px) sits just
+        //    ahead (probe the terrain, since a gentle node-delta slope can still
+        //    hide a localized ledge).
+        // A gradual ramp is neither, so it's walked up — the auto-step keeps
+        // pace at walk speed and jumping there is wasteful (and builds momentum
+        // that overshoots what follows).
+        const dir = Math.sign(destination.to.x - destination.from.x) || 1;
+        const rX = Math.round(x);
+        const rY = Math.round(y);
+        const stepTooTall = getLevel().collidesWith(
+          this.character.body.mask,
+          rX + dir * 2,
+          rY - MAX_STEP,
+        );
+        if (destination.to.isLadder() || stepTooTall) {
+          commands.push({ type: CommandType.KeyDown, key: Key.Up });
+        }
       }
 
       this.lastX = x;
@@ -261,29 +378,56 @@ export class Path {
       if (!this.done) {
         getLevel().debugLayer.highlightEdge(this.edges[this.pathIndex]);
 
-        // If the new edge is a Jump and we're starting cold (low speed, short distance
-        // to from.x), schedule a backwards pre-roll. We walk away from from.x for
-        // enough frames to build run-up distance.
+        // If the new edge is a Jump, schedule a backwards pre-roll when the bot
+        // can't reach launch speed in the room it has ahead of the launch node.
+        // We walk away from from.x for enough frames to build run-up distance.
         const newEdge = this.edges[this.pathIndex];
         if (newEdge?.type === EdgeType.Jump) {
           const md = Math.sign(newEdge.to.x - newEdge.from.x);
           const distToLaunch = (newEdge.from.x - (x + 3)) * md;
           const speedAlong = this.character.body.xVelocity * md;
 
-          // Only pre-roll when effectively stationary or moving the wrong way.
-          // If already moving forward (even slowly), natural acceleration will
-          // bring us to speed before launch — pre-rolling would waste momentum.
+          // Pre-roll unless we're already fast enough, OR have enough room ahead
+          // of the launch node to accelerate up to speed. The room check (not a
+          // speed-only check) is what matters: when the bot drops directly onto
+          // the launch node before a wide jump (distToLaunch ≤ 0, no room ahead),
+          // natural acceleration can't save it — it would walk straight off the
+          // edge with no run-up. Backing up first is the only way to gain speed.
+          const roomAhead = Math.max(0, distToLaunch);
           if (
-            speedAlong < 0.1 &&
-            distToLaunch > 0 &&
-            distToLaunch < runUpDistanceFromRest()
+            speedAlong < REVERSE_INPUT_SPEED &&
+            roomAhead < runUpDistanceFromRest()
           ) {
-            // Walk backwards until we have enough room to accelerate.
-            const needed = runUpDistanceFromRest() - Math.max(0, distToLaunch);
-            // Convert pixels-to-walk-back into frames by dividing by terminal velocity.
-            // We're walking backwards from rest so the average velocity is lower — this
-            // conversion already accounts for that, no extra margin needed.
-            this.prerollFrames = Math.ceil(needed / WALK_TERMINAL_VELOCITY);
+            // Walk backwards until we have enough room to accelerate. When the
+            // bot is at or past the launch node, roomAhead is 0 and we back up
+            // the full run-up distance.
+            const needed = runUpDistanceFromRest() - roomAhead;
+            // Only back up if there's solid ground beneath the whole reverse
+            // run-up. Otherwise we'd walk off a cliff behind us — e.g. the ledge
+            // of a Fall edge we just descended (the bot lands moving slowly and
+            // would reverse straight back off it). A wall behind is fine: it
+            // reads as solid here and merely caps how far we actually back up.
+            const rX = Math.round(x);
+            const rY = Math.round(y);
+            let safeToBackUp = true;
+            for (let b = 1; b <= Math.ceil(needed); b++) {
+              if (
+                !getLevel().collidesWith(
+                  this.character.body.mask,
+                  rX - md * b,
+                  rY + 1,
+                )
+              ) {
+                safeToBackUp = false;
+                break;
+              }
+            }
+            if (safeToBackUp) {
+              // Convert pixels-to-walk-back into frames by dividing by terminal velocity.
+              // We're walking backwards from rest so the average velocity is lower — this
+              // conversion already accounts for that, no extra margin needed.
+              this.prerollFrames = Math.ceil(needed / WALK_TERMINAL_VELOCITY);
+            }
           }
         }
       }

--- a/src/data/bot/physics.ts
+++ b/src/data/bot/physics.ts
@@ -75,6 +75,66 @@ export const MAX_JUMP_HEIGHT = Math.floor(STANDING_JUMP.peakHeight);
 // holding air-control for the full flight. Rounded down for conservative graph planning.
 export const MAX_JUMP_DISTANCE = Math.floor(RUNNING_JUMP.distance);
 
+// Jump reachability envelope: the maximum height (px above launch) a jump can
+// reach at each integer horizontal distance. MAX_JUMP_HEIGHT and
+// MAX_JUMP_DISTANCE are independent caps; this couples them, so the graph can
+// reject jumps that demand near-max height AND near-max distance at once —
+// physically impossible in a single arc.
+const JUMP_HEIGHT_AT_DISTANCE: number[] = (() => {
+  const env: number[] = [0];
+  const samples = 24;
+  for (let i = 0; i <= samples; i++) {
+    const launchX = (WALK_TERMINAL_VELOCITY * i) / samples;
+    let s = { x: 0, y: 0, xv: launchX, yv: -JUMP_STRENGTH };
+    let prev = { x: 0, h: 0 };
+    for (let frame = 1; frame <= 200; frame++) {
+      s = airStep(s, 1);
+      const cur = { x: s.x, h: -s.y };
+      for (let xi = Math.ceil(prev.x); xi <= Math.floor(cur.x); xi++) {
+        const t = (xi - prev.x) / (cur.x - prev.x || 1);
+        const h = prev.h + t * (cur.h - prev.h);
+        if (env[xi] === undefined || h > env[xi]) {
+          env[xi] = h;
+        }
+      }
+      prev = cur;
+      if (s.y > 0 && frame > 1) break;
+    }
+  }
+  // The samples above hold full forward air-control, which pushes the apex out
+  // to x≈10 — so they understate the height at very short distances. But the
+  // bot can withhold air-control and jump nearly straight up, reaching the apex
+  // at x≈0. So at any distance up to where the arc peaks, the full apex height
+  // is reachable: flatten the rising side to the peak.
+  let peakIdx = 0;
+  for (let x = 1; x < env.length; x++) {
+    if (env[x] > env[peakIdx]) peakIdx = x;
+  }
+  for (let x = 0; x < peakIdx; x++) env[x] = env[peakIdx];
+  return env;
+})();
+
+// Extra vertical reach beyond the ballistic arc when landing on a ledge. The
+// body steps up to MAX_STEP (3px, body.ts) as its feet reach a ledge corner,
+// so a jump whose apex stops a hair below the target still clambers onto it.
+// This is what makes near-vertical jumps to a ledge ~MAX_JUMP_HEIGHT+ high land
+// (the apex is ~21.95px, so a clean 22px step would otherwise be rejected).
+const LANDING_CLAMBER = 3;
+
+/**
+ * Whether a jump from a surface can clear `dyUp` pixels of rise over `dx`
+ * pixels of horizontal distance. `dyUp` is positive for an upward target,
+ * zero/negative for a level-or-downward one (always reachable within range).
+ * Distances past the arc's reach return false.
+ */
+export function jumpReaches(dx: number, dyUp: number): boolean {
+  const i = Math.floor(Math.abs(dx));
+  if (i >= JUMP_HEIGHT_AT_DISTANCE.length) {
+    return false;
+  }
+  return dyUp <= JUMP_HEIGHT_AT_DISTANCE[i] + LANDING_CLAMBER;
+}
+
 // Minimum launch xVelocity required to reach a jump's nominal max distance with margin.
 // Below this threshold, the bot should walk longer before launching.
 // Set to 75% of terminal velocity — generous enough that the bot isn't paralysed by tiny

--- a/src/data/wfc/postProcess.ts
+++ b/src/data/wfc/postProcess.ts
@@ -82,28 +82,106 @@ export function renderGrid(grid: WfcTile[][]): OffscreenCanvas {
   return canvas;
 }
 
-/** Apply Gaussian blur and re-threshold to produce clean mask */
+// Blur strength, in pixels of Gaussian σ. The old `ctx.filter = "blur(4px)"`
+// was σ ≈ 4; lower = sharper terrain edges. Tune this single knob to taste.
+const BLUR_SIGMA = 3.5;
+const BLUR_PASSES = 3;
+const SOLID_ALPHA_THRESHOLD = 64;
+
+// Per-pass box-blur radii whose combined variance approximates a Gaussian of
+// BLUR_SIGMA (Kuckir's 3-box method). Mixed radii let us hit fractional σ that
+// a single integer radius can't. Computed once at module load.
+function boxRadiiForGauss(sigma: number, passes: number): number[] {
+  const wIdeal = Math.sqrt((12 * sigma * sigma) / passes + 1);
+  let wl = Math.floor(wIdeal);
+  if (wl % 2 === 0) wl--;
+  const wu = wl + 2;
+  const mIdeal =
+    (12 * sigma * sigma - passes * wl * wl - 4 * passes * wl - 3 * passes) /
+    (-4 * wl - 4);
+  const m = Math.round(mIdeal);
+
+  const radii: number[] = [];
+  for (let i = 0; i < passes; i++) radii.push(((i < m ? wl : wu) - 1) / 2);
+  return radii;
+}
+
+const BLUR_RADII = boxRadiiForGauss(BLUR_SIGMA, BLUR_PASSES);
+
+// One separable box-blur pass. At the canvas border the window is clamped and
+// the average is renormalised over the in-bounds samples only — so edge terrain
+// (notably the floor row sitting on the bottom edge) keeps full weight rather
+// than fading toward transparent. Zero-padding the border instead amplified
+// tiny per-engine raster differences right at the edge into a divergent mask.
+// Uses a sliding window so each pass is O(width * height) regardless of radius.
+function boxBlurPass(
+  src: Float32Array,
+  dst: Float32Array,
+  width: number,
+  height: number,
+  radius: number,
+  horizontal: boolean,
+) {
+  const outer = horizontal ? height : width;
+  const inner = horizontal ? width : height;
+  const stride = horizontal ? 1 : width;
+
+  for (let o = 0; o < outer; o++) {
+    const base = horizontal ? o * width : o;
+
+    let sum = 0;
+    for (let i = 0; i <= radius && i < inner; i++) sum += src[base + i * stride];
+
+    for (let i = 0; i < inner; i++) {
+      const lo = i - radius < 0 ? 0 : i - radius;
+      const hi = i + radius >= inner ? inner - 1 : i + radius;
+      dst[base + i * stride] = sum / (hi - lo + 1);
+
+      const add = i + radius + 1;
+      const sub = i - radius;
+      if (add < inner) sum += src[base + add * stride];
+      if (sub >= 0) sum -= src[base + sub * stride];
+    }
+  }
+}
+
+/**
+ * Blur (deterministic, pure JS) and re-threshold to produce a clean mask.
+ *
+ * The blur is computed in JS rather than via `ctx.filter = "blur()"` because
+ * the canvas filter is engine-specific (Skia vs Gecko differ in kernel and
+ * edge handling), which made the same fixture produce different collision
+ * masks — and thus different bot graphs — across browsers. Identical float
+ * math here yields identical masks on every engine.
+ */
 export function postProcess(canvas: OffscreenCanvas): OffscreenCanvas {
   const { width, height } = canvas;
-  const smoothed = new OffscreenCanvas(width, height);
-  const ctx = smoothed.getContext("2d")!;
-
-  ctx.filter = "blur(4px)";
-  ctx.drawImage(canvas, 0, 0);
-
-  const imageData = ctx.getImageData(0, 0, width, height);
+  const imageData = canvas
+    .getContext("2d")!
+    .getImageData(0, 0, width, height);
   const data = imageData.data;
-  for (let i = 0; i < data.length; i += 4) {
-    const alpha = data[i + 3];
-    const solid = alpha > 64;
-    data[i] = 0;
-    data[i + 1] = 0;
-    data[i + 2] = 0;
-    data[i + 3] = solid ? 255 : 0;
+
+  const n = width * height;
+  let a = new Float32Array(n);
+  let b = new Float32Array(n);
+  for (let i = 0; i < n; i++) a[i] = data[i * 4 + 3];
+
+  for (const radius of BLUR_RADII) {
+    boxBlurPass(a, b, width, height, radius, true);
+    boxBlurPass(b, a, width, height, radius, false);
   }
 
-  ctx.filter = "none";
-  ctx.putImageData(imageData, 0, 0);
+  for (let i = 0; i < n; i++) {
+    const solid = a[i] > SOLID_ALPHA_THRESHOLD ? 255 : 0;
+    const o = i * 4;
+    data[o] = 0;
+    data[o + 1] = 0;
+    data[o + 2] = 0;
+    data[o + 3] = solid;
+  }
+
+  const smoothed = new OffscreenCanvas(width, height);
+  smoothed.getContext("2d")!.putImageData(imageData, 0, 0);
   return smoothed;
 }
 


### PR DESCRIPTION
### Description

Three fixes extracted from work on the bot's navigation. The dev-only `/#/test/pathfinding` harness used to validate them is kept local (not part of this PR).

- **Deterministic collision mask** — compute the WFC mask blur in pure JS (separable box-blur) instead of the engine-specific `ctx.filter = "blur()"`, so a given tile grid yields identical masks (and nav graphs) across browsers.
- **Physically-accurate graph jumps** — couple jump height and distance via a launch-speed reachability envelope (`physics.jumpReaches`); connect flat gap-jumps across same-height ledges; allow near-vertical jumps; use a vertical-rise clearance check for steep jumps.
- **Path follower over steep terrain** — brake into falls (land on the platform, not the pit), run-up pre-roll for wide jumps (terrain-probed so it never reverses off a cliff), commit to horizontal jumps in motion, brake into vertical jumps and fire them from the launch node, and walk up ramps instead of hopping every step.

### Manual check

The graph/path follower logic is covered by unit tests (`yarn test src/data/bot` — 41 passing). The WFC mask refactor is the main runtime-visible change.

- Generate a WFC map (Builder or a hosted game)
- [ ] Maps generate correctly and the terrain collision mask looks right
- [ ] Bots still navigate terrain in a normal game without regressions

[Checklist for a thorough manual check](https://teamleader.atlassian.net/wiki/spaces/ENG/pages/3332735012/Manual+check+list)
