### PR TITLE
Add bot AI strategies for 10 offensive spells

### DIFF
--- a/src/data/bot/strategies/__spec__/acid.spec.ts
+++ b/src/data/bot/strategies/__spec__/acid.spec.ts
@@ -1,0 +1,9 @@
+import { Acid } from "../acid";
+
+describe("Acid.predictDamageAt", () => {
+  it("scales flat droplet damage by expected droplets within Acid range", () => {
+    // Life 1 → per-droplet = 3 + 1 = 4; EXPECTED_DROPLETS = 4 → 16 within range (90px = 15 game units)
+    expect(Acid.predictDamageAt(10, 1)).toBe(16);
+    expect(Acid.predictDamageAt(20, 1)).toBe(0);
+  });
+});

--- a/src/data/bot/strategies/__spec__/arthurSword.spec.ts
+++ b/src/data/bot/strategies/__spec__/arthurSword.spec.ts
@@ -1,0 +1,10 @@
+import { ArthurSword } from "../arthurSword";
+
+describe("ArthurSword.predictDamageAt", () => {
+  it("counts EXPECTED_HITS flat fall-damage hits within range", () => {
+    // Arcane value 1 → per-hit power = 2 + 2 = 4; EXPECTED_HITS = 3 → 12 within range
+    expect(ArthurSword.predictDamageAt(5, 1)).toBe(12);
+    // beyond SwordTip range (80px ≈ 13.3 game units)
+    expect(ArthurSword.predictDamageAt(20, 1)).toBe(0);
+  });
+});

--- a/src/data/bot/strategies/__spec__/babylon.spec.ts
+++ b/src/data/bot/strategies/__spec__/babylon.spec.ts
@@ -1,0 +1,9 @@
+import { Babylon } from "../babylon";
+
+describe("Babylon.predictDamageAt", () => {
+  it("applies flat 8-damage hits within range, scaled by EXPECTED_HITS", () => {
+    // EXPECTED_HITS = 4 → 32 within range, 0 outside SmallSword range (30px ≈ 5 game units)
+    expect(Babylon.predictDamageAt(3)).toBe(32);
+    expect(Babylon.predictDamageAt(10)).toBe(0);
+  });
+});

--- a/src/data/bot/strategies/__spec__/catastravia.spec.ts
+++ b/src/data/bot/strategies/__spec__/catastravia.spec.ts
@@ -1,0 +1,10 @@
+import { Catastravia } from "../catastravia";
+
+describe("Catastravia.predictDamageAt", () => {
+  it("sums an expected number of small explosive hits at the target", () => {
+    // per-missile center damage = predictExplosive(0, 12, 2) = 10*2 = 20.
+    // EXPECTED_HITS_ON_TARGET = 3 → 60 at center.
+    expect(Catastravia.predictDamageAt(0)).toBeCloseTo(60, 0);
+    expect(Catastravia.predictDamageAt(30)).toBe(0);
+  });
+});

--- a/src/data/bot/strategies/__spec__/doragate.spec.ts
+++ b/src/data/bot/strategies/__spec__/doragate.spec.ts
@@ -1,0 +1,10 @@
+import { Doragate } from "../doragate";
+
+describe("Doragate.predictDamageAt", () => {
+  it("scales tiny explosive hits by expected pebbles", () => {
+    // Arcane 1 → multiplier = 1.5 + 0.7 = 2.2; center = predictExplosive(0,4,2.2) = 10*2.2 = 22;
+    // EXPECTED_PEBBLES = 2 → 44 at center.
+    expect(Doragate.predictDamageAt(0, 1)).toBeCloseTo(44, 0);
+    expect(Doragate.predictDamageAt(20, 1)).toBe(0); // radius 4 game units is tiny
+  });
+});

--- a/src/data/bot/strategies/__spec__/guidanceHeading.spec.ts
+++ b/src/data/bot/strategies/__spec__/guidanceHeading.spec.ts
@@ -1,0 +1,26 @@
+import { chooseGuidanceHeading } from "../guidanceHeading";
+import { CollisionMask } from "../../../collision/collisionMask";
+
+function emptyMask(w: number, h: number): CollisionMask {
+  const m = CollisionMask.forRect(w, h);
+  m.subtract(CollisionMask.forRect(w, h), 0, 0);
+  return m;
+}
+
+describe("chooseGuidanceHeading", () => {
+  it("aims straight at the target when the path is clear", () => {
+    const mask = emptyMask(200, 200);
+    const h = chooseGuidanceHeading(mask, [10, 100], [190, 100], 40);
+    expect(Math.abs(h)).toBeLessThan(0.2); // ~0 rad = straight right
+  });
+
+  it("steers off the direct line when a wall blocks it", () => {
+    const mask = emptyMask(200, 200);
+    // A wall stub at game x=40 (within the 40-unit lookahead from x=10) that
+    // blocks the flat direct line but leaves clearance above for a deflected ray.
+    mask.add(CollisionMask.forRect(1, 60), 40, 90);
+    const h = chooseGuidanceHeading(mask, [10, 100], [190, 100], 40);
+    // Clearance is above the wall, so it must steer upward (negative heading).
+    expect(h).toBeLessThan(0);
+  });
+});

--- a/src/data/bot/strategies/__spec__/hairpin.spec.ts
+++ b/src/data/bot/strategies/__spec__/hairpin.spec.ts
@@ -1,0 +1,10 @@
+import { Hairpin } from "../hairpin";
+
+describe("Hairpin.predictDamageAt", () => {
+  it("scales explosive falloff by expected landed bombs and Elemental value", () => {
+    // Elemental 1 → multiplier = 5*(0.7+0.3) = 5; center = predictExplosive(0,16,5) = 10*5 = 50;
+    // EXPECTED_BOMBS = 2 → 100 at center.
+    expect(Hairpin.predictDamageAt(0, 1)).toBeCloseTo(100, 0);
+    expect(Hairpin.predictDamageAt(40, 1)).toBe(0);
+  });
+});

--- a/src/data/bot/strategies/__spec__/lightning.spec.ts
+++ b/src/data/bot/strategies/__spec__/lightning.spec.ts
@@ -1,0 +1,8 @@
+import { Lightning } from "../lightning";
+
+describe("Lightning.predictPerTarget", () => {
+  it("is 20 + 5 per Elemental element value", () => {
+    expect(Lightning.predictPerTarget(0)).toBe(20);
+    expect(Lightning.predictPerTarget(2)).toBe(30);
+  });
+});

--- a/src/data/bot/strategies/__spec__/meteor.spec.ts
+++ b/src/data/bot/strategies/__spec__/meteor.spec.ts
@@ -1,0 +1,10 @@
+import { Meteor } from "../meteor";
+
+describe("Meteor.predictDamageAt", () => {
+  it("uses explosive falloff scaled by expected near-target bounces", () => {
+    // Elemental value 2 → multiplier = 5 + 1 = 6; at distance 0 predictExplosive ≈ 10*6 = 60;
+    // EXPECTED_BOUNCES = 2 → ~120 at center.
+    expect(Meteor.predictDamageAt(0, 2)).toBeCloseTo(120, 0);
+    expect(Meteor.predictDamageAt(40, 2)).toBe(0);
+  });
+});

--- a/src/data/bot/strategies/__spec__/nephtear.spec.ts
+++ b/src/data/bot/strategies/__spec__/nephtear.spec.ts
@@ -1,0 +1,9 @@
+import { Nephtear } from "../nephtear";
+
+describe("Nephtear.predictDamageAt", () => {
+  it("is flat power within impact radius, 0 beyond it", () => {
+    // With Elemental element value 1: power = 30 * (0.7 + 0.3) = 30.
+    expect(Nephtear.predictDamageAt(5, 1)).toBe(30);
+    expect(Nephtear.predictDamageAt(20, 1)).toBe(0);
+  });
+});

--- a/src/data/bot/strategies/__spec__/scoring.spec.ts
+++ b/src/data/bot/strategies/__spec__/scoring.spec.ts
@@ -4,6 +4,8 @@ import {
   KILL_BONUS,
   MIN_RESERVE,
   predictExplosiveDamage,
+  predictImpactDamage,
+  predictFallDamage,
   scoreCandidate,
   collectAllies,
   hasLineOfSight,
@@ -196,5 +198,20 @@ describe("hasLineOfSight", () => {
     const wallColumn = CollisionMask.forRect(1, 100);
     walled.add(wallColumn, 50, 0);
     expect(hasLineOfSight(walled, [60, 60], [540, 60])).toBe(false);
+  });
+});
+
+describe("predictImpactDamage", () => {
+  it("returns full power within 16 game units, else 0", () => {
+    expect(predictImpactDamage(10, 25)).toBe(25);
+    expect(predictImpactDamage(20, 25)).toBe(0);
+  });
+});
+
+describe("predictFallDamage", () => {
+  it("returns full power within the shape range, else 0", () => {
+    // SwordTip range = 80px = ~13.33 game units
+    expect(predictFallDamage(10, 80 / 6, 4)).toBe(4);
+    expect(predictFallDamage(20, 80 / 6, 4)).toBe(0);
   });
 });

--- a/src/data/bot/strategies/__spec__/scoring.spec.ts
+++ b/src/data/bot/strategies/__spec__/scoring.spec.ts
@@ -6,6 +6,7 @@ import {
   predictExplosiveDamage,
   predictImpactDamage,
   predictFallDamage,
+  predictChainTargets,
   scoreCandidate,
   collectAllies,
   hasLineOfSight,
@@ -213,5 +214,32 @@ describe("predictFallDamage", () => {
     // SwordTip range = 80px = ~13.33 game units
     expect(predictFallDamage(10, 80 / 6, 4)).toBe(4);
     expect(predictFallDamage(20, 80 / 6, 4)).toBe(0);
+  });
+});
+
+describe("predictChainTargets", () => {
+  it("counts enemies reachable by chaining within range, capped at maxChains", () => {
+    const start: [number, number] = [0, 0];
+    const enemies: [number, number][] = [
+      [200, 0],   // chain 1 from start
+      [400, 0],   // chain 2 (within 260 of #1)
+      [2000, 0],  // far away — unreachable
+    ];
+    expect(predictChainTargets(start, enemies, 260, 5)).toBe(2);
+  });
+
+  it("never exceeds maxChains", () => {
+    const start: [number, number] = [0, 0];
+    const enemies: [number, number][] = Array.from(
+      { length: 10 },
+      (_, i) => [i * 100, 0] as [number, number],
+    );
+    expect(predictChainTargets(start, enemies, 260, 5)).toBe(5);
+  });
+
+  it("returns 0 when there are no reachable enemies", () => {
+    const start: [number, number] = [0, 0];
+    expect(predictChainTargets(start, [], 260, 5)).toBe(0);
+    expect(predictChainTargets(start, [[1000, 0]], 260, 5)).toBe(0);
   });
 });

--- a/src/data/bot/strategies/__spec__/scoring.spec.ts
+++ b/src/data/bot/strategies/__spec__/scoring.spec.ts
@@ -6,7 +6,9 @@ import {
   predictExplosiveDamage,
   scoreCandidate,
   collectAllies,
+  hasLineOfSight,
 } from "../scoring";
+import { CollisionMask } from "../../../collision/collisionMask";
 import { Character } from "../../../entity/character";
 
 describe("predictExplosiveDamage", () => {
@@ -176,5 +178,23 @@ describe("collectAllies", () => {
     const self = makeChar(playerA);
     const allies = collectAllies(self, [self]);
     expect(allies).toEqual([self]);
+  });
+});
+
+describe("hasLineOfSight", () => {
+  it("is true across an empty mask and false through a solid column", () => {
+    // 100x100 game-unit mask, all empty.
+    const empty = CollisionMask.forRect(100, 100);
+    empty.subtract(CollisionMask.forRect(100, 100), 0, 0);
+    expect(
+      hasLineOfSight(empty, [60, 60], [540, 60]) // screen px → game units 10..90
+    ).toBe(true);
+
+    // Fill a vertical wall at game x=50 (the midpoint of the ray).
+    const walled = CollisionMask.forRect(100, 100);
+    walled.subtract(CollisionMask.forRect(100, 100), 0, 0);
+    const wallColumn = CollisionMask.forRect(1, 100);
+    walled.add(wallColumn, 50, 0);
+    expect(hasLineOfSight(walled, [60, 60], [540, 60])).toBe(false);
   });
 });

--- a/src/data/bot/strategies/acid.ts
+++ b/src/data/bot/strategies/acid.ts
@@ -1,0 +1,86 @@
+import { ACID } from "../../spells";
+import { getLevel, getManager } from "../../context";
+import { Character } from "../../entity/character";
+import { Element } from "../../spells/types";
+import { Cluster } from "../cluster";
+import { Graph } from "../graph";
+import { Evaluation } from "./strategy";
+import { InstantPressCast } from "./instantPressCast";
+import {
+  collectAllies,
+  hasLineOfSight,
+  predictFallDamage,
+  scoreAOECandidate,
+} from "./scoring";
+
+// 90 = Acid shape's range in screen px (fallDamage.ts); ÷6 → game units.
+const ACID_RANGE_GAME = 90 / 6;
+const PER_DROPLET_BASE = 3;
+// Of the ~13 droplets over the spray, a few land near a stationary target.
+// Conservative starting value — refine during playtesting.
+const EXPECTED_DROPLETS = 4;
+const MAX_RANGE_SCREEN = 500;
+const MIN_RANGE_SCREEN = 80;
+
+export class Acid extends InstantPressCast {
+  public static spell = ACID;
+
+  protected aimPoint(): [number, number] {
+    return this.evaluation!.target.centerScreen;
+  }
+
+  static predictDamageAt(distanceGameUnits: number, lifeValue: number): number {
+    const perDroplet = PER_DROPLET_BASE + lifeValue;
+    return predictFallDamage(distanceGameUnits, ACID_RANGE_GAME, perDroplet) * EXPECTED_DROPLETS;
+  }
+
+  evaluate(graph: Graph, targets: Character[]) {
+    this.graph = graph;
+    const myCenter = this.character.getCenter();
+    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
+    const surface = getLevel().terrain.collisionMask;
+    const currentMana = this.character.player.mana;
+    const life = getManager().getElementValue(Element.Life);
+
+    const everyone: Character[] = [];
+    getLevel().withNearbyEntities(myCenter[0], myCenter[1], MAX_RANGE_SCREEN, (entity) => {
+      if (entity instanceof Character) everyone.push(entity);
+    });
+    const allies = collectAllies(this.character, everyone);
+
+    this.evaluations = targets
+      .slice(0, 3)
+      .map((target) => {
+        const targetCenter = target.getCenter();
+        const dx = targetCenter[0] - myCenter[0];
+        const dy = targetCenter[1] - myCenter[1];
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        if (distance > MAX_RANGE_SCREEN || distance < MIN_RANGE_SCREEN) return null;
+        if (!hasLineOfSight(surface, myCenter, targetCenter)) return null;
+
+        const impactXGame = targetCenter[0] / 6;
+        const impactYGame = targetCenter[1] / 6;
+        const predict = (c: Character) => {
+          const [sx, sy] = c.getCenter();
+          const d = Math.sqrt(
+            (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
+          );
+          return Acid.predictDamageAt(d, life);
+        };
+
+        const value = scoreAOECandidate({
+          target,
+          allies,
+          predictDamage: predict,
+          spell: Acid.spell,
+          currentMana,
+        });
+        if (value === null) return null;
+        return { target: Cluster.onCharacter(target), value, to: [myNode] };
+      })
+      .filter(Boolean)
+      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+
+    this.getNextEvaluation();
+  }
+}

--- a/src/data/bot/strategies/acid.ts
+++ b/src/data/bot/strategies/acid.ts
@@ -1,17 +1,11 @@
 import { ACID } from "../../spells";
-import { getLevel, getManager } from "../../context";
+import { getManager } from "../../context";
 import { Character } from "../../entity/character";
 import { Element } from "../../spells/types";
-import { Cluster } from "../cluster";
 import { Graph } from "../graph";
-import { Evaluation } from "./strategy";
 import { InstantPressCast } from "./instantPressCast";
-import {
-  collectAllies,
-  hasLineOfSight,
-  predictFallDamage,
-  scoreAOECandidate,
-} from "./scoring";
+import { hasLineOfSight, predictFallDamage } from "./scoring";
+import { evaluateAOECandidates } from "./aoeEvaluation";
 
 // 90 = Acid shape's range in screen px (fallDamage.ts); ÷6 → game units.
 const ACID_RANGE_GAME = 90 / 6;
@@ -36,50 +30,20 @@ export class Acid extends InstantPressCast {
 
   evaluate(graph: Graph, targets: Character[]) {
     this.graph = graph;
-    const myCenter = this.character.getCenter();
-    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
-    const surface = getLevel().terrain.collisionMask;
-    const currentMana = this.character.player.mana;
     const life = getManager().getElementValue(Element.Life);
 
-    const everyone: Character[] = [];
-    getLevel().withNearbyEntities(myCenter[0], myCenter[1], MAX_RANGE_SCREEN, (entity) => {
-      if (entity instanceof Character) everyone.push(entity);
-    });
-    const allies = collectAllies(this.character, everyone);
-
-    this.evaluations = targets
-      .slice(0, 3)
-      .map((target) => {
-        const targetCenter = target.getCenter();
-        const dx = targetCenter[0] - myCenter[0];
-        const dy = targetCenter[1] - myCenter[1];
-        const distance = Math.sqrt(dx * dx + dy * dy);
+    this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
+      spell: Acid.spell,
+      reachScreen: ACID_RANGE_GAME * 6,
+      impactPoint: (target, { myCenter, surface }) => {
+        const center = target.getCenter();
+        const distance = Math.hypot(center[0] - myCenter[0], center[1] - myCenter[1]);
         if (distance > MAX_RANGE_SCREEN || distance < MIN_RANGE_SCREEN) return null;
-        if (!hasLineOfSight(surface, myCenter, targetCenter)) return null;
-
-        const impactXGame = targetCenter[0] / 6;
-        const impactYGame = targetCenter[1] / 6;
-        const predict = (c: Character) => {
-          const [sx, sy] = c.getCenter();
-          const d = Math.sqrt(
-            (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
-          );
-          return Acid.predictDamageAt(d, life);
-        };
-
-        const value = scoreAOECandidate({
-          target,
-          allies,
-          predictDamage: predict,
-          spell: Acid.spell,
-          currentMana,
-        });
-        if (value === null) return null;
-        return { target: Cluster.onCharacter(target), value, to: [myNode] };
-      })
-      .filter(Boolean)
-      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+        if (!hasLineOfSight(surface, myCenter, center)) return null;
+        return center;
+      },
+      predictDamageAt: (d) => Acid.predictDamageAt(d, life),
+    });
 
     this.getNextEvaluation();
   }

--- a/src/data/bot/strategies/aoeEvaluation.ts
+++ b/src/data/bot/strategies/aoeEvaluation.ts
@@ -1,0 +1,87 @@
+import { getLevel } from "../../context";
+import { Character } from "../../entity/character";
+import { CollisionMask } from "../../collision/collisionMask";
+import { Spell } from "../../spells";
+import { Cluster } from "../cluster";
+import { Graph } from "../graph";
+import { Evaluation } from "./strategy";
+import { collectAllies, scoreAOECandidate } from "./scoring";
+
+export interface AOEContext {
+  myCenter: [number, number];
+  surface: CollisionMask;
+}
+
+export interface AOEStrategyConfig {
+  spell: Spell;
+  // Effective blast reach in screen px: the farthest a character can sit from the impact
+  // point and still take damage. Allies are gathered within this radius of each impact
+  // point, so teammates near a distant target are considered for friendly fire even when
+  // they stand far from the bot.
+  reachScreen: number;
+  // Resolve a target to its impact point (screen px), or return null to reject it
+  // (out of range, blocked line of sight, …). `context` carries the bot center + terrain.
+  impactPoint: (target: Character, context: AOEContext) => [number, number] | null;
+  // Damage dealt at `distanceGameUnits` from the impact point (element scaling baked in).
+  predictDamageAt: (distanceGameUnits: number) => number;
+}
+
+/**
+ * Shared evaluate() body for AOE strategies: gather candidates, score each target's impact
+ * with its allies, and return them sorted best-first. Strategies supply only the
+ * spell-specific bits via `config` (impact point + gating, damage falloff, blast reach).
+ */
+export function evaluateAOECandidates(
+  character: Character,
+  graph: Graph,
+  targets: Character[],
+  config: AOEStrategyConfig,
+): Evaluation[] {
+  const myCenter = character.getCenter();
+  const myNode = graph.getClosestNode(...character.bodyFootCenter);
+  const surface = getLevel().terrain.collisionMask;
+  const currentMana = character.player.mana;
+  const context: AOEContext = { myCenter, surface };
+
+  return targets
+    .slice(0, 3)
+    .map((target) => {
+      const impact = config.impactPoint(target, context);
+      if (!impact) return null;
+
+      // Gather allies around the impact point — not the bot — so we never blow up a
+      // teammate standing next to a far-off target just because it was beyond bot range.
+      const allyPool: Character[] = [];
+      getLevel().withNearbyEntities(
+        impact[0],
+        impact[1],
+        config.reachScreen,
+        (entity) => {
+          if (entity instanceof Character) allyPool.push(entity);
+        },
+      );
+      const allies = collectAllies(character, allyPool);
+
+      const impactXGame = impact[0] / 6;
+      const impactYGame = impact[1] / 6;
+      const predict = (c: Character) => {
+        const [sx, sy] = c.getCenter();
+        const d = Math.sqrt(
+          (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
+        );
+        return config.predictDamageAt(d);
+      };
+
+      const value = scoreAOECandidate({
+        target,
+        allies,
+        predictDamage: predict,
+        spell: config.spell,
+        currentMana,
+      });
+      if (value === null) return null;
+      return { target: Cluster.onCharacter(target), value, to: [myNode] };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b!.value - a!.value) as Evaluation[];
+}

--- a/src/data/bot/strategies/arthurSword.ts
+++ b/src/data/bot/strategies/arthurSword.ts
@@ -1,0 +1,78 @@
+import { ARTHUR_SWORD } from "../../spells";
+import { getLevel, getManager } from "../../context";
+import { Character } from "../../entity/character";
+import { Element } from "../../spells/types";
+import { Cluster } from "../cluster";
+import { Graph } from "../graph";
+import { Evaluation } from "./strategy";
+import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
+import { collectAllies, predictFallDamage, scoreAOECandidate } from "./scoring";
+import { probeX } from "../../map/utils";
+
+const HOLD_TICKS = 30;
+// 80 = SwordTip shape's range in screen px (fallDamage.ts); ÷6 → game units.
+const SWORD_RANGE_GAME = 80 / 6;
+// The sword bounces many times; assume a few land within range of a target under the
+// landing column. Conservative starting value — refine during playtesting.
+const EXPECTED_HITS = 3;
+
+export class ArthurSword extends ChargedHoldReleaseCast {
+  public static spell = ARTHUR_SWORD;
+
+  protected readonly holdTicks = HOLD_TICKS;
+
+  protected aimPoint(): [number, number] {
+    // Aim at the target's X; the sword falls from the sky there. Y is irrelevant.
+    return this.evaluation!.target.centerScreen;
+  }
+
+  static predictDamageAt(distanceGameUnits: number, arcaneValue: number): number {
+    const perHit = 2 + 2 * arcaneValue;
+    return predictFallDamage(distanceGameUnits, SWORD_RANGE_GAME, perHit) * EXPECTED_HITS;
+  }
+
+  evaluate(graph: Graph, targets: Character[]) {
+    this.graph = graph;
+    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
+    const currentMana = this.character.player.mana;
+    const surface = getLevel().terrain.collisionMask;
+    const arcane = getManager().getElementValue(Element.Arcane);
+
+    const everyone: Character[] = [];
+    getLevel().withNearbyEntities(
+      ...this.character.getCenter(),
+      SWORD_RANGE_GAME * 6 * 4,
+      (entity) => {
+        if (entity instanceof Character) everyone.push(entity);
+      },
+    );
+    const allies = collectAllies(this.character, everyone);
+
+    this.evaluations = targets
+      .slice(0, 3)
+      .map((target) => {
+        const feetXGame = target.body.position[0] + 3;
+        const feetYGame = probeX(surface, feetXGame);
+        const predict = (c: Character) => {
+          const [sx, sy] = c.getCenter();
+          const d = Math.sqrt(
+            (sx / 6 - feetXGame) ** 2 + (sy / 6 - feetYGame) ** 2,
+          );
+          return ArthurSword.predictDamageAt(d, arcane);
+        };
+        const value = scoreAOECandidate({
+          target,
+          allies,
+          predictDamage: predict,
+          spell: ArthurSword.spell,
+          currentMana,
+        });
+        if (value === null) return null;
+        return { target: Cluster.onCharacter(target), value, to: [myNode] };
+      })
+      .filter(Boolean)
+      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+
+    this.getNextEvaluation();
+  }
+}

--- a/src/data/bot/strategies/arthurSword.ts
+++ b/src/data/bot/strategies/arthurSword.ts
@@ -1,12 +1,11 @@
 import { ARTHUR_SWORD } from "../../spells";
-import { getLevel, getManager } from "../../context";
+import { getManager } from "../../context";
 import { Character } from "../../entity/character";
 import { Element } from "../../spells/types";
-import { Cluster } from "../cluster";
 import { Graph } from "../graph";
-import { Evaluation } from "./strategy";
 import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
-import { collectAllies, predictFallDamage, scoreAOECandidate } from "./scoring";
+import { predictFallDamage } from "./scoring";
+import { evaluateAOECandidates } from "./aoeEvaluation";
 import { probeX } from "../../map/utils";
 
 const HOLD_TICKS = 30;
@@ -33,45 +32,19 @@ export class ArthurSword extends ChargedHoldReleaseCast {
 
   evaluate(graph: Graph, targets: Character[]) {
     this.graph = graph;
-    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
-    const currentMana = this.character.player.mana;
-    const surface = getLevel().terrain.collisionMask;
     const arcane = getManager().getElementValue(Element.Arcane);
 
-    const everyone: Character[] = [];
-    getLevel().withNearbyEntities(
-      ...this.character.getCenter(),
-      SWORD_RANGE_GAME * 6 * 4,
-      (entity) => {
-        if (entity instanceof Character) everyone.push(entity);
-      },
-    );
-    const allies = collectAllies(this.character, everyone);
-
-    this.evaluations = targets
-      .slice(0, 3)
-      .map((target) => {
+    this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
+      spell: ArthurSword.spell,
+      reachScreen: SWORD_RANGE_GAME * 6,
+      // The sword lands on the ground under the target, not at its body center.
+      impactPoint: (target, { surface }) => {
         const feetXGame = target.body.position[0] + 3;
         const feetYGame = probeX(surface, feetXGame);
-        const predict = (c: Character) => {
-          const [sx, sy] = c.getCenter();
-          const d = Math.sqrt(
-            (sx / 6 - feetXGame) ** 2 + (sy / 6 - feetYGame) ** 2,
-          );
-          return ArthurSword.predictDamageAt(d, arcane);
-        };
-        const value = scoreAOECandidate({
-          target,
-          allies,
-          predictDamage: predict,
-          spell: ArthurSword.spell,
-          currentMana,
-        });
-        if (value === null) return null;
-        return { target: Cluster.onCharacter(target), value, to: [myNode] };
-      })
-      .filter(Boolean)
-      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+        return [feetXGame * 6, feetYGame * 6];
+      },
+      predictDamageAt: (d) => ArthurSword.predictDamageAt(d, arcane),
+    });
 
     this.getNextEvaluation();
   }

--- a/src/data/bot/strategies/babylon.ts
+++ b/src/data/bot/strategies/babylon.ts
@@ -1,0 +1,76 @@
+import { BABYLON } from "../../spells";
+import { getLevel } from "../../context";
+import { Character } from "../../entity/character";
+import { Cluster } from "../cluster";
+import { Graph } from "../graph";
+import { Evaluation } from "./strategy";
+import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
+import { collectAllies, predictFallDamage, scoreAOECandidate } from "./scoring";
+import { probeX } from "../../map/utils";
+
+const HOLD_TICKS = 30;
+// 30 = SmallSword shape's range in screen px (fallDamage.ts); ÷6 → game units.
+const SMALL_SWORD_RANGE_GAME = 30 / 6;
+const PER_HIT = 8; // flat, no element scaling (smallSword.ts)
+// Several of the ~10+ swords land near a target under the spread. Conservative
+// starting value — refine during playtesting.
+const EXPECTED_HITS = 4;
+
+export class Babylon extends ChargedHoldReleaseCast {
+  public static spell = BABYLON;
+
+  protected readonly holdTicks = HOLD_TICKS;
+
+  protected aimPoint(): [number, number] {
+    // Aim at the target's X; swords rain from the sky near it.
+    return this.evaluation!.target.centerScreen;
+  }
+
+  static predictDamageAt(distanceGameUnits: number): number {
+    return predictFallDamage(distanceGameUnits, SMALL_SWORD_RANGE_GAME, PER_HIT) * EXPECTED_HITS;
+  }
+
+  evaluate(graph: Graph, targets: Character[]) {
+    this.graph = graph;
+    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
+    const currentMana = this.character.player.mana;
+    const surface = getLevel().terrain.collisionMask;
+
+    const everyone: Character[] = [];
+    getLevel().withNearbyEntities(
+      ...this.character.getCenter(),
+      SMALL_SWORD_RANGE_GAME * 6 * 4,
+      (entity) => {
+        if (entity instanceof Character) everyone.push(entity);
+      },
+    );
+    const allies = collectAllies(this.character, everyone);
+
+    this.evaluations = targets
+      .slice(0, 3)
+      .map((target) => {
+        const feetXGame = target.body.position[0] + 3;
+        const feetYGame = probeX(surface, feetXGame);
+        const predict = (c: Character) => {
+          const [sx, sy] = c.getCenter();
+          const d = Math.sqrt(
+            (sx / 6 - feetXGame) ** 2 + (sy / 6 - feetYGame) ** 2,
+          );
+          return Babylon.predictDamageAt(d);
+        };
+        const value = scoreAOECandidate({
+          target,
+          allies,
+          predictDamage: predict,
+          spell: Babylon.spell,
+          currentMana,
+        });
+        if (value === null) return null;
+        return { target: Cluster.onCharacter(target), value, to: [myNode] };
+      })
+      .filter(Boolean)
+      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+
+    this.getNextEvaluation();
+  }
+}

--- a/src/data/bot/strategies/babylon.ts
+++ b/src/data/bot/strategies/babylon.ts
@@ -1,11 +1,9 @@
 import { BABYLON } from "../../spells";
-import { getLevel } from "../../context";
 import { Character } from "../../entity/character";
-import { Cluster } from "../cluster";
 import { Graph } from "../graph";
-import { Evaluation } from "./strategy";
 import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
-import { collectAllies, predictFallDamage, scoreAOECandidate } from "./scoring";
+import { predictFallDamage } from "./scoring";
+import { evaluateAOECandidates } from "./aoeEvaluation";
 import { probeX } from "../../map/utils";
 
 const HOLD_TICKS = 30;
@@ -32,44 +30,18 @@ export class Babylon extends ChargedHoldReleaseCast {
 
   evaluate(graph: Graph, targets: Character[]) {
     this.graph = graph;
-    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
-    const currentMana = this.character.player.mana;
-    const surface = getLevel().terrain.collisionMask;
 
-    const everyone: Character[] = [];
-    getLevel().withNearbyEntities(
-      ...this.character.getCenter(),
-      SMALL_SWORD_RANGE_GAME * 6 * 4,
-      (entity) => {
-        if (entity instanceof Character) everyone.push(entity);
-      },
-    );
-    const allies = collectAllies(this.character, everyone);
-
-    this.evaluations = targets
-      .slice(0, 3)
-      .map((target) => {
+    this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
+      spell: Babylon.spell,
+      reachScreen: SMALL_SWORD_RANGE_GAME * 6,
+      // The swords land on the ground under the target, not at its body center.
+      impactPoint: (target, { surface }) => {
         const feetXGame = target.body.position[0] + 3;
         const feetYGame = probeX(surface, feetXGame);
-        const predict = (c: Character) => {
-          const [sx, sy] = c.getCenter();
-          const d = Math.sqrt(
-            (sx / 6 - feetXGame) ** 2 + (sy / 6 - feetYGame) ** 2,
-          );
-          return Babylon.predictDamageAt(d);
-        };
-        const value = scoreAOECandidate({
-          target,
-          allies,
-          predictDamage: predict,
-          spell: Babylon.spell,
-          currentMana,
-        });
-        if (value === null) return null;
-        return { target: Cluster.onCharacter(target), value, to: [myNode] };
-      })
-      .filter(Boolean)
-      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+        return [feetXGame * 6, feetYGame * 6];
+      },
+      predictDamageAt: (d) => Babylon.predictDamageAt(d),
+    });
 
     this.getNextEvaluation();
   }

--- a/src/data/bot/strategies/bakuretsu.ts
+++ b/src/data/bot/strategies/bakuretsu.ts
@@ -1,4 +1,3 @@
-import { Command, CommandType, Key } from "../../controller/controller";
 import { BAKURETSU } from "../../spells";
 import { getLevel, getManager } from "../../context";
 import { Character } from "../../entity/character";
@@ -6,17 +5,12 @@ import { Element } from "../../spells/types";
 import { Cluster } from "../cluster";
 import { Graph } from "../graph";
 import { Evaluation } from "./strategy";
-import { RangedStrategy } from "./rangedStrategy";
 import { collectAllies, predictExplosiveDamage, scoreAOECandidate } from "./scoring";
 import { probeX } from "../../map/utils";
+import { InstantPressCast } from "./instantPressCast";
 
-export class Bakuretsu extends RangedStrategy {
+export class Bakuretsu extends InstantPressCast {
   public static spell = BAKURETSU;
-
-  // Bakuretsu falls from the sky regardless of the bot's position — no LOS needed.
-  protected requiresLineOfSight(): boolean {
-    return false;
-  }
 
   // Bakuretsu blast radius in game units (matches ExplosiveDamage radius in the spell).
   private static BLAST_RADIUS_GAME = 32;
@@ -87,37 +81,10 @@ export class Bakuretsu extends RangedStrategy {
     return predictExplosiveDamage(distance, Bakuretsu.BLAST_RADIUS_GAME, damageMultiplier);
   }
 
-  private pressed = false;
-  private castTime = 0;
-
-  execute(dt: number): Command[] | null {
-    this.castTime += dt;
-
+  protected aimPoint(): [number, number] {
     const [centerX, centerY] = this.evaluation!.target.centerScreen;
-
-    // First call: press M1 (cursor's x maps to projectile spawn x).
-    // Add a small random horizontal offset so explosions don't always land directly on
-    // the target's head — gives the bot a bit of imperfection / variety.
-    // The y component is irrelevant for Bakuretsu (always falls from sky).
-    if (!this.pressed) {
-      this.pressed = true;
-      const offsetX = (Math.random() - 0.5) * 60; // ±30 screen px = ±5 game units
-      return [
-        { type: CommandType.ResetKeys },
-        {
-          type: CommandType.MouseMove,
-          x: centerX + offsetX,
-          y: centerY,
-        },
-        { type: CommandType.KeyPress, key: Key.M1 },
-      ];
-    }
-
-    // Cast already issued — idle a few frames so the cursor's tick observes it, then finish.
-    if (this.castTime > 5) {
-      return null;
-    }
-
-    return [];
+    // ±30 screen px horizontal jitter so explosions don't always land dead-center.
+    const offsetX = (Math.random() - 0.5) * 60;
+    return [centerX + offsetX, centerY];
   }
 }

--- a/src/data/bot/strategies/catastravia.ts
+++ b/src/data/bot/strategies/catastravia.ts
@@ -1,16 +1,9 @@
 import { CATASTRAVIA } from "../../spells";
-import { getLevel } from "../../context";
 import { Character } from "../../entity/character";
-import { Cluster } from "../cluster";
 import { Graph } from "../graph";
-import { Evaluation } from "./strategy";
 import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
-import {
-  collectAllies,
-  hasLineOfSight,
-  predictExplosiveDamage,
-  scoreAOECandidate,
-} from "./scoring";
+import { hasLineOfSight, predictExplosiveDamage } from "./scoring";
+import { evaluateAOECandidates } from "./aoeEvaluation";
 
 const HOLD_TICKS = 50;
 const MISSILE_RADIUS_GAME = 12;
@@ -38,48 +31,20 @@ export class Catastravia extends ChargedHoldReleaseCast {
 
   evaluate(graph: Graph, targets: Character[]) {
     this.graph = graph;
-    const myCenter = this.character.getCenter();
-    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
-    const surface = getLevel().terrain.collisionMask;
-    const currentMana = this.character.player.mana;
 
-    const everyone: Character[] = [];
-    getLevel().withNearbyEntities(myCenter[0], myCenter[1], MAX_RANGE_SCREEN, (entity) => {
-      if (entity instanceof Character) everyone.push(entity);
+    this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
+      spell: Catastravia.spell,
+      reachScreen: (MISSILE_RADIUS_GAME + 5) * 6,
+      impactPoint: (target, { myCenter, surface }) => {
+        const center = target.getCenter();
+        if (Math.hypot(center[0] - myCenter[0], center[1] - myCenter[1]) > MAX_RANGE_SCREEN) {
+          return null;
+        }
+        if (!hasLineOfSight(surface, myCenter, center)) return null;
+        return center;
+      },
+      predictDamageAt: (d) => Catastravia.predictDamageAt(d),
     });
-    const allies = collectAllies(this.character, everyone);
-
-    this.evaluations = targets
-      .slice(0, 3)
-      .map((target) => {
-        const targetCenter = target.getCenter();
-        const dx = targetCenter[0] - myCenter[0];
-        const dy = targetCenter[1] - myCenter[1];
-        if (Math.sqrt(dx * dx + dy * dy) > MAX_RANGE_SCREEN) return null;
-        if (!hasLineOfSight(surface, myCenter, targetCenter)) return null;
-
-        const impactXGame = targetCenter[0] / 6;
-        const impactYGame = targetCenter[1] / 6;
-        const predict = (c: Character) => {
-          const [sx, sy] = c.getCenter();
-          const d = Math.sqrt(
-            (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
-          );
-          return Catastravia.predictDamageAt(d);
-        };
-
-        const value = scoreAOECandidate({
-          target,
-          allies,
-          predictDamage: predict,
-          spell: Catastravia.spell,
-          currentMana,
-        });
-        if (value === null) return null;
-        return { target: Cluster.onCharacter(target), value, to: [myNode] };
-      })
-      .filter(Boolean)
-      .sort((a, b) => b!.value - a!.value) as Evaluation[];
 
     this.getNextEvaluation();
   }

--- a/src/data/bot/strategies/catastravia.ts
+++ b/src/data/bot/strategies/catastravia.ts
@@ -1,0 +1,86 @@
+import { CATASTRAVIA } from "../../spells";
+import { getLevel } from "../../context";
+import { Character } from "../../entity/character";
+import { Cluster } from "../cluster";
+import { Graph } from "../graph";
+import { Evaluation } from "./strategy";
+import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
+import {
+  collectAllies,
+  hasLineOfSight,
+  predictExplosiveDamage,
+  scoreAOECandidate,
+} from "./scoring";
+
+const HOLD_TICKS = 50;
+const MISSILE_RADIUS_GAME = 12;
+const MISSILE_MULTIPLIER = 2;
+// Only a fraction of the cone's volley lands on any one target. Conservative
+// starting value — refine during playtesting.
+const EXPECTED_HITS_ON_TARGET = 3;
+const MAX_RANGE_SCREEN = 800;
+
+export class Catastravia extends ChargedHoldReleaseCast {
+  public static spell = CATASTRAVIA;
+
+  protected readonly holdTicks = HOLD_TICKS;
+
+  protected aimPoint(): [number, number] {
+    return this.evaluation!.target.centerScreen;
+  }
+
+  static predictDamageAt(distanceGameUnits: number): number {
+    return (
+      predictExplosiveDamage(distanceGameUnits, MISSILE_RADIUS_GAME, MISSILE_MULTIPLIER) *
+      EXPECTED_HITS_ON_TARGET
+    );
+  }
+
+  evaluate(graph: Graph, targets: Character[]) {
+    this.graph = graph;
+    const myCenter = this.character.getCenter();
+    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
+    const surface = getLevel().terrain.collisionMask;
+    const currentMana = this.character.player.mana;
+
+    const everyone: Character[] = [];
+    getLevel().withNearbyEntities(myCenter[0], myCenter[1], MAX_RANGE_SCREEN, (entity) => {
+      if (entity instanceof Character) everyone.push(entity);
+    });
+    const allies = collectAllies(this.character, everyone);
+
+    this.evaluations = targets
+      .slice(0, 3)
+      .map((target) => {
+        const targetCenter = target.getCenter();
+        const dx = targetCenter[0] - myCenter[0];
+        const dy = targetCenter[1] - myCenter[1];
+        if (Math.sqrt(dx * dx + dy * dy) > MAX_RANGE_SCREEN) return null;
+        if (!hasLineOfSight(surface, myCenter, targetCenter)) return null;
+
+        const impactXGame = targetCenter[0] / 6;
+        const impactYGame = targetCenter[1] / 6;
+        const predict = (c: Character) => {
+          const [sx, sy] = c.getCenter();
+          const d = Math.sqrt(
+            (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
+          );
+          return Catastravia.predictDamageAt(d);
+        };
+
+        const value = scoreAOECandidate({
+          target,
+          allies,
+          predictDamage: predict,
+          spell: Catastravia.spell,
+          currentMana,
+        });
+        if (value === null) return null;
+        return { target: Cluster.onCharacter(target), value, to: [myNode] };
+      })
+      .filter(Boolean)
+      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+
+    this.getNextEvaluation();
+  }
+}

--- a/src/data/bot/strategies/chargedHoldReleaseCast.ts
+++ b/src/data/bot/strategies/chargedHoldReleaseCast.ts
@@ -1,0 +1,43 @@
+import { Command, CommandType, Key } from "../../controller/controller";
+import { RangedStrategy } from "./rangedStrategy";
+
+/**
+ * Cast gesture for spells fired from a charged cursor (PoweredArcaneCircle / ArcaneCircle):
+ * hold M1 aimed at aimPoint() for holdTicks (which charges power), then release to fire.
+ * Hold duration is wall-clock-equivalent — accumulate dt, don't count calls.
+ */
+export abstract class ChargedHoldReleaseCast extends RangedStrategy {
+  protected abstract readonly holdTicks: number;
+  protected abstract aimPoint(): [number, number];
+
+  private castTime = 0;
+  private released = false;
+
+  execute(dt: number): Command[] | null {
+    const justStarted = this.castTime === 0;
+    this.castTime += dt;
+
+    const [mouseX, mouseY] = this.aimPoint();
+
+    if (this.castTime < this.holdTicks) {
+      const commands: Command[] = [];
+      if (justStarted) commands.push({ type: CommandType.ResetKeys });
+      commands.push(
+        { type: CommandType.MouseMove, x: mouseX, y: mouseY },
+        { type: CommandType.KeyDown, key: Key.M1 },
+      );
+      return commands;
+    }
+
+    if (!this.released) {
+      this.released = true;
+      return [
+        { type: CommandType.KeyUp, key: Key.M1 },
+        { type: CommandType.MouseMove, x: mouseX, y: mouseY },
+      ];
+    }
+
+    if (this.castTime > this.holdTicks + 5) return null;
+    return [];
+  }
+}

--- a/src/data/bot/strategies/doragate.ts
+++ b/src/data/bot/strategies/doragate.ts
@@ -1,0 +1,85 @@
+import { DORAGATE } from "../../spells";
+import { getLevel, getManager } from "../../context";
+import { Character } from "../../entity/character";
+import { Element } from "../../spells/types";
+import { Cluster } from "../cluster";
+import { Graph } from "../graph";
+import { Evaluation } from "./strategy";
+import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
+import {
+  collectAllies,
+  hasLineOfSight,
+  predictExplosiveDamage,
+  scoreAOECandidate,
+} from "./scoring";
+
+const HOLD_TICKS = 40;
+const PEBBLE_RADIUS_GAME = 4;
+// Of the 4+ launched pebbles, assume ~2 graze a point target. Conservative
+// starting value — refine during playtesting.
+const EXPECTED_PEBBLES = 2;
+const MAX_RANGE_SCREEN = 600;
+
+export class Doragate extends ChargedHoldReleaseCast {
+  public static spell = DORAGATE;
+
+  protected readonly holdTicks = HOLD_TICKS;
+
+  protected aimPoint(): [number, number] {
+    return this.evaluation!.target.centerScreen;
+  }
+
+  static predictDamageAt(distanceGameUnits: number, arcaneValue: number): number {
+    const multiplier = 1.5 + arcaneValue * 0.7;
+    return predictExplosiveDamage(distanceGameUnits, PEBBLE_RADIUS_GAME, multiplier) * EXPECTED_PEBBLES;
+  }
+
+  evaluate(graph: Graph, targets: Character[]) {
+    this.graph = graph;
+    const myCenter = this.character.getCenter();
+    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
+    const surface = getLevel().terrain.collisionMask;
+    const currentMana = this.character.player.mana;
+    const arcane = getManager().getElementValue(Element.Arcane);
+
+    const everyone: Character[] = [];
+    getLevel().withNearbyEntities(myCenter[0], myCenter[1], MAX_RANGE_SCREEN, (entity) => {
+      if (entity instanceof Character) everyone.push(entity);
+    });
+    const allies = collectAllies(this.character, everyone);
+
+    this.evaluations = targets
+      .slice(0, 3)
+      .map((target) => {
+        const targetCenter = target.getCenter();
+        const dx = targetCenter[0] - myCenter[0];
+        const dy = targetCenter[1] - myCenter[1];
+        if (Math.sqrt(dx * dx + dy * dy) > MAX_RANGE_SCREEN) return null;
+        if (!hasLineOfSight(surface, myCenter, targetCenter)) return null;
+
+        const impactXGame = targetCenter[0] / 6;
+        const impactYGame = targetCenter[1] / 6;
+        const predict = (c: Character) => {
+          const [sx, sy] = c.getCenter();
+          const d = Math.sqrt(
+            (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
+          );
+          return Doragate.predictDamageAt(d, arcane);
+        };
+
+        const value = scoreAOECandidate({
+          target,
+          allies,
+          predictDamage: predict,
+          spell: Doragate.spell,
+          currentMana,
+        });
+        if (value === null) return null;
+        return { target: Cluster.onCharacter(target), value, to: [myNode] };
+      })
+      .filter(Boolean)
+      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+
+    this.getNextEvaluation();
+  }
+}

--- a/src/data/bot/strategies/doragate.ts
+++ b/src/data/bot/strategies/doragate.ts
@@ -1,17 +1,11 @@
 import { DORAGATE } from "../../spells";
-import { getLevel, getManager } from "../../context";
+import { getManager } from "../../context";
 import { Character } from "../../entity/character";
 import { Element } from "../../spells/types";
-import { Cluster } from "../cluster";
 import { Graph } from "../graph";
-import { Evaluation } from "./strategy";
 import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
-import {
-  collectAllies,
-  hasLineOfSight,
-  predictExplosiveDamage,
-  scoreAOECandidate,
-} from "./scoring";
+import { hasLineOfSight, predictExplosiveDamage } from "./scoring";
+import { evaluateAOECandidates } from "./aoeEvaluation";
 
 const HOLD_TICKS = 40;
 const PEBBLE_RADIUS_GAME = 4;
@@ -36,49 +30,21 @@ export class Doragate extends ChargedHoldReleaseCast {
 
   evaluate(graph: Graph, targets: Character[]) {
     this.graph = graph;
-    const myCenter = this.character.getCenter();
-    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
-    const surface = getLevel().terrain.collisionMask;
-    const currentMana = this.character.player.mana;
     const arcane = getManager().getElementValue(Element.Arcane);
 
-    const everyone: Character[] = [];
-    getLevel().withNearbyEntities(myCenter[0], myCenter[1], MAX_RANGE_SCREEN, (entity) => {
-      if (entity instanceof Character) everyone.push(entity);
+    this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
+      spell: Doragate.spell,
+      reachScreen: (PEBBLE_RADIUS_GAME + 5) * 6,
+      impactPoint: (target, { myCenter, surface }) => {
+        const center = target.getCenter();
+        if (Math.hypot(center[0] - myCenter[0], center[1] - myCenter[1]) > MAX_RANGE_SCREEN) {
+          return null;
+        }
+        if (!hasLineOfSight(surface, myCenter, center)) return null;
+        return center;
+      },
+      predictDamageAt: (d) => Doragate.predictDamageAt(d, arcane),
     });
-    const allies = collectAllies(this.character, everyone);
-
-    this.evaluations = targets
-      .slice(0, 3)
-      .map((target) => {
-        const targetCenter = target.getCenter();
-        const dx = targetCenter[0] - myCenter[0];
-        const dy = targetCenter[1] - myCenter[1];
-        if (Math.sqrt(dx * dx + dy * dy) > MAX_RANGE_SCREEN) return null;
-        if (!hasLineOfSight(surface, myCenter, targetCenter)) return null;
-
-        const impactXGame = targetCenter[0] / 6;
-        const impactYGame = targetCenter[1] / 6;
-        const predict = (c: Character) => {
-          const [sx, sy] = c.getCenter();
-          const d = Math.sqrt(
-            (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
-          );
-          return Doragate.predictDamageAt(d, arcane);
-        };
-
-        const value = scoreAOECandidate({
-          target,
-          allies,
-          predictDamage: predict,
-          spell: Doragate.spell,
-          currentMana,
-        });
-        if (value === null) return null;
-        return { target: Cluster.onCharacter(target), value, to: [myNode] };
-      })
-      .filter(Boolean)
-      .sort((a, b) => b!.value - a!.value) as Evaluation[];
 
     this.getNextEvaluation();
   }

--- a/src/data/bot/strategies/fireball.ts
+++ b/src/data/bot/strategies/fireball.ts
@@ -28,14 +28,6 @@ const MIN_RANGE_SCREEN = 150;
 export class Fireball extends ChargedHoldReleaseCast {
   public static spell = FIREBALL;
 
-  protected maxRange(): number {
-    return MAX_RANGE_SCREEN;
-  }
-
-  protected minRange(): number {
-    return MIN_RANGE_SCREEN;
-  }
-
   protected readonly holdTicks = HOLD_TICKS;
 
   protected aimPoint(): [number, number] {

--- a/src/data/bot/strategies/fireball.ts
+++ b/src/data/bot/strategies/fireball.ts
@@ -1,6 +1,5 @@
-import { Command, CommandType, Key } from "../../controller/controller";
 import { FIREBALL } from "../../spells";
-import { RangedStrategy } from "./rangedStrategy";
+import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
 import { Character } from "../../entity/character";
 import { Cluster } from "../cluster";
 import { Graph } from "../graph";
@@ -26,7 +25,7 @@ const MAX_RANGE_SCREEN = 600;
 // distance, prefer Melee.
 const MIN_RANGE_SCREEN = 150;
 
-export class Fireball extends RangedStrategy {
+export class Fireball extends ChargedHoldReleaseCast {
   public static spell = FIREBALL;
 
   protected maxRange(): number {
@@ -35,6 +34,13 @@ export class Fireball extends RangedStrategy {
 
   protected minRange(): number {
     return MIN_RANGE_SCREEN;
+  }
+
+  protected readonly holdTicks = HOLD_TICKS;
+
+  protected aimPoint(): [number, number] {
+    const [centerX, centerY] = this.evaluation!.target.centerScreen;
+    return [centerX, centerY - AIM_LIFT_PIXELS];
   }
 
   private static BLAST_RADIUS_GAME = 16;
@@ -120,58 +126,4 @@ export class Fireball extends RangedStrategy {
     return predictExplosiveDamage(distance, Fireball.BLAST_RADIUS_GAME, damageMultiplier);
   }
 
-  // PoweredArcaneCircle charges power by ~0.1 * dt per tick, so total charge is
-  // proportional to accumulated time, not call count. Track dt so we hold for the
-  // same wall-clock duration regardless of frame rate.
-  private castTime = 0;
-  private released = false;
-
-  execute(dt: number): Command[] | null {
-    const justStarted = this.castTime === 0;
-    this.castTime += dt;
-
-    const [centerX, centerY] = this.evaluation!.target.centerScreen;
-    const mouseX = centerX;
-    const mouseY = centerY - AIM_LIFT_PIXELS;
-
-    // Phase 1: hold M1 with mouse pointed slightly above target.
-    if (this.castTime < HOLD_TICKS) {
-      const commands: Command[] = [];
-
-      if (justStarted) {
-        commands.push({ type: CommandType.ResetKeys });
-      }
-
-      commands.push(
-        {
-          type: CommandType.MouseMove,
-          x: mouseX,
-          y: mouseY,
-        },
-        { type: CommandType.KeyDown, key: Key.M1 }
-      );
-
-      return commands;
-    }
-
-    // Phase 2: first tick past HOLD_TICKS — release M1 to fire at the charged power.
-    if (!this.released) {
-      this.released = true;
-      return [
-        { type: CommandType.KeyUp, key: Key.M1 },
-        {
-          type: CommandType.MouseMove,
-          x: mouseX,
-          y: mouseY,
-        },
-      ];
-    }
-
-    // Phase 3: idle so the cursor observes M1 released.
-    if (this.castTime > HOLD_TICKS + 5) {
-      return null;
-    }
-
-    return [];
-  }
 }

--- a/src/data/bot/strategies/fireball.ts
+++ b/src/data/bot/strategies/fireball.ts
@@ -7,7 +7,7 @@ import { Graph } from "../graph";
 import { Evaluation } from "./strategy";
 import { getLevel, getManager } from "../../context";
 import { Element } from "../../spells/types";
-import { collectAllies, predictExplosiveDamage, scoreAOECandidate } from "./scoring";
+import { collectAllies, hasLineOfSight, predictExplosiveDamage, scoreAOECandidate } from "./scoring";
 
 // PoweredArcaneCircle charges power at 0.1/tick starting from ~0.
 // 50 ticks → power ≈ 5.0, near-max (5.49) — gives Fireball maximum range.
@@ -73,14 +73,7 @@ export class Fireball extends RangedStrategy {
         if (distance > MAX_RANGE_SCREEN || distance < MIN_RANGE_SCREEN) return null;
 
         // LOS check vs terrain.
-        if (
-          surface.collidesWithLine(
-            Math.round(myCenter[0] / 6),
-            Math.round(myCenter[1] / 6),
-            Math.round(targetCenter[0] / 6),
-            Math.round(targetCenter[1] / 6),
-          )
-        ) {
+        if (!hasLineOfSight(surface, myCenter, targetCenter)) {
           return null;
         }
 

--- a/src/data/bot/strategies/guidanceHeading.ts
+++ b/src/data/bot/strategies/guidanceHeading.ts
@@ -1,0 +1,40 @@
+import { CollisionMask } from "../../collision/collisionMask";
+
+/**
+ * Choose a steering heading (radians) for a guided missile at `fromGame` aiming for
+ * `targetGame` (game units). Samples the direct heading plus symmetric angular offsets,
+ * rejecting any that hit terrain within `lookaheadGameUnits`, and returns the
+ * collision-free heading closest to the direct target direction. Falls back to the
+ * direct heading if every candidate is blocked (keep homing rather than freeze).
+ */
+export function chooseGuidanceHeading(
+  surface: CollisionMask,
+  fromGame: [number, number],
+  targetGame: [number, number],
+  lookaheadGameUnits: number,
+): number {
+  const direct = Math.atan2(
+    targetGame[1] - fromGame[1],
+    targetGame[0] - fromGame[0],
+  );
+
+  const offsets = [0, -0.3, 0.3, -0.6, 0.6, -0.9, 0.9, -1.2, 1.2];
+  for (const off of offsets) {
+    const heading = direct + off;
+    const ahead: [number, number] = [
+      fromGame[0] + Math.cos(heading) * lookaheadGameUnits,
+      fromGame[1] + Math.sin(heading) * lookaheadGameUnits,
+    ];
+    if (
+      !surface.collidesWithLine(
+        Math.round(fromGame[0]),
+        Math.round(fromGame[1]),
+        Math.round(ahead[0]),
+        Math.round(ahead[1]),
+      )
+    ) {
+      return heading;
+    }
+  }
+  return direct;
+}

--- a/src/data/bot/strategies/hairpin.ts
+++ b/src/data/bot/strategies/hairpin.ts
@@ -1,17 +1,11 @@
 import { HAIRPIN } from "../../spells";
-import { getLevel, getManager } from "../../context";
+import { getManager } from "../../context";
 import { Character } from "../../entity/character";
 import { Element } from "../../spells/types";
-import { Cluster } from "../cluster";
 import { Graph } from "../graph";
-import { Evaluation } from "./strategy";
 import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
-import {
-  collectAllies,
-  hasLineOfSight,
-  predictExplosiveDamage,
-  scoreAOECandidate,
-} from "./scoring";
+import { hasLineOfSight, predictExplosiveDamage } from "./scoring";
+import { evaluateAOECandidates } from "./aoeEvaluation";
 
 const HOLD_TICKS = 45;
 const BOMB_RADIUS_GAME = 16;
@@ -36,49 +30,21 @@ export class Hairpin extends ChargedHoldReleaseCast {
 
   evaluate(graph: Graph, targets: Character[]) {
     this.graph = graph;
-    const myCenter = this.character.getCenter();
-    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
-    const surface = getLevel().terrain.collisionMask;
-    const currentMana = this.character.player.mana;
     const elemental = getManager().getElementValue(Element.Elemental);
 
-    const everyone: Character[] = [];
-    getLevel().withNearbyEntities(myCenter[0], myCenter[1], MAX_RANGE_SCREEN, (entity) => {
-      if (entity instanceof Character) everyone.push(entity);
+    this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
+      spell: Hairpin.spell,
+      reachScreen: (BOMB_RADIUS_GAME + 5) * 6,
+      impactPoint: (target, { myCenter, surface }) => {
+        const center = target.getCenter();
+        if (Math.hypot(center[0] - myCenter[0], center[1] - myCenter[1]) > MAX_RANGE_SCREEN) {
+          return null;
+        }
+        if (!hasLineOfSight(surface, myCenter, center)) return null;
+        return center;
+      },
+      predictDamageAt: (d) => Hairpin.predictDamageAt(d, elemental),
     });
-    const allies = collectAllies(this.character, everyone);
-
-    this.evaluations = targets
-      .slice(0, 3)
-      .map((target) => {
-        const targetCenter = target.getCenter();
-        const dx = targetCenter[0] - myCenter[0];
-        const dy = targetCenter[1] - myCenter[1];
-        if (Math.sqrt(dx * dx + dy * dy) > MAX_RANGE_SCREEN) return null;
-        if (!hasLineOfSight(surface, myCenter, targetCenter)) return null;
-
-        const impactXGame = targetCenter[0] / 6;
-        const impactYGame = targetCenter[1] / 6;
-        const predict = (c: Character) => {
-          const [sx, sy] = c.getCenter();
-          const d = Math.sqrt(
-            (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
-          );
-          return Hairpin.predictDamageAt(d, elemental);
-        };
-
-        const value = scoreAOECandidate({
-          target,
-          allies,
-          predictDamage: predict,
-          spell: Hairpin.spell,
-          currentMana,
-        });
-        if (value === null) return null;
-        return { target: Cluster.onCharacter(target), value, to: [myNode] };
-      })
-      .filter(Boolean)
-      .sort((a, b) => b!.value - a!.value) as Evaluation[];
 
     this.getNextEvaluation();
   }

--- a/src/data/bot/strategies/hairpin.ts
+++ b/src/data/bot/strategies/hairpin.ts
@@ -1,0 +1,85 @@
+import { HAIRPIN } from "../../spells";
+import { getLevel, getManager } from "../../context";
+import { Character } from "../../entity/character";
+import { Element } from "../../spells/types";
+import { Cluster } from "../cluster";
+import { Graph } from "../graph";
+import { Evaluation } from "./strategy";
+import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
+import {
+  collectAllies,
+  hasLineOfSight,
+  predictExplosiveDamage,
+  scoreAOECandidate,
+} from "./scoring";
+
+const HOLD_TICKS = 45;
+const BOMB_RADIUS_GAME = 16;
+// Of the 3 launched bombs, assume ~2 land near a point target. Conservative
+// starting value — refine during playtesting.
+const EXPECTED_BOMBS = 2;
+const MAX_RANGE_SCREEN = 700;
+
+export class Hairpin extends ChargedHoldReleaseCast {
+  public static spell = HAIRPIN;
+
+  protected readonly holdTicks = HOLD_TICKS;
+
+  protected aimPoint(): [number, number] {
+    return this.evaluation!.target.centerScreen;
+  }
+
+  static predictDamageAt(distanceGameUnits: number, elementalValue: number): number {
+    const multiplier = 5 * (0.7 + elementalValue * 0.3);
+    return predictExplosiveDamage(distanceGameUnits, BOMB_RADIUS_GAME, multiplier) * EXPECTED_BOMBS;
+  }
+
+  evaluate(graph: Graph, targets: Character[]) {
+    this.graph = graph;
+    const myCenter = this.character.getCenter();
+    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
+    const surface = getLevel().terrain.collisionMask;
+    const currentMana = this.character.player.mana;
+    const elemental = getManager().getElementValue(Element.Elemental);
+
+    const everyone: Character[] = [];
+    getLevel().withNearbyEntities(myCenter[0], myCenter[1], MAX_RANGE_SCREEN, (entity) => {
+      if (entity instanceof Character) everyone.push(entity);
+    });
+    const allies = collectAllies(this.character, everyone);
+
+    this.evaluations = targets
+      .slice(0, 3)
+      .map((target) => {
+        const targetCenter = target.getCenter();
+        const dx = targetCenter[0] - myCenter[0];
+        const dy = targetCenter[1] - myCenter[1];
+        if (Math.sqrt(dx * dx + dy * dy) > MAX_RANGE_SCREEN) return null;
+        if (!hasLineOfSight(surface, myCenter, targetCenter)) return null;
+
+        const impactXGame = targetCenter[0] / 6;
+        const impactYGame = targetCenter[1] / 6;
+        const predict = (c: Character) => {
+          const [sx, sy] = c.getCenter();
+          const d = Math.sqrt(
+            (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
+          );
+          return Hairpin.predictDamageAt(d, elemental);
+        };
+
+        const value = scoreAOECandidate({
+          target,
+          allies,
+          predictDamage: predict,
+          spell: Hairpin.spell,
+          currentMana,
+        });
+        if (value === null) return null;
+        return { target: Cluster.onCharacter(target), value, to: [myNode] };
+      })
+      .filter(Boolean)
+      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+
+    this.getNextEvaluation();
+  }
+}

--- a/src/data/bot/strategies/instantPressCast.ts
+++ b/src/data/bot/strategies/instantPressCast.ts
@@ -1,0 +1,31 @@
+import { Command, CommandType, Key } from "../../controller/controller";
+import { RangedStrategy } from "./rangedStrategy";
+
+/**
+ * Cast gesture for spells that fire on a single M1 press (ApplyCursor / single-press
+ * cursors): one tick of ResetKeys + aim + KeyPress M1, then idle until the cursor
+ * observes the press.
+ */
+export abstract class InstantPressCast extends RangedStrategy {
+  protected abstract aimPoint(): [number, number];
+
+  private pressed = false;
+  private castTime = 0;
+
+  execute(dt: number): Command[] | null {
+    this.castTime += dt;
+
+    if (!this.pressed) {
+      this.pressed = true;
+      const [x, y] = this.aimPoint();
+      return [
+        { type: CommandType.ResetKeys },
+        { type: CommandType.MouseMove, x, y },
+        { type: CommandType.KeyPress, key: Key.M1 },
+      ];
+    }
+
+    if (this.castTime > 5) return null;
+    return [];
+  }
+}

--- a/src/data/bot/strategies/lightning.ts
+++ b/src/data/bot/strategies/lightning.ts
@@ -1,0 +1,90 @@
+import { LIGHTNING, getSpellCost } from "../../spells";
+import { getLevel, getManager } from "../../context";
+import { Character } from "../../entity/character";
+import { Element } from "../../spells/types";
+import { Cluster } from "../cluster";
+import { Graph } from "../graph";
+import { Evaluation } from "./strategy";
+import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
+import { hasLineOfSight, predictChainTargets, scoreCandidate } from "./scoring";
+
+const HOLD_TICKS = 35;
+const CHAIN_RANGE_SCREEN = 260;
+const MAX_CHAINS = 5;
+// Same value as CHAIN_RANGE_SCREEN: the first hop uses the same range as later hops.
+const MAX_RANGE_SCREEN = 260;
+
+export class Lightning extends ChargedHoldReleaseCast {
+  public static spell = LIGHTNING;
+
+  protected readonly holdTicks = HOLD_TICKS;
+
+  protected aimPoint(): [number, number] {
+    return this.evaluation!.target.centerScreen;
+  }
+
+  static predictPerTarget(elementalValue: number): number {
+    return 20 + elementalValue * 5;
+  }
+
+  evaluate(graph: Graph, targets: Character[]) {
+    this.graph = graph;
+    const myCenter = this.character.getCenter();
+    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
+    const surface = getLevel().terrain.collisionMask;
+    const currentMana = this.character.player.mana;
+    const perTarget = Lightning.predictPerTarget(
+      getManager().getElementValue(Element.Elemental),
+    );
+
+    const enemies: Character[] = [];
+    getLevel().withNearbyEntities(
+      myCenter[0],
+      myCenter[1],
+      CHAIN_RANGE_SCREEN * MAX_CHAINS,
+      (entity) => {
+        if (entity instanceof Character && entity.player !== this.character.player) {
+          enemies.push(entity);
+        }
+      },
+    );
+
+    this.evaluations = targets
+      .slice(0, 3)
+      .map((target) => {
+        const targetCenter = target.getCenter();
+        const dx = targetCenter[0] - myCenter[0];
+        const dy = targetCenter[1] - myCenter[1];
+        if (Math.sqrt(dx * dx + dy * dy) > MAX_RANGE_SCREEN) return null;
+        if (!hasLineOfSight(surface, myCenter, targetCenter)) return null;
+
+        // Chains start at the primary target and hop to other nearby enemies.
+        // +1 counts the primary target; MAX_CHAINS - 1 caps the hops that follow it,
+        // keeping total hits within the spell's chain limit.
+        const otherEnemies = enemies
+          .filter((e) => e !== target)
+          .map((e) => e.getCenter());
+        const hits =
+          predictChainTargets(targetCenter, otherEnemies, CHAIN_RANGE_SCREEN, MAX_CHAINS - 1) + 1;
+        const enemyDamage = perTarget * hits;
+
+        // Chains can hit allies, but ally damage and kill-detection are omitted here.
+        // This underestimates value in clusters and will NOT suppress firing near a
+        // low-HP ally. Accepted as a conservative start; revisit if bots team-kill.
+        const value = scoreCandidate({
+          enemyDamage,
+          friendlyDamage: 0,
+          killsAlly: false,
+          targetHp: target.hp,
+          spellCost: getSpellCost(Lightning.spell),
+          currentMana,
+        });
+        if (value === null) return null;
+        return { target: Cluster.onCharacter(target), value, to: [myNode] };
+      })
+      .filter(Boolean)
+      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+
+    this.getNextEvaluation();
+  }
+}

--- a/src/data/bot/strategies/magicMissile.ts
+++ b/src/data/bot/strategies/magicMissile.ts
@@ -1,0 +1,140 @@
+import { Command, CommandType, Key } from "../../controller/controller";
+import { MAGIC_MISSILE } from "../../spells";
+import { getLevel, getManager } from "../../context";
+import { Character } from "../../entity/character";
+import { EntityType, isSpawnableEntity, Spawnable } from "../../entity/types";
+import { Element } from "../../spells/types";
+import { Cluster } from "../cluster";
+import { Graph } from "../graph";
+import { Evaluation } from "./strategy";
+import { RangedStrategy } from "./rangedStrategy";
+import {
+  collectAllies,
+  predictExplosiveDamage,
+  scoreAOECandidate,
+} from "./scoring";
+import { chooseGuidanceHeading } from "./guidanceHeading";
+
+const BLAST_RADIUS_GAME = 16;
+const LOOKAHEAD_GAME = 40;
+const MAX_RANGE_SCREEN = 1500;
+const SAFETY_TIMEOUT = 600; // ticks; bail if the missile never reports gone
+// Screen-px vector length used to turn a steering heading into a mouse position —
+// long enough that the missile tracks the angle, not the cursor's distance.
+const AIM_PROJECTION_SCREEN = 300;
+
+export class MagicMissile extends RangedStrategy {
+  public static spell = MAGIC_MISSILE;
+
+  static predictDamageAt(
+    distanceGameUnits: number,
+    arcaneValue: number,
+  ): number {
+    return predictExplosiveDamage(
+      distanceGameUnits,
+      BLAST_RADIUS_GAME,
+      5 + arcaneValue,
+    );
+  }
+
+  evaluate(graph: Graph, targets: Character[]) {
+    this.graph = graph;
+    const myCenter = this.character.getCenter();
+    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
+    const currentMana = this.character.player.mana;
+    const arcane = getManager().getElementValue(Element.Arcane);
+
+    const everyone: Character[] = [];
+    getLevel().withNearbyEntities(
+      myCenter[0],
+      myCenter[1],
+      MAX_RANGE_SCREEN,
+      (entity) => {
+        if (entity instanceof Character) everyone.push(entity);
+      },
+    );
+    const allies = collectAllies(this.character, everyone);
+
+    // No LOS check — the missile steers around terrain, so range alone gates viability.
+    this.evaluations = targets
+      .slice(0, 3)
+      .map((target) => {
+        const targetCenter = target.getCenter();
+        const dx = targetCenter[0] - myCenter[0];
+        const dy = targetCenter[1] - myCenter[1];
+        if (Math.sqrt(dx * dx + dy * dy) > MAX_RANGE_SCREEN) return null;
+
+        const impactXGame = targetCenter[0] / 6;
+        const impactYGame = targetCenter[1] / 6;
+        const predict = (c: Character) => {
+          const [sx, sy] = c.getCenter();
+          const d = Math.sqrt(
+            (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
+          );
+          return MagicMissile.predictDamageAt(d, arcane);
+        };
+
+        const value = scoreAOECandidate({
+          target,
+          allies,
+          predictDamage: predict,
+          spell: MagicMissile.spell,
+          currentMana,
+        });
+        if (value === null) return null;
+
+        return { target: Cluster.onCharacter(target), value, to: [myNode] };
+      })
+      .filter(Boolean)
+      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+
+    this.getNextEvaluation();
+  }
+
+  private fired = false;
+  private castTime = 0;
+
+  private findMissile(): Spawnable | null {
+    let found: Spawnable | null = null;
+    getLevel().entities.forEach((entity) => {
+      if (isSpawnableEntity(entity) && entity.type === EntityType.MagicMissile) {
+        found = entity;
+      }
+    });
+    return found;
+  }
+
+  execute(dt: number): Command[] | null {
+    this.castTime += dt;
+    const surface = getLevel().terrain.collisionMask;
+    const [targetX, targetY] = this.evaluation!.target.centerScreen;
+
+    if (!this.fired) {
+      this.fired = true;
+      return [
+        { type: CommandType.ResetKeys },
+        { type: CommandType.MouseMove, x: targetX, y: targetY },
+        { type: CommandType.KeyDown, key: Key.M1 },
+      ];
+    }
+
+    const missile = this.findMissile();
+    if (!missile || this.castTime > SAFETY_TIMEOUT) {
+      return null;
+    }
+
+    const [mx, my] = missile.getCenter();
+    const heading = chooseGuidanceHeading(
+      surface,
+      [mx / 6, my / 6],
+      [targetX / 6, targetY / 6],
+      LOOKAHEAD_GAME,
+    );
+    const aimX = mx + Math.cos(heading) * AIM_PROJECTION_SCREEN;
+    const aimY = my + Math.sin(heading) * AIM_PROJECTION_SCREEN;
+    return [
+      { type: CommandType.MouseMove, x: aimX, y: aimY },
+      { type: CommandType.KeyDown, key: Key.M1 },
+    ];
+  }
+}

--- a/src/data/bot/strategies/magicMissile.ts
+++ b/src/data/bot/strategies/magicMissile.ts
@@ -1,18 +1,13 @@
 import { Command, CommandType, Key } from "../../controller/controller";
 import { MAGIC_MISSILE } from "../../spells";
+import { MagicMissile as MagicMissileEntity } from "../../spells/magicMissile";
 import { getLevel, getManager } from "../../context";
 import { Character } from "../../entity/character";
-import { EntityType, isSpawnableEntity, Spawnable } from "../../entity/types";
 import { Element } from "../../spells/types";
-import { Cluster } from "../cluster";
 import { Graph } from "../graph";
-import { Evaluation } from "./strategy";
 import { RangedStrategy } from "./rangedStrategy";
-import {
-  collectAllies,
-  predictExplosiveDamage,
-  scoreAOECandidate,
-} from "./scoring";
+import { predictExplosiveDamage } from "./scoring";
+import { evaluateAOECandidates } from "./aoeEvaluation";
 import { chooseGuidanceHeading } from "./guidanceHeading";
 
 const BLAST_RADIUS_GAME = 16;
@@ -22,6 +17,10 @@ const SAFETY_TIMEOUT = 600; // ticks; bail if the missile never reports gone
 // Screen-px vector length used to turn a steering heading into a mouse position —
 // long enough that the missile tracks the angle, not the cursor's distance.
 const AIM_PROJECTION_SCREEN = 300;
+// target.centerScreen is the foot center (≈ ground level for a grounded character).
+// Aim at the body instead so the missile flies above the terrain and strikes the
+// enemy's body, rather than nosediving into the ground at our own feet. Empirical.
+const AIM_LIFT_PIXELS = 24;
 
 export class MagicMissile extends RangedStrategy {
   public static spell = MAGIC_MISSILE;
@@ -39,65 +38,34 @@ export class MagicMissile extends RangedStrategy {
 
   evaluate(graph: Graph, targets: Character[]) {
     this.graph = graph;
-    const myCenter = this.character.getCenter();
-    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
-    const currentMana = this.character.player.mana;
     const arcane = getManager().getElementValue(Element.Arcane);
 
-    const everyone: Character[] = [];
-    getLevel().withNearbyEntities(
-      myCenter[0],
-      myCenter[1],
-      MAX_RANGE_SCREEN,
-      (entity) => {
-        if (entity instanceof Character) everyone.push(entity);
+    this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
+      spell: MagicMissile.spell,
+      reachScreen: (BLAST_RADIUS_GAME + 5) * 6,
+      // No LOS check — the missile steers around terrain, so range alone gates viability.
+      impactPoint: (target, { myCenter }) => {
+        const center = target.getCenter();
+        if (Math.hypot(center[0] - myCenter[0], center[1] - myCenter[1]) > MAX_RANGE_SCREEN) {
+          return null;
+        }
+        return center;
       },
-    );
-    const allies = collectAllies(this.character, everyone);
-
-    // No LOS check — the missile steers around terrain, so range alone gates viability.
-    this.evaluations = targets
-      .slice(0, 3)
-      .map((target) => {
-        const targetCenter = target.getCenter();
-        const dx = targetCenter[0] - myCenter[0];
-        const dy = targetCenter[1] - myCenter[1];
-        if (Math.sqrt(dx * dx + dy * dy) > MAX_RANGE_SCREEN) return null;
-
-        const impactXGame = targetCenter[0] / 6;
-        const impactYGame = targetCenter[1] / 6;
-        const predict = (c: Character) => {
-          const [sx, sy] = c.getCenter();
-          const d = Math.sqrt(
-            (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
-          );
-          return MagicMissile.predictDamageAt(d, arcane);
-        };
-
-        const value = scoreAOECandidate({
-          target,
-          allies,
-          predictDamage: predict,
-          spell: MagicMissile.spell,
-          currentMana,
-        });
-        if (value === null) return null;
-
-        return { target: Cluster.onCharacter(target), value, to: [myNode] };
-      })
-      .filter(Boolean)
-      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+      predictDamageAt: (d) => MagicMissile.predictDamageAt(d, arcane),
+    });
 
     this.getNextEvaluation();
   }
 
   private fired = false;
   private castTime = 0;
+  private cleanedUp = false;
 
-  private findMissile(): Spawnable | null {
-    let found: Spawnable | null = null;
+  // Only our own missile, so a missile fired by another bot/player isn't steered.
+  private findMissile(): MagicMissileEntity | null {
+    let found: MagicMissileEntity | null = null;
     getLevel().entities.forEach((entity) => {
-      if (isSpawnableEntity(entity) && entity.type === EntityType.MagicMissile) {
+      if (entity instanceof MagicMissileEntity && entity.owner === this.character) {
         found = entity;
       }
     });
@@ -107,7 +75,8 @@ export class MagicMissile extends RangedStrategy {
   execute(dt: number): Command[] | null {
     this.castTime += dt;
     const surface = getLevel().terrain.collisionMask;
-    const [targetX, targetY] = this.evaluation!.target.centerScreen;
+    const [targetX, footY] = this.evaluation!.target.centerScreen;
+    const targetY = footY - AIM_LIFT_PIXELS;
 
     if (!this.fired) {
       this.fired = true;
@@ -120,6 +89,12 @@ export class MagicMissile extends RangedStrategy {
 
     const missile = this.findMissile();
     if (!missile || this.castTime > SAFETY_TIMEOUT) {
+      // Release M1 once before finishing so we don't leave the button held down for
+      // the next strategy (it would steer/charge whatever comes next).
+      if (!this.cleanedUp) {
+        this.cleanedUp = true;
+        return [{ type: CommandType.ResetKeys }];
+      }
       return null;
     }
 

--- a/src/data/bot/strategies/meteor.ts
+++ b/src/data/bot/strategies/meteor.ts
@@ -1,0 +1,81 @@
+import { METEOR } from "../../spells";
+import { getLevel, getManager } from "../../context";
+import { Character } from "../../entity/character";
+import { Element } from "../../spells/types";
+import { Cluster } from "../cluster";
+import { Graph } from "../graph";
+import { Evaluation } from "./strategy";
+import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
+import { collectAllies, predictExplosiveDamage, scoreAOECandidate } from "./scoring";
+import { probeX } from "../../map/utils";
+
+// Long enough for the Lock cursor to acquire the target before release — the Lock
+// only casts once locked, so too short a hold would miss the targeting window.
+const HOLD_TICKS = 70;
+const BLAST_RADIUS_GAME = 16;
+// Bounces that land near the target before the meteor travels off. Conservative
+// starting value — refine during playtesting.
+const EXPECTED_BOUNCES = 2;
+
+export class Meteor extends ChargedHoldReleaseCast {
+  public static spell = METEOR;
+
+  protected readonly holdTicks = HOLD_TICKS;
+
+  protected aimPoint(): [number, number] {
+    return this.evaluation!.target.centerScreen;
+  }
+
+  static predictDamageAt(distanceGameUnits: number, elementalValue: number): number {
+    const multiplier = 5 + elementalValue / 2;
+    return (
+      predictExplosiveDamage(distanceGameUnits, BLAST_RADIUS_GAME, multiplier) *
+      EXPECTED_BOUNCES
+    );
+  }
+
+  evaluate(graph: Graph, targets: Character[]) {
+    this.graph = graph;
+    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
+    const currentMana = this.character.player.mana;
+    const surface = getLevel().terrain.collisionMask;
+    const elemental = getManager().getElementValue(Element.Elemental);
+
+    const everyone: Character[] = [];
+    getLevel().withNearbyEntities(
+      ...this.character.getCenter(),
+      BLAST_RADIUS_GAME * 6 * 5,
+      (entity) => {
+        if (entity instanceof Character) everyone.push(entity);
+      },
+    );
+    const allies = collectAllies(this.character, everyone);
+
+    this.evaluations = targets
+      .slice(0, 3)
+      .map((target) => {
+        const feetXGame = target.body.position[0] + 3;
+        const feetYGame = probeX(surface, feetXGame);
+        const predict = (c: Character) => {
+          const [sx, sy] = c.getCenter();
+          const d = Math.sqrt(
+            (sx / 6 - feetXGame) ** 2 + (sy / 6 - feetYGame) ** 2,
+          );
+          return Meteor.predictDamageAt(d, elemental);
+        };
+        const value = scoreAOECandidate({
+          target,
+          allies,
+          predictDamage: predict,
+          spell: Meteor.spell,
+          currentMana,
+        });
+        if (value === null) return null;
+        return { target: Cluster.onCharacter(target), value, to: [myNode] };
+      })
+      .filter(Boolean)
+      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+
+    this.getNextEvaluation();
+  }
+}

--- a/src/data/bot/strategies/meteor.ts
+++ b/src/data/bot/strategies/meteor.ts
@@ -1,12 +1,11 @@
 import { METEOR } from "../../spells";
-import { getLevel, getManager } from "../../context";
+import { getManager } from "../../context";
 import { Character } from "../../entity/character";
 import { Element } from "../../spells/types";
-import { Cluster } from "../cluster";
 import { Graph } from "../graph";
-import { Evaluation } from "./strategy";
 import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
-import { collectAllies, predictExplosiveDamage, scoreAOECandidate } from "./scoring";
+import { predictExplosiveDamage } from "./scoring";
+import { evaluateAOECandidates } from "./aoeEvaluation";
 import { probeX } from "../../map/utils";
 
 // Long enough for the Lock cursor to acquire the target before release — the Lock
@@ -36,45 +35,19 @@ export class Meteor extends ChargedHoldReleaseCast {
 
   evaluate(graph: Graph, targets: Character[]) {
     this.graph = graph;
-    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
-    const currentMana = this.character.player.mana;
-    const surface = getLevel().terrain.collisionMask;
     const elemental = getManager().getElementValue(Element.Elemental);
 
-    const everyone: Character[] = [];
-    getLevel().withNearbyEntities(
-      ...this.character.getCenter(),
-      BLAST_RADIUS_GAME * 6 * 5,
-      (entity) => {
-        if (entity instanceof Character) everyone.push(entity);
-      },
-    );
-    const allies = collectAllies(this.character, everyone);
-
-    this.evaluations = targets
-      .slice(0, 3)
-      .map((target) => {
+    this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
+      spell: Meteor.spell,
+      reachScreen: (BLAST_RADIUS_GAME + 5) * 6,
+      // The meteor lands on the ground under the target, not at its body center.
+      impactPoint: (target, { surface }) => {
         const feetXGame = target.body.position[0] + 3;
         const feetYGame = probeX(surface, feetXGame);
-        const predict = (c: Character) => {
-          const [sx, sy] = c.getCenter();
-          const d = Math.sqrt(
-            (sx / 6 - feetXGame) ** 2 + (sy / 6 - feetYGame) ** 2,
-          );
-          return Meteor.predictDamageAt(d, elemental);
-        };
-        const value = scoreAOECandidate({
-          target,
-          allies,
-          predictDamage: predict,
-          spell: Meteor.spell,
-          currentMana,
-        });
-        if (value === null) return null;
-        return { target: Cluster.onCharacter(target), value, to: [myNode] };
-      })
-      .filter(Boolean)
-      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+        return [feetXGame * 6, feetYGame * 6];
+      },
+      predictDamageAt: (d) => Meteor.predictDamageAt(d, elemental),
+    });
 
     this.getNextEvaluation();
   }

--- a/src/data/bot/strategies/nephtear.ts
+++ b/src/data/bot/strategies/nephtear.ts
@@ -1,0 +1,85 @@
+import { NEPHTEAR } from "../../spells";
+import { getLevel, getManager } from "../../context";
+import { Character } from "../../entity/character";
+import { Element } from "../../spells/types";
+import { Cluster } from "../cluster";
+import { Graph } from "../graph";
+import { Evaluation } from "./strategy";
+import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
+import {
+  collectAllies,
+  hasLineOfSight,
+  predictImpactDamage,
+  scoreAOECandidate,
+} from "./scoring";
+
+const HOLD_TICKS = 40;
+const AIM_LIFT_PIXELS = 40;
+const MAX_RANGE_SCREEN = 700;
+const MIN_RANGE_SCREEN = 120;
+
+export class Nephtear extends ChargedHoldReleaseCast {
+  public static spell = NEPHTEAR;
+
+  protected readonly holdTicks = HOLD_TICKS;
+
+  protected aimPoint(): [number, number] {
+    const [cx, cy] = this.evaluation!.target.centerScreen;
+    return [cx, cy - AIM_LIFT_PIXELS];
+  }
+
+  static predictDamageAt(distanceGameUnits: number, elementValue: number): number {
+    const power = 30 * (0.7 + elementValue * 0.3);
+    return predictImpactDamage(distanceGameUnits, power);
+  }
+
+  evaluate(graph: Graph, targets: Character[]) {
+    this.graph = graph;
+    const myCenter = this.character.getCenter();
+    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
+    const surface = getLevel().terrain.collisionMask;
+    const currentMana = this.character.player.mana;
+    const elementValue = getManager().getElementValue(Element.Elemental);
+
+    const everyone: Character[] = [];
+    getLevel().withNearbyEntities(myCenter[0], myCenter[1], MAX_RANGE_SCREEN, (e) => {
+      if (e instanceof Character) everyone.push(e);
+    });
+    const allies = collectAllies(this.character, everyone);
+
+    this.evaluations = targets
+      .slice(0, 3)
+      .map((target) => {
+        const targetCenter = target.getCenter();
+        const dx = targetCenter[0] - myCenter[0];
+        const dy = targetCenter[1] - myCenter[1];
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        if (distance > MAX_RANGE_SCREEN || distance < MIN_RANGE_SCREEN) return null;
+        if (!hasLineOfSight(surface, myCenter, targetCenter)) return null;
+
+        const impactXGame = targetCenter[0] / 6;
+        const impactYGame = targetCenter[1] / 6;
+        const predict = (c: Character) => {
+          const [sx, sy] = c.getCenter();
+          const d = Math.sqrt(
+            (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
+          );
+          return Nephtear.predictDamageAt(d, elementValue);
+        };
+
+        const value = scoreAOECandidate({
+          target,
+          allies,
+          predictDamage: predict,
+          spell: Nephtear.spell,
+          currentMana,
+        });
+        if (value === null) return null;
+        return { target: Cluster.onCharacter(target), value, to: [myNode] };
+      })
+      .filter(Boolean)
+      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+
+    this.getNextEvaluation();
+  }
+}

--- a/src/data/bot/strategies/nephtear.ts
+++ b/src/data/bot/strategies/nephtear.ts
@@ -1,20 +1,16 @@
 import { NEPHTEAR } from "../../spells";
-import { getLevel, getManager } from "../../context";
+import { getManager } from "../../context";
 import { Character } from "../../entity/character";
 import { Element } from "../../spells/types";
-import { Cluster } from "../cluster";
 import { Graph } from "../graph";
-import { Evaluation } from "./strategy";
 import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
-import {
-  collectAllies,
-  hasLineOfSight,
-  predictImpactDamage,
-  scoreAOECandidate,
-} from "./scoring";
+import { hasLineOfSight, predictImpactDamage } from "./scoring";
+import { evaluateAOECandidates } from "./aoeEvaluation";
 
 const HOLD_TICKS = 40;
 const AIM_LIFT_PIXELS = 40;
+// ImpactDamage applies within a 16-game-unit circle (impactDamage.ts); ×6 → screen px.
+const IMPACT_RADIUS_GAME = 16;
 const MAX_RANGE_SCREEN = 700;
 const MIN_RANGE_SCREEN = 120;
 
@@ -35,50 +31,20 @@ export class Nephtear extends ChargedHoldReleaseCast {
 
   evaluate(graph: Graph, targets: Character[]) {
     this.graph = graph;
-    const myCenter = this.character.getCenter();
-    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
-    const surface = getLevel().terrain.collisionMask;
-    const currentMana = this.character.player.mana;
     const elementValue = getManager().getElementValue(Element.Elemental);
 
-    const everyone: Character[] = [];
-    getLevel().withNearbyEntities(myCenter[0], myCenter[1], MAX_RANGE_SCREEN, (e) => {
-      if (e instanceof Character) everyone.push(e);
-    });
-    const allies = collectAllies(this.character, everyone);
-
-    this.evaluations = targets
-      .slice(0, 3)
-      .map((target) => {
-        const targetCenter = target.getCenter();
-        const dx = targetCenter[0] - myCenter[0];
-        const dy = targetCenter[1] - myCenter[1];
-        const distance = Math.sqrt(dx * dx + dy * dy);
+    this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
+      spell: Nephtear.spell,
+      reachScreen: IMPACT_RADIUS_GAME * 6,
+      impactPoint: (target, { myCenter, surface }) => {
+        const center = target.getCenter();
+        const distance = Math.hypot(center[0] - myCenter[0], center[1] - myCenter[1]);
         if (distance > MAX_RANGE_SCREEN || distance < MIN_RANGE_SCREEN) return null;
-        if (!hasLineOfSight(surface, myCenter, targetCenter)) return null;
-
-        const impactXGame = targetCenter[0] / 6;
-        const impactYGame = targetCenter[1] / 6;
-        const predict = (c: Character) => {
-          const [sx, sy] = c.getCenter();
-          const d = Math.sqrt(
-            (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
-          );
-          return Nephtear.predictDamageAt(d, elementValue);
-        };
-
-        const value = scoreAOECandidate({
-          target,
-          allies,
-          predictDamage: predict,
-          spell: Nephtear.spell,
-          currentMana,
-        });
-        if (value === null) return null;
-        return { target: Cluster.onCharacter(target), value, to: [myNode] };
-      })
-      .filter(Boolean)
-      .sort((a, b) => b!.value - a!.value) as Evaluation[];
+        if (!hasLineOfSight(surface, myCenter, center)) return null;
+        return center;
+      },
+      predictDamageAt: (d) => Nephtear.predictDamageAt(d, elementValue),
+    });
 
     this.getNextEvaluation();
   }

--- a/src/data/bot/strategies/scoring.ts
+++ b/src/data/bot/strategies/scoring.ts
@@ -111,6 +111,37 @@ export function predictFallDamage(
   return distanceGameUnits <= rangeGameUnits ? power : 0;
 }
 
+// Greedy estimate of how many enemies a chain effect reaches: from `start`, repeatedly
+// hop to the nearest not-yet-hit enemy within `chainRange` (screen px), up to `maxChains`.
+export function predictChainTargets(
+  start: [number, number],
+  enemiesScreen: [number, number][],
+  chainRange: number,
+  maxChains: number,
+): number {
+  const remaining = enemiesScreen.slice();
+  let from = start;
+  let hits = 0;
+  while (hits < maxChains && remaining.length > 0) {
+    let bestIdx = -1;
+    let bestDist = Infinity;
+    for (let i = 0; i < remaining.length; i++) {
+      const dx = remaining[i][0] - from[0];
+      const dy = remaining[i][1] - from[1];
+      const d = Math.sqrt(dx * dx + dy * dy);
+      if (d <= chainRange && d < bestDist) {
+        bestDist = d;
+        bestIdx = i;
+      }
+    }
+    if (bestIdx === -1) break;
+    from = remaining[bestIdx];
+    remaining.splice(bestIdx, 1);
+    hits++;
+  }
+  return hits;
+}
+
 // Coordinates are screen px; the mask works in game units, hence the ÷6.
 export function hasLineOfSight(
   surface: CollisionMask,

--- a/src/data/bot/strategies/scoring.ts
+++ b/src/data/bot/strategies/scoring.ts
@@ -1,5 +1,6 @@
 import { Character } from "../../entity/character";
 import { Spell, getSpellCost } from "../../spells";
+import { CollisionMask } from "../../collision/collisionMask";
 
 export const COST_FLOOR = 15;
 export const KILL_BONUS = 50;
@@ -89,4 +90,18 @@ export function scoreAOECandidate(args: {
     spellCost: getSpellCost(args.spell),
     currentMana: args.currentMana,
   });
+}
+
+// Coordinates are screen px; the mask works in game units, hence the ÷6.
+export function hasLineOfSight(
+  surface: CollisionMask,
+  fromScreen: [number, number],
+  toScreen: [number, number],
+): boolean {
+  return !surface.collidesWithLine(
+    Math.round(fromScreen[0] / 6),
+    Math.round(fromScreen[1] / 6),
+    Math.round(toScreen[0] / 6),
+    Math.round(toScreen[1] / 6),
+  );
 }

--- a/src/data/bot/strategies/scoring.ts
+++ b/src/data/bot/strategies/scoring.ts
@@ -92,6 +92,25 @@ export function scoreAOECandidate(args: {
   });
 }
 
+// ImpactDamage applies a flat `power` to entities within a 16-game-unit circle
+// (no distance falloff — see impactDamage.ts). `distanceGameUnits` is target → impact.
+export function predictImpactDamage(
+  distanceGameUnits: number,
+  power: number,
+): number {
+  return distanceGameUnits <= 16 ? power : 0;
+}
+
+// FallDamage applies a flat `power` within the shape's range (no falloff — see
+// fallDamage.ts). Pass the shape's range in GAME units (engine constants are px; ÷6).
+export function predictFallDamage(
+  distanceGameUnits: number,
+  rangeGameUnits: number,
+  power: number,
+): number {
+  return distanceGameUnits <= rangeGameUnits ? power : 0;
+}
+
 // Coordinates are screen px; the mask works in game units, hence the ÷6.
 export function hasLineOfSight(
   surface: CollisionMask,

--- a/src/data/bot/strategies/zoltraak.ts
+++ b/src/data/bot/strategies/zoltraak.ts
@@ -7,7 +7,7 @@ import { Cluster } from "../cluster";
 import { Graph } from "../graph";
 import { Evaluation } from "./strategy";
 import { RangedStrategy } from "./rangedStrategy";
-import { scoreCandidate } from "./scoring";
+import { hasLineOfSight, scoreCandidate } from "./scoring";
 
 // Hold M1 for ~60 ticks so the cursor's charge indicator becomes fully visible
 // (matches a normal player cast).
@@ -55,14 +55,7 @@ export class Zoltraak extends RangedStrategy {
         const targetCenter = target.getCenter();
 
         // LOS check vs terrain.
-        if (
-          surface.collidesWithLine(
-            Math.round(myCenter[0] / 6),
-            Math.round(myCenter[1] / 6),
-            Math.round(targetCenter[0] / 6),
-            Math.round(targetCenter[1] / 6),
-          )
-        ) {
+        if (!hasLineOfSight(surface, myCenter, targetCenter)) {
           return null;
         }
 

--- a/src/data/bot/strategies/zoltraak.ts
+++ b/src/data/bot/strategies/zoltraak.ts
@@ -1,4 +1,3 @@
-import { Command, CommandType, Key } from "../../controller/controller";
 import { ZOLTRAAK, getSpellCost } from "../../spells";
 import { getLevel, getManager } from "../../context";
 import { Character } from "../../entity/character";
@@ -6,7 +5,7 @@ import { Element } from "../../spells/types";
 import { Cluster } from "../cluster";
 import { Graph } from "../graph";
 import { Evaluation } from "./strategy";
-import { RangedStrategy } from "./rangedStrategy";
+import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
 import { hasLineOfSight, scoreCandidate } from "./scoring";
 
 // Hold M1 for ~60 ticks so the cursor's charge indicator becomes fully visible
@@ -22,8 +21,14 @@ const BEAM_LENGTH_SCREEN = 912;
 // same hits the engine produces.
 const BEAM_HALF_WIDTH_SCREEN = 48;
 
-export class Zoltraak extends RangedStrategy {
+export class Zoltraak extends ChargedHoldReleaseCast {
   public static spell = ZOLTRAAK;
+
+  protected readonly holdTicks = HOLD_TICKS;
+
+  protected aimPoint(): [number, number] {
+    return this.evaluation!.target.centerScreen;
+  }
 
   evaluate(graph: Graph, targets: Character[]) {
     this.graph = graph;
@@ -145,57 +150,4 @@ export class Zoltraak extends RangedStrategy {
     return perpX * perpX + perpY * perpY <= BEAM_HALF_WIDTH_SCREEN * BEAM_HALF_WIDTH_SCREEN;
   }
 
-  // Hold duration is wall-clock-equivalent (matches a normal player cast), so
-  // accumulate dt rather than counting calls.
-  private castTime = 0;
-  private released = false;
-
-  execute(dt: number): Command[] | null {
-    const justStarted = this.castTime === 0;
-    this.castTime += dt;
-
-    const targetCenter = this.evaluation!.target.centerScreen;
-    const mouseX = targetCenter[0];
-    const mouseY = targetCenter[1];
-
-    // Phase 1: hold M1 with mouse pointed at target so the cursor aims correctly.
-    if (this.castTime < HOLD_TICKS) {
-      const commands: Command[] = [];
-
-      if (justStarted) {
-        commands.push({ type: CommandType.ResetKeys });
-      }
-
-      commands.push(
-        {
-          type: CommandType.MouseMove,
-          x: mouseX,
-          y: mouseY,
-        },
-        { type: CommandType.KeyDown, key: Key.M1 }
-      );
-
-      return commands;
-    }
-
-    // Phase 2: first tick past HOLD_TICKS — release M1 so the cursor fires.
-    if (!this.released) {
-      this.released = true;
-      return [
-        { type: CommandType.KeyUp, key: Key.M1 },
-        {
-          type: CommandType.MouseMove,
-          x: mouseX,
-          y: mouseY,
-        },
-      ];
-    }
-
-    // Phase 3: cast issued; idle for a few frames so the cursor's tick observes M1 released.
-    if (this.castTime > HOLD_TICKS + 5) {
-      return null;
-    }
-
-    return [];
-  }
 }

--- a/src/data/bot/targeting.ts
+++ b/src/data/bot/targeting.ts
@@ -4,6 +4,7 @@ import { Melee } from "./strategies/melee";
 import { Bakuretsu } from "./strategies/bakuretsu";
 import { Fireball } from "./strategies/fireball";
 import { Zoltraak } from "./strategies/zoltraak";
+import { Catastravia } from "./strategies/catastravia";
 import { Nephtear } from "./strategies/nephtear";
 import { MagicMissile } from "./strategies/magicMissile";
 import { ArthurSword } from "./strategies/arthurSword";
@@ -20,6 +21,7 @@ export class Targeting {
     Bakuretsu,
     Fireball,
     Zoltraak,
+    Catastravia,
     Nephtear,
     MagicMissile,
     ArthurSword,

--- a/src/data/bot/targeting.ts
+++ b/src/data/bot/targeting.ts
@@ -4,6 +4,7 @@ import { Melee } from "./strategies/melee";
 import { Bakuretsu } from "./strategies/bakuretsu";
 import { Fireball } from "./strategies/fireball";
 import { Zoltraak } from "./strategies/zoltraak";
+import { Nephtear } from "./strategies/nephtear";
 import { StrategyConstructor } from "./strategies/strategy";
 
 export class Targeting {
@@ -15,6 +16,7 @@ export class Targeting {
     Bakuretsu,
     Fireball,
     Zoltraak,
+    Nephtear,
   ];
 
   static evaluateStrategies(self: Character) {

--- a/src/data/bot/targeting.ts
+++ b/src/data/bot/targeting.ts
@@ -5,6 +5,7 @@ import { Bakuretsu } from "./strategies/bakuretsu";
 import { Fireball } from "./strategies/fireball";
 import { Zoltraak } from "./strategies/zoltraak";
 import { Nephtear } from "./strategies/nephtear";
+import { MagicMissile } from "./strategies/magicMissile";
 import { StrategyConstructor } from "./strategies/strategy";
 
 export class Targeting {
@@ -17,6 +18,7 @@ export class Targeting {
     Fireball,
     Zoltraak,
     Nephtear,
+    MagicMissile,
   ];
 
   static evaluateStrategies(self: Character) {

--- a/src/data/bot/targeting.ts
+++ b/src/data/bot/targeting.ts
@@ -7,6 +7,7 @@ import { Zoltraak } from "./strategies/zoltraak";
 import { Nephtear } from "./strategies/nephtear";
 import { MagicMissile } from "./strategies/magicMissile";
 import { ArthurSword } from "./strategies/arthurSword";
+import { Babylon } from "./strategies/babylon";
 import { StrategyConstructor } from "./strategies/strategy";
 
 export class Targeting {
@@ -21,6 +22,7 @@ export class Targeting {
     Nephtear,
     MagicMissile,
     ArthurSword,
+    Babylon,
   ];
 
   static evaluateStrategies(self: Character) {

--- a/src/data/bot/targeting.ts
+++ b/src/data/bot/targeting.ts
@@ -5,6 +5,7 @@ import { Bakuretsu } from "./strategies/bakuretsu";
 import { Fireball } from "./strategies/fireball";
 import { Zoltraak } from "./strategies/zoltraak";
 import { Catastravia } from "./strategies/catastravia";
+import { Hairpin } from "./strategies/hairpin";
 import { Nephtear } from "./strategies/nephtear";
 import { MagicMissile } from "./strategies/magicMissile";
 import { ArthurSword } from "./strategies/arthurSword";
@@ -22,6 +23,7 @@ export class Targeting {
     Fireball,
     Zoltraak,
     Catastravia,
+    Hairpin,
     Nephtear,
     MagicMissile,
     ArthurSword,

--- a/src/data/bot/targeting.ts
+++ b/src/data/bot/targeting.ts
@@ -8,6 +8,7 @@ import { Nephtear } from "./strategies/nephtear";
 import { MagicMissile } from "./strategies/magicMissile";
 import { ArthurSword } from "./strategies/arthurSword";
 import { Babylon } from "./strategies/babylon";
+import { Meteor } from "./strategies/meteor";
 import { StrategyConstructor } from "./strategies/strategy";
 
 export class Targeting {
@@ -23,6 +24,7 @@ export class Targeting {
     MagicMissile,
     ArthurSword,
     Babylon,
+    Meteor,
   ];
 
   static evaluateStrategies(self: Character) {

--- a/src/data/bot/targeting.ts
+++ b/src/data/bot/targeting.ts
@@ -6,6 +6,7 @@ import { Fireball } from "./strategies/fireball";
 import { Zoltraak } from "./strategies/zoltraak";
 import { Catastravia } from "./strategies/catastravia";
 import { Hairpin } from "./strategies/hairpin";
+import { Doragate } from "./strategies/doragate";
 import { Nephtear } from "./strategies/nephtear";
 import { MagicMissile } from "./strategies/magicMissile";
 import { ArthurSword } from "./strategies/arthurSword";
@@ -24,6 +25,7 @@ export class Targeting {
     Zoltraak,
     Catastravia,
     Hairpin,
+    Doragate,
     Nephtear,
     MagicMissile,
     ArthurSword,

--- a/src/data/bot/targeting.ts
+++ b/src/data/bot/targeting.ts
@@ -12,6 +12,7 @@ import { MagicMissile } from "./strategies/magicMissile";
 import { ArthurSword } from "./strategies/arthurSword";
 import { Babylon } from "./strategies/babylon";
 import { Meteor } from "./strategies/meteor";
+import { Lightning } from "./strategies/lightning";
 import { StrategyConstructor } from "./strategies/strategy";
 
 export class Targeting {
@@ -31,6 +32,7 @@ export class Targeting {
     ArthurSword,
     Babylon,
     Meteor,
+    Lightning,
   ];
 
   static evaluateStrategies(self: Character) {

--- a/src/data/bot/targeting.ts
+++ b/src/data/bot/targeting.ts
@@ -6,6 +6,7 @@ import { Fireball } from "./strategies/fireball";
 import { Zoltraak } from "./strategies/zoltraak";
 import { Nephtear } from "./strategies/nephtear";
 import { MagicMissile } from "./strategies/magicMissile";
+import { ArthurSword } from "./strategies/arthurSword";
 import { StrategyConstructor } from "./strategies/strategy";
 
 export class Targeting {
@@ -19,6 +20,7 @@ export class Targeting {
     Zoltraak,
     Nephtear,
     MagicMissile,
+    ArthurSword,
   ];
 
   static evaluateStrategies(self: Character) {

--- a/src/data/bot/targeting.ts
+++ b/src/data/bot/targeting.ts
@@ -13,6 +13,7 @@ import { ArthurSword } from "./strategies/arthurSword";
 import { Babylon } from "./strategies/babylon";
 import { Meteor } from "./strategies/meteor";
 import { Lightning } from "./strategies/lightning";
+import { Acid } from "./strategies/acid";
 import { StrategyConstructor } from "./strategies/strategy";
 
 export class Targeting {
@@ -33,6 +34,7 @@ export class Targeting {
     Babylon,
     Meteor,
     Lightning,
+    Acid,
   ];
 
   static evaluateStrategies(self: Character) {

--- a/src/data/spells/index.ts
+++ b/src/data/spells/index.ts
@@ -482,7 +482,7 @@ const MIND_CONTROL = spell(Lock, {
   range: null,
 });
 
-const DORAGATE = spell(ArcaneCircle, {
+export const DORAGATE = spell(ArcaneCircle, {
   name: "Doragate",
   description: "Rocks to bullets",
   elements: [Element.Physical, Element.Arcane],

--- a/src/data/spells/index.ts
+++ b/src/data/spells/index.ts
@@ -408,7 +408,7 @@ const FIRE_WHEEL = spell(PoweredArcaneCircle, {
   range: "L",
 });
 
-const LIGHTNING = spell(ArcaneCircle, {
+export const LIGHTNING = spell(ArcaneCircle, {
   name: "Judradjim",
   description: "Generate chain lightning",
   elements: [Element.Elemental],

--- a/src/data/spells/index.ts
+++ b/src/data/spells/index.ts
@@ -237,7 +237,7 @@ export const MAGIC_MISSILE = spell(ApplyCursor, {
   range: "L",
 });
 
-const BABYLON = spell(ArrowDown, {
+export const BABYLON = spell(ArrowDown, {
   name: "Gates of babylon",
   description: "Drop swords from the sky",
   elements: [Element.Physical],

--- a/src/data/spells/index.ts
+++ b/src/data/spells/index.ts
@@ -209,7 +209,7 @@ const CATASTRAVIA = spell(PoweredArcaneCircle, {
   range: "M",
 });
 
-const MAGIC_MISSILE = spell(ApplyCursor, {
+export const MAGIC_MISSILE = spell(ApplyCursor, {
   name: "Vollzanbel",
   description: "Guided missile",
   elements: [Element.Arcane, Element.Life],

--- a/src/data/spells/index.ts
+++ b/src/data/spells/index.ts
@@ -425,7 +425,7 @@ export const LIGHTNING = spell(ArcaneCircle, {
   range: "S",
 });
 
-const ACID = spell(ApplyCursor, {
+export const ACID = spell(ApplyCursor, {
   name: "Reamstroha",
   description: "Spray a stream of acid",
   elements: [Element.Life],

--- a/src/data/spells/index.ts
+++ b/src/data/spells/index.ts
@@ -326,7 +326,7 @@ const WIND_BLAST = spell(PoweredArcaneCircle, {
   range: "S",
 });
 
-const HAIRPIN = spell(PoweredArcaneCircle, {
+export const HAIRPIN = spell(PoweredArcaneCircle, {
   name: "Balterie",
   description: "Launch several bombs that detonate on contact",
   elements: [Element.Elemental],

--- a/src/data/spells/index.ts
+++ b/src/data/spells/index.ts
@@ -289,7 +289,7 @@ const REELSEIDEN = spell(Lock, {
   range: null,
 });
 
-const NEPHTEAR = spell(PoweredArcaneCircle, {
+export const NEPHTEAR = spell(PoweredArcaneCircle, {
   name: "Nephtear",
   description: "Ice spike",
   elements: [Element.Elemental],

--- a/src/data/spells/index.ts
+++ b/src/data/spells/index.ts
@@ -192,7 +192,7 @@ const WINGS = spell(ApplyCursor, {
   range: null,
 });
 
-const CATASTRAVIA = spell(PoweredArcaneCircle, {
+export const CATASTRAVIA = spell(PoweredArcaneCircle, {
   name: "Catastravia",
   description: "Holy missile volley",
   elements: [Element.Life, Element.Arcane],

--- a/src/data/spells/index.ts
+++ b/src/data/spells/index.ts
@@ -377,7 +377,7 @@ const ROCK = spell(RockCursor, {
   range: null,
 });
 
-const METEOR = spell(Lock, {
+export const METEOR = spell(Lock, {
   name: "Waldgose",
   description: "Cause a meteor to fall from the sky",
   elements: [Element.Physical, Element.Elemental],

--- a/src/data/spells/index.ts
+++ b/src/data/spells/index.ts
@@ -90,7 +90,7 @@ export const FIREBALL = spell(PoweredArcaneCircle, {
   range: "M",
 });
 
-const ARTHUR_SWORD = spell(ArrowDown, {
+export const ARTHUR_SWORD = spell(ArrowDown, {
   name: "Excalibur",
   description: "Giant sword from the sky",
   elements: [Element.Physical, Element.Arcane],

--- a/src/data/spells/magicMissile.ts
+++ b/src/data/spells/magicMissile.ts
@@ -103,6 +103,10 @@ export class MagicMissile extends Container implements Syncable {
     return [this.position.x + 24, this.position.y + 24];
   }
 
+  get owner(): Character {
+    return this.character;
+  }
+
   private onCollide = (x: number, y: number) => {
     this._die(x, y);
   };


### PR DESCRIPTION
### Description

Bots previously only used 4 offensive spells (Melee, Bakuretsu, Fireball, Zoltraak). This adds bot strategies for 10 more — Nephtear, Magic Missile, Arthur Sword, Babylon, Meteor, Catastravia, Hairpin, Doragate, Lightning, and Acid — and registers them in `Targeting`.

Along the way it extracts two reusable cast-gesture base classes (`ChargedHoldReleaseCast`, `InstantPressCast`) and retrofits the existing Bakuretsu/Fireball/Zoltraak strategies onto them, and adds shared scoring/geometry helpers to `scoring.ts` (`hasLineOfSight`, impact/fall/chain damage predictors, and a guided-missile heading helper). Each new strategy ships with predictor/geometry unit tests; the full suite and type-check pass.

> [!NOTE]
> Magic Missile's guided-flight targeting is still being tuned — a fix to stop it skimming into terrain is in progress and will follow on this branch.

### Manual check

- Host a local game, add a bot, and raise the mana multiplier (e.g. 2500%) so the bot can afford every spell
- Play several turns so the bot acts repeatedly
- [ ] The bot casts the new offensive spells (Nephtear, Magic Missile, Arthur Sword, Babylon, Meteor, Catastravia, Hairpin, Doragate, Lightning, Acid) without console errors
- [ ] The bot aims at enemy characters and does not blow itself or its teammates up
- [ ] Existing Melee / Fireball / Zoltraak / Bakuretsu still cast correctly after the base-class refactor