### PR TITLE
Fix null graph crash when enabling bot debug mid-game

### DIFF
--- a/src/data/map/debugLayer.ts
+++ b/src/data/map/debugLayer.ts
@@ -8,9 +8,9 @@ export class DebugLayer extends Graphics {
   private graph: Graph | null = null;
 
   draw(graph: Graph) {
+    this.graph = graph;
     if (!isBotDebugEnabled()) return;
     this.clear();
-    this.graph = graph;
 
     for (let node of this.graph.getNodes()) {
       for (let edge of node.edges) {
@@ -41,8 +41,8 @@ export class DebugLayer extends Graphics {
   }
 
   highlightEdge(edge: Edge) {
-    if (!isBotDebugEnabled()) return;
-    this.draw(this.graph!);
+    if (!isBotDebugEnabled() || !this.graph) return;
+    this.draw(this.graph);
     this.drawEdge(edge, 3);
 
     this.circle(edge.from.x * 6, edge.from.y * 6, 10);


### PR DESCRIPTION
### Description

Enabling bot debug mode (`window.debug()`) after a turn had already built its graph crashed with `can't access property "getNodes", this.graph is null`.

`DebugLayer.draw` set `this.graph = graph` *after* its `isBotDebugEnabled()` early return, so a graph built while debug was off never got stored. Turning debug on afterwards then dereferenced the null graph via `highlightEdge → draw(this.graph!)` (called from the `Path` constructor each tick).

- Capture `this.graph` before the early return, so the layer always tracks the current graph regardless of debug state.
- Guard `highlightEdge` against a still-null graph (no graph built yet).

### Manual check

- Start a game with a bot, leave bot debug off
- Once the bot is moving, run `window.debug()` in the console
- [ ] The graph/path overlay appears with no console error
- [ ] Toggling it off and on again still works