### PR TITLE
Bot fall path-following: avoid fall-damage drops, fix jump run-up braking

### DIFF
--- a/src/data/bot/__spec__/edge.spec.ts
+++ b/src/data/bot/__spec__/edge.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Edge, EdgeType } from "../edge";
 import { Node, NodeType } from "../node";
+import { MAX_SAFE_FALL_HEIGHT } from "../physics";
 
 const node = (x: number, y: number) => new Node(x, y, NodeType.Regular);
 
@@ -76,18 +77,19 @@ describe("Edge", () => {
       ).toBeCloseTo(distance * JUMP_COST_FACTOR + VERTICAL_JUMP_PENALTY / xDiff);
     });
 
-    it("a fall within the height limit costs distance × the fall factor", () => {
-      // |dy| 40 ≤ FALL_LIMIT_HEIGHT (72).
-      expect(new Edge(node(0, 0), node(30, 40), EdgeType.Fall).cost).toBeCloseTo(
-        DISTANCE * FALL_COST_FACTOR
-      );
+    it("a fall within the damage-free height costs distance × the fall factor", () => {
+      const dy = MAX_SAFE_FALL_HEIGHT - 5;
+      const distance = Math.hypot(10, dy);
+      expect(
+        new Edge(node(0, 0), node(10, dy), EdgeType.Fall).cost
+      ).toBeCloseTo(distance * FALL_COST_FACTOR);
     });
 
-    it("a fall past the height limit is heavily penalised", () => {
-      // |dy| 80 > FALL_LIMIT_HEIGHT — effectively unreachable.
-      const distance = Math.hypot(10, 80);
+    it("a fall past the damage-free height is priced as unreachable", () => {
+      const dy = MAX_SAFE_FALL_HEIGHT + 20;
+      const distance = Math.hypot(10, dy);
       expect(
-        new Edge(node(0, 0), node(10, 80), EdgeType.Fall).cost
+        new Edge(node(0, 0), node(10, dy), EdgeType.Fall).cost
       ).toBeCloseTo(1000 + distance);
     });
   });

--- a/src/data/bot/__spec__/physics.spec.ts
+++ b/src/data/bot/__spec__/physics.spec.ts
@@ -3,7 +3,9 @@ import {
   APEX_FRAMES,
   MAX_JUMP_DISTANCE,
   MAX_JUMP_HEIGHT,
+  MAX_SAFE_FALL_HEIGHT,
   MIN_LAUNCH_SPEED,
+  SAFE_LANDING_SPEED,
   WALK_TERMINAL_VELOCITY,
   runUpDistanceFromRest,
 } from "../physics";
@@ -183,5 +185,32 @@ describe("physics.ts mirrors the real Body integration", () => {
     // MAX_JUMP_DISTANCE is floor()'d, so the live landing sits within [D, D + 1).
     expect(landingX).toBeGreaterThanOrEqual(MAX_JUMP_DISTANCE);
     expect(landingX).toBeLessThan(MAX_JUMP_DISTANCE + 1);
+  });
+
+  // Returns body.yVelocity (what onCollide checks for fall damage) at landing.
+  function landingSpeedAfterFalling(height: number): number {
+    const surface = {
+      collidesWith: () => false,
+    } as unknown as CollisionMask;
+    const body = new Body(surface, { mask: {} as unknown as CollisionMask });
+    for (let frame = 0; frame < 200; frame++) {
+      body.tick(1);
+      if (body.precisePosition[1] >= height) {
+        return body.yVelocity;
+      }
+    }
+    return body.yVelocity;
+  }
+
+  it("a fall of MAX_SAFE_FALL_HEIGHT lands within the safe landing speed", () => {
+    expect(landingSpeedAfterFalling(MAX_SAFE_FALL_HEIGHT)).toBeLessThanOrEqual(
+      SAFE_LANDING_SPEED
+    );
+  });
+
+  it("a fall well past MAX_SAFE_FALL_HEIGHT exceeds the safe landing speed", () => {
+    expect(
+      landingSpeedAfterFalling(MAX_SAFE_FALL_HEIGHT + 12)
+    ).toBeGreaterThan(SAFE_LANDING_SPEED);
   });
 });

--- a/src/data/bot/edge.ts
+++ b/src/data/bot/edge.ts
@@ -1,12 +1,12 @@
 import { getDistance } from "../../util/math";
 import { Graph } from "./graph";
 import { Node } from "./node";
+import { MAX_SAFE_FALL_HEIGHT } from "./physics";
 
 const JUMP_COST_FACTOR = 1.2;
 const FALL_COST_FACTOR = 1.4;
 const VERTICAL_JUMP_PENALTY = 50;
 const NARROW_JUMP_XDIFF = 5;
-const FALL_LIMIT_HEIGHT = 72;
 const UNREACHABLE_FALL_COST = 1000;
 
 export enum EdgeType {
@@ -50,7 +50,7 @@ export class Edge {
       }
     } else {
       const heightDiff = Math.abs(this.dy);
-      if (heightDiff > FALL_LIMIT_HEIGHT) {
+      if (heightDiff > MAX_SAFE_FALL_HEIGHT) {
         this.cost = UNREACHABLE_FALL_COST + distance;
       } else {
         this.cost = distance * FALL_COST_FACTOR;

--- a/src/data/bot/graph.ts
+++ b/src/data/bot/graph.ts
@@ -19,7 +19,6 @@ export class Graph {
   public static JUMP_DISTANCE = MAX_JUMP_DISTANCE;
   public static DIAGONAL_DISTANCE = MAX_JUMP_DISTANCE + 4;
 
-  public static FALL_LIMIT = 60;
   public static CHARACTER_HEIGHT = 16;
 
   public static RESOLUTION = 12;

--- a/src/data/bot/path.ts
+++ b/src/data/bot/path.ts
@@ -267,7 +267,8 @@ export class Path {
     const fallAhead =
       destination.type === EdgeType.Fall
         ? destination
-        : nextDestination?.type === EdgeType.Fall
+        : destination.type !== EdgeType.Jump &&
+            nextDestination?.type === EdgeType.Fall
           ? nextDestination
           : null;
     if (fallAhead) {

--- a/src/data/bot/physics.ts
+++ b/src/data/bot/physics.ts
@@ -59,6 +59,23 @@ export const MAX_JUMP_HEIGHT = Math.floor(STANDING_JUMP.peakHeight);
 
 export const MAX_JUMP_DISTANCE = Math.floor(RUNNING_JUMP.distance);
 
+// Mirror of BOUNCE_TRIGGER_ACTIVE in character.ts; landing faster deals damage.
+export const SAFE_LANDING_SPEED = 4;
+
+export const MAX_SAFE_FALL_HEIGHT: number = (() => {
+  let s = { x: 0, y: 0, xv: 0, yv: 0 };
+  let safeHeight = 0;
+  for (let frame = 0; frame < 200; frame++) {
+    const next = airStep(s, 0);
+    if (next.yv > SAFE_LANDING_SPEED) {
+      break;
+    }
+    safeHeight = next.y;
+    s = next;
+  }
+  return Math.floor(safeHeight);
+})();
+
 const JUMP_HEIGHT_AT_DISTANCE: number[] = (() => {
   const env: number[] = [0];
   const samples = 24;


### PR DESCRIPTION
### Description

Two related fixes to how the bot follows fall/jump edges, both confined to `src/data/bot/`.

**1. Avoid fall-damage drops**
Bots routed through drops that deal fall damage. Damage triggers in `character.ts:onCollide` once landing speed exceeds the bounce trigger; the bot is always the active character while walking, so the limit is the active trigger (`4`).
- Replaces `edge.ts`'s arbitrary `72px` fall limit with `MAX_SAFE_FALL_HEIGHT`, derived in `physics.ts` from the real `Body` fall integration as the greatest from-rest drop landing at or below that trigger — **53px** (the old `72px` landed at ~`4.5`, i.e. damage).
- Falls beyond the limit are priced as effectively unreachable, so A\* only takes a damaging drop when there is no safer way down.
- Removes the unused `Graph.FALL_LIMIT` constant.

**2. Don't brake jump run-up for a fall after the landing**
`computeBrakeKey`'s descent brake (`SAFE_DESCENT_SPEED`) also fired when `nextDestination` was a Fall. While the current edge is an upward Jump, that Fall is the move *after* landing, so the brake capped run-up at `0.6` (below the `0.75` terminal walk speed) and the bot jumped short — or stalled if it dipped below `MIN_LAUNCH_SPEED`. Now `nextDestination` falls are ignored while the current edge is a Jump (mirroring the steep-jump guard right below it).

**Tests:** guards pinning `MAX_SAFE_FALL_HEIGHT` to a live `Body` fall and to `SAFE_LANDING_SPEED`, so a `body.ts` change can't silently re-introduce damaging falls. `vue-tsc` clean; **58 bot tests pass**.

**E2E (pathfinding harness):** `arrived, 0 re-plans`. Fall limit alone: 6541 frames (= baseline). With the run-up fix: **6509 frames** — slightly faster, confirming the brake was needlessly firing and no regression.

### Manual check

N/A — confined to `src/data/bot/`, no API/UI/config change. Path-following behaviour verified on the e2e pathfinding harness; thresholds covered by the physics/edge unit tests.