### PR TITLE
Bot pathfinding: deterministic test harness and jump execution fixes

### DIFF
--- a/docs/bot-pathfinding-test.md
+++ b/docs/bot-pathfinding-test.md
@@ -1,0 +1,126 @@
+# Bot pathfinding test route
+
+A dev-only harness for iterating on the bot's node follower (`src/data/bot/path.ts`) without the friction of setting up a full game.
+
+## Where it lives
+
+- Route: `/#/test/pathfinding` (registered in `src/main.ts` behind `import.meta.env.DEV`, so the chunk is dropped from production builds)
+- Page: `src/components/pages/PathfindingTest.vue`
+- Map fixture: `src/data/wfc/fixtures/zigzagMap.ts`
+
+## What it does
+
+On page load:
+
+1. Builds a deterministic 12×8 WFC tile grid — a zigzag with 4 walkable floor rows (rows 1/3/5/7) joined by three ladder runs that alternate which end of each leg they sit at. Each leg mixes ramps, `floorBox` hops and `floorHole` gaps so the follower hits walk/jump/climb/fall edges. See `zigzagMap.ts` for the literal grid.
+2. Spawns one `Character` at a fixed body position `(40, 540)` — bottom-left corner of the bottom floor.
+3. Sets a fixed target node at `(40, 80)` — top-left corner of the top floor.
+4. Builds the navigation graph (`Level.buildGraph`), runs `Pathfinding.findPath` between spawn and target, and wraps the resulting edges in a `Path`.
+5. Wires a `TestController` to the player so the `Path` follower's keypresses drive the body.
+6. Enables the bot debug overlay (`setBotDebugEnabled(true)`) so graph nodes, planned path, and currently-followed edge are visible.
+7. Ticks the simulation on a **single Pixi ticker** (`Ticker.shared`) with a fixed `dt` of `1.0` per frame (`FIXED_DT`), so the run doesn't depend on browser frame scheduling. Each frame it:
+   - calls `Path.getCommand(dt)` and applies the returned commands to the test controller,
+   - calls `controlContinuous` for walk velocity and `Level.tick(dt)` so physics + camera advance,
+   - and calls `Character.control` **once every 3rd frame** (`CONTROL_EVERY_N_FRAMES = 3`) — i.e. ~20 Hz at 60 fps, the same cadence as `Server.fixedTick` in production. (An earlier version drove `control` from a separate 20 Hz `setInterval`, but it drifted against the ticker and produced non-reproducible trajectories; folding it into the ticker fixed that.) This cadence matters: `control` handles `body.jump()`, `mountLadder()`, and the ladder edge-dismount rule; running it every frame would reset `yVelocity = 0` each tick and prevent ladder climbing.
+8. **Re-plans on stuck.** When the follower makes no edge progress for ~2 s (`Path.stuck`), the harness finds the closest graph node to the body's current foot position and re-runs `findPath` to the same target, up to `MAX_REPLANS` (3) times. Each attempt logs `re-plan attempt` then either `re-plan #N` (new path found) or `re-plan FAILED` (no path from the current node). The run only ends — with the `stuck` summary — when a re-plan fails, the body falls out of the map, or the cap is reached.
+
+Because every input is deterministic — fixed spawn, fixed target, fixed map, no RNG in the follower, and a deterministic collision mask (the blur in `wfc/postProcess.ts` is computed in JS, not via the engine-specific `ctx.filter`) — successive page loads produce the same result (same tick count to arrive, same stuck position if it fails), and the result is now identical across browsers too.
+
+## Driving it
+
+```
+yarn dev
+# open http://localhost:3000/#/test/pathfinding
+```
+
+The character spawns and immediately starts walking the planned path. The camera follows. Scroll wheel zooms. No keyboard input needed (and ignored — the test controller is the only one driving the bot).
+
+Append `?mirror=1` (`#/test/pathfinding?mirror=1`) to run the whole fixture mirrored left↔right — map, spawn, and target are all reflected across `MAP_WIDTH`, so the follower is exercised right-to-left as well. A directional bias in the path logic shows up as a different result (re-plans / stuck) than the unmirrored run.
+
+## Reading the console logs
+
+Open devtools → console. You'll see lines like:
+
+```
+[pathfinding-test] character spawned at [40, 540]
+[pathfinding-test] path built, edges: 310
+[pathfinding-test] edge 1/310: walk from (48, 626) to (60, 626) [Δ12, 0]
+[pathfinding-test] edge 2/310: walk from (60, 626) to (72, 626) [Δ12, 0]
+…
+[pathfinding-test] re-plan #1: 284 new edges from (362.8, 597.0)
+…
+[pathfinding-test] stuck:   1310 frames, 21.83s sim time, 342/587 edges, at (792.0, 612.0)
+```
+
+(Numbers are illustrative of a current run — the follower doesn't complete this map, so it re-plans and ends `stuck`; an `arrived` run ends with that line instead. The `<completed>/<total>` total grows past the initial 310 because each re-plan appends its edges.)
+
+**Format of the per-edge line:**
+
+```
+edge <N>/<total>: <type> from (<fromX>, <fromY>) to (<toX>, <toY>) [Δ<dx>, <dy>]
+```
+
+- `<N>/<total>` — current edge index out of total path length.
+- `<type>` — `walk`, `climb`, `jump`, or `fall` (see `src/data/bot/edge.ts:EdgeType`).
+- `(fromX, fromY)` → `(toX, toY)` — the graph node positions in mask-space pixels. Graph nodes sit 8 pixels above the floor surface they belong to.
+- `[Δdx, dy]` — to-from delta, signed. Useful for spotting non-trivial edges at a glance:
+  - `walk` with `Δy = 0` — flat traversal.
+  - `walk` with `Δy < -3` — step-up (handled by the Walk-with-rise branch in `path.ts`; >3 pixels exceeds the body's auto-step).
+  - `climb` — always vertical, `Δx = 0`.
+  - `jump` with `Δx ≠ 0` — horizontal jump; the Path follower needs run-up and launches at the from-edge.
+
+A new edge logs **only when the path advances** (`Path.remainingNodes` decreases). If you see no progress over many seconds, the bot is stuck on the current edge — the next log will be a `re-plan` attempt (see below) or, if re-planning is done, the stuck/arrived summary.
+
+**Re-plan lines** (emitted when the follower stalls, before the run is declared over):
+
+- `re-plan attempt at body foot (x, y); closest node (nx, ny)` — the follower stalled; the harness is re-planning from `(nx, ny)`.
+- `re-plan #N: <k> new edges from (x, y)` — a fresh path was found; following resumes.
+- `re-plan FAILED: success=false …` — no path from the current node; the run ends with a `stuck` summary next.
+
+**Result line** (terminal — only after re-planning is exhausted):
+
+- `arrived: <frames> frames, <s>s sim time, <completed>/<total> edges` — full completion.
+- `stuck:   <frames> frames, <s>s sim time, <completed>/<total> edges, at (x, y)` — `Path.bustedTimer` (in `path.ts`) ran out (~2 sim seconds of no edge advance) and re-planning couldn't recover. `(x, y)` is the body's precise position when the run ended — useful for going back to the screenshot and seeing where the bot wedged.
+
+The terminal result is also written to the DOM (a `[data-test-status]` element, text prefixed with `pathfinding-test:done`) so automation can wait on it without a timeout — see below.
+
+Sim time = `frames / 60`. One frame = one Pixi `deltaTime` of 1.0 at 60 fps.
+
+## Iterating on the node follower
+
+Typical loop:
+
+1. Read the latest log run (especially the last few `edge` lines before `stuck`). The edge type tells you which branch of `Path.getCommand` was active.
+2. Open `src/data/bot/path.ts` and change behavior for that branch.
+3. Reload the page. The deterministic setup means tick counts are directly comparable — if your change made the bot arrive at the same edge in fewer frames, that's a real improvement, not noise.
+4. If the bot starts arriving at the destination, compare total frames across runs.
+
+Things to keep in mind while iterating:
+
+- **`Path.getCommand` is dt-scaled in Pixi frames, not ms.** A `dt` of ~1.0 per call is normal at 60 fps. `BUSTED_TIMER = 120` means ~2 seconds before "stuck".
+- **`Character.control` runs every 3rd frame (~20 Hz at 60 fps), not every frame.** Anything you change in `characterMovement.ts` (jump, ladder mount, edge dismount) sees the same cadence as the production server, so test behavior should match the real game.
+- **The bot debug overlay** (toggled on automatically) draws graph nodes (numbered), the planned path (highlighted edge), and edges color-coded by type. Useful for sanity-checking against the logs.
+
+## Known sharp edges
+
+- The graph creates Jump edges between LadderTop nodes and adjacent platforms. Ladder *middle* nodes don't get Jump edges (recent fix in `graph.ts`) — the bot has to climb all the way to LadderTop before exiting sideways.
+- The Path inserts a "pre-roll" detour (in `Pathfinding.reconstructPath`) for Jump edges that reverse direction, so the bot walks backward to build run-up. This shows up as extra Walk edges in the log around Jump edges.
+- A `Path.WALKING_NEXT_DISTANCE` of 12 (squared = `sqrt(12) ≈ 3.5` pixels) means edge advance triggers when the body center comes within ~3.5 pixels of the destination — generous enough that the bot doesn't need to land exactly on the node.
+
+## Automating with Playwright MCP
+
+The test page is a good candidate for fully-automated regression: deterministic setup, a single terminal result (in both the console and a `[data-test-status]` DOM marker), no UI interaction needed.
+
+When Playwright MCP is available, a single recipe drives the whole loop (verified with the current MCP plugin):
+
+1. **Start the dev server** — `yarn dev` (background; serves `localhost:3000`). Skip if already running.
+2. **Navigate** — `browser_navigate("http://localhost:3000/#/test/pathfinding")`.
+3. **Wait for the run to finish** — `browser_wait_for({ text: "pathfinding-test:done" })`. The harness writes the terminal result into a `[data-test-status]` DOM element prefixed with `pathfinding-test:done` (`… arrived …`, `… stuck …`, or `… no-path`), so `wait_for` resolves the moment the run ends — no fixed sleep, regardless of how long re-planning takes or how big the map grows.
+4. **Read the result** — either read the DOM element directly (`browser_evaluate(() => document.querySelector("[data-test-status]").textContent)`), or pull the full per-edge trace from `browser_console_messages({ level: "info" })` and filter for `[pathfinding-test]`.
+5. **Parse the result line** — from the DOM marker: `/pathfinding-test:done (arrived|stuck|no-path)(?: (\d+) frames (\d+)\/(\d+) edges(?: at \(([\d.]+), ([\d.]+)\))?)?/`. Or, from the console, the `arrived`/`stuck` lines: `/arrived:\s+(\d+) frames, ([\d.]+)s sim time, (\d+)\/(\d+) edges/` and `/stuck:\s+(\d+) frames, ([\d.]+)s sim time, (\d+)\/(\d+) edges, at \(([\d.]+), ([\d.]+)\)/`.
+
+A regression check looks like: run the recipe, compare the tick count to a baseline. If the bot now arrives in fewer frames, the change improved the follower. If it stuck where it didn't before, the change regressed.
+
+For an A/B comparison: stash a baseline tick count in the repo (e.g., `docs/bot-pathfinding-baseline.txt`), and have the recipe diff against it. Anything within ±2 frames is noise from non-deterministic Pixi timing; larger swings are real.
+
+Playwright MCP isn't currently set up to run from CI — this is an interactive workflow for now.

--- a/docs/bot-pathfinding-test.md
+++ b/docs/bot-pathfinding-test.md
@@ -43,6 +43,10 @@ Append `?mirror=1` (`#/test/pathfinding?mirror=1`) to run the whole fixture mirr
 
 `?pair=N` (default `0`) picks the spawn/target from the map's own spawn locations (`Terrain.getSpawnLocations`), sorted by x: pair `N` runs the Nth-leftmost spawn to the Nth-rightmost, i.e. a left↔right crossing. Successive `N` probe different crossings.
 
+`?from=x,y&to=x,y` (mask-space px, real maps only) override the pair-derived spawn/target, for probing specific map regions — e.g. `?map=Office&from=140,247&to=167,107` runs the bottom-left → top-left corner. Points snap to the closest graph node; the map's spawn locations are safe values. The character settles onto the ground before the path is planned (spawn locations can sit a few dozen px in the air).
+
+`?trace=1` additionally logs the full planned path (`[pathfinding-plan]` lines) at build time plus a per-frame `[pathfinding-trace]` line (foot position, velocities, grounded, pressed keys) while a path is being followed — the primary tool for diagnosing why a specific edge fails. `window.__pathfindingTest` exposes `{ level, graph, character }` for ad-hoc queries from the console.
+
 ```
 # open http://localhost:3000/#/test/pathfinding?map=Stadium&pair=1
 ```

--- a/docs/bot-pathfinding-test.md
+++ b/docs/bot-pathfinding-test.md
@@ -37,6 +37,18 @@ The character spawns and immediately starts walking the planned path. The camera
 
 Append `?mirror=1` (`#/test/pathfinding?mirror=1`) to run the whole fixture mirrored left↔right — map, spawn, and target are all reflected across `MAP_WIDTH`, so the follower is exercised right-to-left as well. A directional bias in the path logic shows up as a different result (re-plans / stuck) than the unmirrored run.
 
+### Running a real map
+
+`?map=<Name>` swaps the zigzag fixture for a bundled map (the keys in `defaultMaps`, `src/util/assets/constants.ts`): `Playground`, `Castle`, `Stadium`, `Mario_World`, `Office`. The map is loaded straight from its `.png` (`Map.fromBlob`), so its baked-in collision mask is used — no browser-dependent mask blur.
+
+`?pair=N` (default `0`) picks the spawn/target from the map's own spawn locations (`Terrain.getSpawnLocations`), sorted by x: pair `N` runs the Nth-leftmost spawn to the Nth-rightmost, i.e. a left↔right crossing. Successive `N` probe different crossings.
+
+```
+# open http://localhost:3000/#/test/pathfinding?map=Stadium&pair=1
+```
+
+Real maps run without a Server, so the engine's killbox damage never fires — instead the harness detects a fall into the killbox itself and ends the run `died` (see below). Some pairs sit on disconnected platforms; those end `no-path` and are expected (the spawn picker doesn't guarantee connectivity). Note the route uses hash-based routing, so a `?map=`/`?pair=` change needs a full reload (`location.reload()`), not just a hash edit, to re-run.
+
 ## Reading the console logs
 
 Open devtools → console. You'll see lines like:
@@ -49,7 +61,7 @@ Open devtools → console. You'll see lines like:
 …
 [pathfinding-test] re-plan #1: 284 new edges from (362.8, 597.0)
 …
-[pathfinding-test] stuck:   1310 frames, 21.83s sim time, 342/587 edges, at (792.0, 612.0)
+[pathfinding-test] stuck 1310 frames 342/587 edges 3 re-plans at (792.0, 612.0), 21.83s sim time
 ```
 
 (Numbers are illustrative of a current run — the follower doesn't complete this map, so it re-plans and ends `stuck`; an `arrived` run ends with that line instead. The `<completed>/<total>` total grows past the initial 310 because each re-plan appends its edges.)
@@ -77,14 +89,15 @@ A new edge logs **only when the path advances** (`Path.remainingNodes` decreases
 - `re-plan #N: <k> new edges from (x, y)` — a fresh path was found; following resumes.
 - `re-plan FAILED: success=false …` — no path from the current node; the run ends with a `stuck` summary next.
 
-**Result line** (terminal — only after re-planning is exhausted):
+**Result line** (terminal — only after re-planning is exhausted). All carry `<r> re-plans`: `0 re-plans` is a clean run; a higher count means the follower stalled and recovered that many times, so a stalling run is no longer hidden behind a final `arrived`.
 
-- `arrived: <frames> frames, <s>s sim time, <completed>/<total> edges` — full completion.
-- `stuck:   <frames> frames, <s>s sim time, <completed>/<total> edges, at (x, y)` — `Path.bustedTimer` (in `path.ts`) ran out (~2 sim seconds of no edge advance) and re-planning couldn't recover. `(x, y)` is the body's precise position when the run ended — useful for going back to the screenshot and seeing where the bot wedged.
+- `arrived <frames> frames <completed>/<total> edges <r> re-plans` — full completion. Confirmed only after the bot stays clear of the killbox for `SETTLE_FRAMES` (90) past the last edge.
+- `stuck <frames> frames <completed>/<total> edges <r> re-plans at (x, y)` — `Path.bustedTimer` (in `path.ts`) ran out (~2 sim seconds of no edge advance) and re-planning couldn't recover. `(x, y)` is the body's precise position when the run ended.
+- `died <frames> frames <completed>/<total> edges <r> re-plans at (x, y)` — the body fell into the killbox (during the path or the post-arrival settle window). Real maps only — the zigzag fixture has no killbox.
+
+`<completed>/<total>` total grows past the initial path length because each re-plan appends its edges. The console also appends `, <s>s sim time` (sim time = `frames / 60`; one frame = one Pixi `deltaTime` of 1.0 at 60 fps).
 
 The terminal result is also written to the DOM (a `[data-test-status]` element, text prefixed with `pathfinding-test:done`) so automation can wait on it without a timeout — see below.
-
-Sim time = `frames / 60`. One frame = one Pixi `deltaTime` of 1.0 at 60 fps.
 
 ## Iterating on the node follower
 
@@ -114,10 +127,10 @@ The test page is a good candidate for fully-automated regression: deterministic 
 When Playwright MCP is available, a single recipe drives the whole loop (verified with the current MCP plugin):
 
 1. **Start the dev server** — `yarn dev` (background; serves `localhost:3000`). Skip if already running.
-2. **Navigate** — `browser_navigate("http://localhost:3000/#/test/pathfinding")`.
-3. **Wait for the run to finish** — `browser_wait_for({ text: "pathfinding-test:done" })`. The harness writes the terminal result into a `[data-test-status]` DOM element prefixed with `pathfinding-test:done` (`… arrived …`, `… stuck …`, or `… no-path`), so `wait_for` resolves the moment the run ends — no fixed sleep, regardless of how long re-planning takes or how big the map grows.
+2. **Navigate** — `browser_navigate("http://localhost:3000/#/test/pathfinding")` (append `?map=…&pair=…` for a real map). The route is hash-based, so when only the query changes between runs follow the navigate with `browser_evaluate(() => location.reload())` to force a fresh run.
+3. **Wait for the run to finish** — `browser_wait_for({ text: "pathfinding-test:done" })`. The harness writes the terminal result into a `[data-test-status]` DOM element prefixed with `pathfinding-test:done` (`… arrived …`, `… stuck …`, `… died …`, or `… no-path`), so `wait_for` resolves the moment the run ends — no fixed sleep, regardless of how long re-planning takes or how big the map grows. (The zigzag fixture runs ~108 s of sim time, so it can exceed a single 30 s `wait_for`; call `wait_for` again.)
 4. **Read the result** — either read the DOM element directly (`browser_evaluate(() => document.querySelector("[data-test-status]").textContent)`), or pull the full per-edge trace from `browser_console_messages({ level: "info" })` and filter for `[pathfinding-test]`.
-5. **Parse the result line** — from the DOM marker: `/pathfinding-test:done (arrived|stuck|no-path)(?: (\d+) frames (\d+)\/(\d+) edges(?: at \(([\d.]+), ([\d.]+)\))?)?/`. Or, from the console, the `arrived`/`stuck` lines: `/arrived:\s+(\d+) frames, ([\d.]+)s sim time, (\d+)\/(\d+) edges/` and `/stuck:\s+(\d+) frames, ([\d.]+)s sim time, (\d+)\/(\d+) edges, at \(([\d.]+), ([\d.]+)\)/`.
+5. **Parse the result line** — from the DOM marker: `/pathfinding-test:done (arrived|stuck|died|no-path)(?: (\d+) frames (\d+)\/(\d+) edges (\d+) re-plans(?: at \(([\d.]+), ([\d.]+)\))?)?/`. Always inspect the `re-plans` count: a run can end `arrived` yet have stalled and recovered several times.
 
 A regression check looks like: run the recipe, compare the tick count to a baseline. If the bot now arrives in fewer frames, the change improved the follower. If it stuck where it didn't before, the change regressed.
 

--- a/src/components/pages/PathfindingTest.vue
+++ b/src/components/pages/PathfindingTest.vue
@@ -5,6 +5,8 @@ import { Ticker, UPDATE_PRIORITY } from "pixi.js";
 import { AssetsContainer } from "../../util/assets/assetsContainer";
 import { Level } from "../../data/map/level";
 import { buildZigzagMap, MAP_WIDTH } from "../../data/wfc/fixtures/zigzagMap";
+import { Map as GameMap } from "../../data/map";
+import { defaultMaps } from "../../util/assets/constants";
 import { setGameContext } from "../../data/context";
 import { Player } from "../../data/network/player";
 import { Character } from "../../data/entity/character";
@@ -120,8 +122,15 @@ function applyCommands(commands: Command[], state: TestController) {
 const route = useRoute();
 const mirror = !!route.query.mirror && route.query.mirror !== "0";
 
+// ?map=<Name> swaps the zigzag fixture for a bundled map; ?pair=N runs the
+// Nth-leftmost spawn to the Nth-rightmost (a left↔right crossing).
+const mapName =
+  typeof route.query.map === "string" ? route.query.map : undefined;
+const realMapConfig = mapName ? defaultMaps[mapName] : undefined;
+const pairIndex = route.query.pair ? parseInt(String(route.query.pair), 10) : 0;
+
 // Unmirrored spawn/target; mirrored variants reflect across MAP_WIDTH. The body
-// is 6px wide, so its left edge mirrors to `MAP_WIDTH - x - 6`.
+// is 6px wide, so its left edge mirrors to `MAP_WIDTH - x - 6`. (Zigzag only.)
 const SPAWN_X = mirror ? MAP_WIDTH - 40 - 6 : 40;
 const TARGET_X = mirror ? MAP_WIDTH - 40 : 40;
 
@@ -146,6 +155,23 @@ let targetNodeRef: Node | null = null;
 let replanCount = 0;
 const MAX_REPLANS = 3;
 
+// No Server here, so the engine's killbox damage never fires — detect falls
+// ourselves, and confirm `arrived` only after the bot stays clear of the
+// killbox for SETTLE_FRAMES (it can reach a cliff-edge node and then slide off).
+const SETTLE_FRAMES = 90;
+let pendingArrival = false;
+let settleFrames = 0;
+let arrivedFrames = 0;
+let arrivedCompleted = 0;
+
+function inKillbox(character: Character): boolean {
+  return level!.terrain.killbox.collidesWith(
+    character.body.mask,
+    character.position.x,
+    character.position.y,
+  );
+}
+
 function createStubManager(getActive: () => Character | null) {
   return {
     getActiveCharacter: () => getActive(),
@@ -167,6 +193,21 @@ const frameTicker = (_ticker: Ticker) => {
   if (!level || !trackedCharacter || !testController) return;
   const dt = FIXED_DT;
 
+  // A killbox fall is terminal and outranks a pending arrival.
+  if ((path || pendingArrival) && inKillbox(trackedCharacter)) {
+    const completed = path ? totalEdges - path.remainingNodes : arrivedCompleted;
+    logResult("died", simFrames, completed);
+    path = null;
+    pendingArrival = false;
+    testController.resetKeys();
+  } else if (pendingArrival) {
+    settleFrames -= dt;
+    if (settleFrames <= 0) {
+      logResult("arrived", arrivedFrames, arrivedCompleted);
+      pendingArrival = false;
+    }
+  }
+
   if (path) {
     simFrames += dt;
     const commands = path.getCommand(dt);
@@ -184,7 +225,10 @@ const frameTicker = (_ticker: Ticker) => {
     }
 
     if (path.done) {
-      logResult(path, simFrames, trackedCharacter, totalEdges);
+      pendingArrival = true;
+      settleFrames = SETTLE_FRAMES;
+      arrivedFrames = simFrames;
+      arrivedCompleted = totalEdges - path.remainingNodes;
       path = null;
       testController.resetKeys();
     } else if (path.stuck) {
@@ -212,7 +256,7 @@ const frameTicker = (_ticker: Ticker) => {
           `[pathfinding-test] re-plan FAILED: success=${result.success} pathLen=${result.path?.length ?? "n/a"}`,
         );
       }
-      logResult(path, simFrames, trackedCharacter, totalEdges);
+      logResult("stuck", simFrames, totalEdges - path.remainingNodes);
       path = null;
       testController.resetKeys();
     }
@@ -226,28 +270,47 @@ const frameTicker = (_ticker: Ticker) => {
   level.tick(dt);
 };
 
-function logResult(p: Path, frames: number, character: Character, edges: number) {
-  const simSeconds = (frames / 60).toFixed(2);
-  const completed = edges - p.remainingNodes;
-  if (p.done) {
-    console.log(
-      `[pathfinding-test] arrived: ${frames.toFixed(0)} frames, ${simSeconds}s sim time, ${completed}/${edges} edges`,
-    );
-    status.value = `pathfinding-test:done arrived ${frames.toFixed(0)} frames ${completed}/${edges} edges`;
-  } else {
-    const [x, y] = character.body.precisePosition;
-    console.log(
-      `[pathfinding-test] stuck:   ${frames.toFixed(0)} frames, ${simSeconds}s sim time, ${completed}/${edges} edges, at (${x.toFixed(1)}, ${y.toFixed(1)})`,
-    );
-    status.value = `pathfinding-test:done stuck ${frames.toFixed(0)} frames ${completed}/${edges} edges at (${x.toFixed(1)}, ${y.toFixed(1)})`;
-  }
+function logResult(
+  kind: "arrived" | "stuck" | "died",
+  frames: number,
+  completed: number,
+) {
+  const [x, y] = trackedCharacter!.body.precisePosition;
+  const at = kind === "arrived" ? "" : ` at (${x.toFixed(1)}, ${y.toFixed(1)})`;
+  const summary = `${kind} ${frames.toFixed(0)} frames ${completed}/${totalEdges} edges ${replanCount} re-plans${at}`;
+  console.log(`[pathfinding-test] ${summary}, ${(frames / 60).toFixed(2)}s sim time`);
+  status.value = `pathfinding-test:done ${summary}`;
 }
 
 watch(canvas, (el) => {
   if (!el) return;
   AssetsContainer.instance.onComplete(async () => {
-    const map = await buildZigzagMap(mirror);
+    let map: GameMap;
+    if (realMapConfig) {
+      const blob = await fetch(realMapConfig.path).then((r) => r.blob());
+      map = await GameMap.fromBlob(blob);
+    } else {
+      map = await buildZigzagMap(mirror);
+    }
     level = new Level(el, map);
+
+    // Zigzag keeps its fixed corner-to-corner coordinates; real maps pick from
+    // their own spawn locations, sorted by x.
+    let spawnPos: [number, number] = [SPAWN_X, 540];
+    let targetPos: [number, number] = [TARGET_X, 80];
+    if (realMapConfig) {
+      const spawns = level.terrain
+        .getSpawnLocations()
+        .slice()
+        .sort((a, b) => a[0] - b[0]);
+      const leftIdx = Math.min(pairIndex, spawns.length - 1);
+      const rightIdx = Math.max(0, spawns.length - 1 - pairIndex);
+      spawnPos = spawns[leftIdx];
+      targetPos = spawns[rightIdx];
+      console.log(
+        `[pathfinding-test] map=${mapName} pair=${pairIndex} of ${spawns.length} spawns; spawn (${spawnPos[0]}, ${spawnPos[1]}) -> target (${targetPos[0]}, ${targetPos[1]})`,
+      );
+    }
 
     let activeCharacter: Character | null = null;
     const stubManager = createStubManager(() => activeCharacter);
@@ -258,7 +321,7 @@ watch(canvas, (el) => {
     const player = new Player();
     player.connect("TestBot", Team.empty(), COLORS[0], testController);
 
-    const character = new Character(player, SPAWN_X, 540, "TestBot");
+    const character = new Character(player, spawnPos[0], spawnPos[1], "TestBot");
     activeCharacter = character;
     trackedCharacter = character;
     player.addCharacter(character);
@@ -278,11 +341,13 @@ watch(canvas, (el) => {
 
     const [spawnX, spawnY] = character.bodyFootCenter;
     const startNode = graph.getClosestNode(spawnX, spawnY);
-    const targetNode = graph.getClosestNode(TARGET_X, 80);
+    const targetNode = graph.getClosestNode(targetPos[0], targetPos[1]);
 
     graphRef = graph;
     targetNodeRef = targetNode;
     replanCount = 0;
+    pendingArrival = false;
+    settleFrames = 0;
 
     const result = Pathfinding.findPath(startNode, targetNode);
     if (!result.success) {

--- a/src/components/pages/PathfindingTest.vue
+++ b/src/components/pages/PathfindingTest.vue
@@ -128,6 +128,20 @@ const mapName =
   typeof route.query.map === "string" ? route.query.map : undefined;
 const realMapConfig = mapName ? defaultMaps[mapName] : undefined;
 const pairIndex = route.query.pair ? parseInt(String(route.query.pair), 10) : 0;
+// ?from=x,y&to=x,y (mask-space px) override the pair-derived spawn/target on
+// real maps, for probing specific map regions.
+function parsePoint(value: unknown): [number, number] | undefined {
+  if (typeof value !== "string") return undefined;
+  const parts = value.split(",").map((p) => parseInt(p, 10));
+  return parts.length === 2 && parts.every(Number.isFinite)
+    ? [parts[0], parts[1]]
+    : undefined;
+}
+const fromOverride = parsePoint(route.query.from);
+const toOverride = parsePoint(route.query.to);
+// ?trace=1 logs per-frame body state while the current edge is a Jump, for
+// diagnosing failed jumps.
+const trace = !!route.query.trace && route.query.trace !== "0";
 
 // Unmirrored spawn/target; mirrored variants reflect across MAP_WIDTH. The body
 // is 6px wide, so its left edge mirrors to `MAP_WIDTH - x - 6`. (Zigzag only.)
@@ -214,6 +228,14 @@ const frameTicker = (_ticker: Ticker) => {
     applyCommands(commands, testController);
 
     const currentIndex = path.edges.length - path.remainingNodes;
+    if (trace && currentIndex < path.edges.length) {
+      const e = path.edges[currentIndex];
+      const body = trackedCharacter.body as any;
+      const [bx, by] = trackedCharacter.bodyFootCenter;
+      console.log(
+        `[pathfinding-trace] f${simFrames} edge#${currentIndex + 1} ${e.type} foot (${bx.toFixed(2)}, ${by.toFixed(2)}) xv ${body.xVelocity.toFixed(3)} yv ${body.yVelocity.toFixed(3)} grounded ${body.grounded} keys ${testController.pressedKeys}`,
+      );
+    }
     if (currentIndex !== lastEdgeIndex && currentIndex < path.edges.length) {
       const e = path.edges[currentIndex];
       const dx = (e.to.x - e.from.x).toFixed(0);
@@ -305,8 +327,8 @@ watch(canvas, (el) => {
         .sort((a, b) => a[0] - b[0]);
       const leftIdx = Math.min(pairIndex, spawns.length - 1);
       const rightIdx = Math.max(0, spawns.length - 1 - pairIndex);
-      spawnPos = spawns[leftIdx];
-      targetPos = spawns[rightIdx];
+      spawnPos = fromOverride ?? spawns[leftIdx];
+      targetPos = toOverride ?? spawns[rightIdx];
       console.log(
         `[pathfinding-test] map=${mapName} pair=${pairIndex} of ${spawns.length} spawns; spawn (${spawnPos[0]}, ${spawnPos[1]}) -> target (${targetPos[0]}, ${targetPos[1]})`,
       );
@@ -337,6 +359,19 @@ watch(canvas, (el) => {
 
     console.log("[pathfinding-test] character spawned at", character.body.precisePosition);
 
+    // Spawn locations can sit a few dozen px in the air; settle the body onto
+    // the ground before planning, like a real bot planning from where it
+    // stands — otherwise the plan starts on a platform the bot falls off of.
+    for (let i = 0; i < 600 && !character.body.grounded; i++) {
+      level.tick(FIXED_DT);
+    }
+    console.log(
+      "[pathfinding-test] settled at",
+      character.body.precisePosition,
+      "grounded",
+      character.body.grounded,
+    );
+
     const graph = level.buildGraph(character);
 
     const [spawnX, spawnY] = character.bodyFootCenter;
@@ -345,6 +380,7 @@ watch(canvas, (el) => {
 
     graphRef = graph;
     targetNodeRef = targetNode;
+    (window as any).__pathfindingTest = { level, graph, character };
     replanCount = 0;
     pendingArrival = false;
     settleFrames = 0;
@@ -359,6 +395,14 @@ watch(canvas, (el) => {
     path = new Path(character, result.path);
     totalEdges = result.path.length;
     console.log("[pathfinding-test] path built, edges:", result.path.length);
+    if (trace) {
+      for (let i = 0; i < result.path.length; i++) {
+        const e = result.path[i];
+        console.log(
+          `[pathfinding-plan] ${i + 1}/${result.path.length}: ${e.type} (${e.from.x}, ${e.from.y}) -> (${e.to.x}, ${e.to.y})`,
+        );
+      }
+    }
 
     simFrames = 0;
     lastEdgeIndex = -1;

--- a/src/components/pages/PathfindingTest.vue
+++ b/src/components/pages/PathfindingTest.vue
@@ -1,0 +1,334 @@
+<script setup lang="ts">
+import { onUnmounted, ref, watch } from "vue";
+import { useRoute } from "vue-router";
+import { Ticker, UPDATE_PRIORITY } from "pixi.js";
+import { AssetsContainer } from "../../util/assets/assetsContainer";
+import { Level } from "../../data/map/level";
+import { buildZigzagMap, MAP_WIDTH } from "../../data/wfc/fixtures/zigzagMap";
+import { setGameContext } from "../../data/context";
+import { Player } from "../../data/network/player";
+import { Character } from "../../data/entity/character";
+import { Team } from "../../data/team";
+import { COLORS } from "../../data/network/constants";
+import { Element } from "../../data/spells/types";
+import { Pathfinding } from "../../data/bot/pathfinding";
+import { Path } from "../../data/bot/path";
+import type { Graph } from "../../data/bot/graph";
+import type { Node } from "../../data/bot/node";
+import { setBotDebugEnabled } from "../../data/bot/debug";
+import { KeyboardController } from "../../data/controller/keyboardController";
+import {
+  CommandType,
+  type Command,
+  type Controller,
+  type Key,
+  keyMap,
+} from "../../data/controller/controller";
+
+class TestController implements Controller {
+  public readonly isBot = true;
+  public pressedKeys = 0;
+  private mouse: [number, number] = [0, 0];
+  private eventHandlers = new Map<Key, Set<() => void>>();
+
+  isKeyDown(key?: Key): boolean {
+    if (key === undefined) {
+      return !!this.pressedKeys;
+    }
+    return !!(this.pressedKeys & keyMap[key]);
+  }
+
+  getMouse(): [number, number] {
+    return this.mouse;
+  }
+
+  getLocalMouse(): [number, number] {
+    return this.mouse;
+  }
+
+  resetKeys() {
+    this.pressedKeys = 0;
+  }
+
+  setKey(key: Key, state: boolean) {
+    if (state) {
+      this.pressedKeys |= keyMap[key];
+    } else {
+      this.pressedKeys &= ~keyMap[key];
+    }
+  }
+
+  serialize(): [number, number, number] {
+    return [this.pressedKeys, ...this.mouse];
+  }
+
+  deserialize(_buffer: [number, number, number]): void {
+    throw new Error("TestController cannot be deserialized");
+  }
+
+  destroy() {}
+
+  addKeyListener(key: Key, fn: () => void): () => void {
+    if (!this.eventHandlers.has(key)) {
+      this.eventHandlers.set(key, new Set());
+    }
+    this.eventHandlers.get(key)!.add(fn);
+    return () => this.removeKeyListener(key, fn);
+  }
+
+  removeKeyListener(key: Key, fn: () => void): void {
+    this.eventHandlers.get(key)?.delete(fn);
+  }
+
+  setMouse(x: number, y: number) {
+    this.mouse = [x, y];
+  }
+}
+
+function applyCommands(commands: Command[], state: TestController) {
+  const lastPressedKeys = state.pressedKeys;
+
+  for (const command of commands) {
+    switch (command.type) {
+      case CommandType.ResetKeys:
+        state.pressedKeys = 0;
+        break;
+
+      case CommandType.KeyDown:
+        state.setKey(command.key, true);
+        break;
+
+      case CommandType.KeyUp:
+        state.setKey(command.key, false);
+        break;
+
+      case CommandType.KeyPress:
+        state.setKey(command.key, !(lastPressedKeys & keyMap[command.key]));
+        break;
+
+      case CommandType.MouseMove:
+        state.setMouse(command.x, command.y);
+        break;
+    }
+  }
+}
+
+// `#/test/pathfinding?mirror=1` runs the whole fixture mirrored left↔right —
+// map, spawn and target — so the follower is exercised right-to-left as well as
+// left-to-right. A directional bias in the path logic shows up as a different
+// result (re-plans / stuck) than the unmirrored run, which arrives in 307/307.
+const route = useRoute();
+const mirror = !!route.query.mirror && route.query.mirror !== "0";
+
+// Unmirrored spawn/target; mirrored variants reflect across MAP_WIDTH. The body
+// is 6px wide, so its left edge mirrors to `MAP_WIDTH - x - 6`.
+const SPAWN_X = mirror ? MAP_WIDTH - 40 - 6 : 40;
+const TARGET_X = mirror ? MAP_WIDTH - 40 : 40;
+
+const canvas = ref<HTMLDivElement | null>(null);
+// Terminal-state marker rendered into the DOM so Playwright can `waitFor` the
+// run to finish instead of relying on a fixed timeout. Stays empty until the
+// run ends (arrived / stuck / no-path), then holds a single result line
+// prefixed with `pathfinding-test:done`.
+const status = ref("");
+
+let level: Level | null = null;
+let path: Path | null = null;
+let simFrames = 0;
+let totalEdges = 0;
+let lastEdgeIndex = -1;
+let testController: TestController | null = null;
+let trackedCharacter: Character | null = null;
+let cameraController: KeyboardController | null = null;
+let frameCounter = 0;
+let graphRef: Graph | null = null;
+let targetNodeRef: Node | null = null;
+let replanCount = 0;
+const MAX_REPLANS = 3;
+
+function createStubManager(getActive: () => Character | null) {
+  return {
+    getActiveCharacter: () => getActive(),
+    getActivePlayer: () => getActive()?.player ?? null,
+    getElementValue: (_e: Element) => 1,
+    setTurnState: (_s: any) => {},
+    dealFallDamage: (_x: number, _y: number, _c: any) => {},
+    isTrusted: (_c: Character) => true,
+  };
+}
+
+// Frame ticker uses a fixed dt and drives Character.control() at exactly
+// every 3 frames so the run is deterministic — `ticker.deltaTime` varies
+// frame-to-frame with browser scheduling, and a separate setInterval drifts
+// against it, both of which produced non-reproducible bot trajectories.
+const FIXED_DT = 1;
+const CONTROL_EVERY_N_FRAMES = 3;
+const frameTicker = (_ticker: Ticker) => {
+  if (!level || !trackedCharacter || !testController) return;
+  const dt = FIXED_DT;
+
+  if (path) {
+    simFrames += dt;
+    const commands = path.getCommand(dt);
+    applyCommands(commands, testController);
+
+    const currentIndex = path.edges.length - path.remainingNodes;
+    if (currentIndex !== lastEdgeIndex && currentIndex < path.edges.length) {
+      const e = path.edges[currentIndex];
+      const dx = (e.to.x - e.from.x).toFixed(0);
+      const dy = (e.to.y - e.from.y).toFixed(0);
+      console.log(
+        `[pathfinding-test] edge ${currentIndex + 1}/${path.edges.length}: ${e.type} from (${e.from.x}, ${e.from.y}) to (${e.to.x}, ${e.to.y}) [Δ${dx}, ${dy}]`,
+      );
+      lastEdgeIndex = currentIndex;
+    }
+
+    if (path.done) {
+      logResult(path, simFrames, trackedCharacter, totalEdges);
+      path = null;
+      testController.resetKeys();
+    } else if (path.stuck) {
+      const [, footY] = trackedCharacter.body.precisePosition;
+      const fellOutOfMap = footY > 1000;
+      if (!fellOutOfMap && replanCount < MAX_REPLANS && graphRef && targetNodeRef) {
+        const [bx, by] = trackedCharacter.bodyFootCenter;
+        const fromNode = graphRef.getClosestNode(bx, by);
+        console.log(
+          `[pathfinding-test] re-plan attempt at body foot (${bx.toFixed(1)}, ${by.toFixed(1)}); closest node (${fromNode.x}, ${fromNode.y})`,
+        );
+        const result = Pathfinding.findPath(fromNode, targetNodeRef);
+        if (result.success && result.path.length > 0) {
+          replanCount++;
+          totalEdges += result.path.length;
+          path = new Path(trackedCharacter, result.path);
+          lastEdgeIndex = -1;
+          testController.resetKeys();
+          console.log(
+            `[pathfinding-test] re-plan #${replanCount}: ${result.path.length} new edges from (${bx.toFixed(1)}, ${by.toFixed(1)})`,
+          );
+          return;
+        }
+        console.log(
+          `[pathfinding-test] re-plan FAILED: success=${result.success} pathLen=${result.path?.length ?? "n/a"}`,
+        );
+      }
+      logResult(path, simFrames, trackedCharacter, totalEdges);
+      path = null;
+      testController.resetKeys();
+    }
+  }
+
+  trackedCharacter.controlContinuous(dt, testController);
+  frameCounter++;
+  if (frameCounter % CONTROL_EVERY_N_FRAMES === 0) {
+    trackedCharacter.control(testController);
+  }
+  level.tick(dt);
+};
+
+function logResult(p: Path, frames: number, character: Character, edges: number) {
+  const simSeconds = (frames / 60).toFixed(2);
+  const completed = edges - p.remainingNodes;
+  if (p.done) {
+    console.log(
+      `[pathfinding-test] arrived: ${frames.toFixed(0)} frames, ${simSeconds}s sim time, ${completed}/${edges} edges`,
+    );
+    status.value = `pathfinding-test:done arrived ${frames.toFixed(0)} frames ${completed}/${edges} edges`;
+  } else {
+    const [x, y] = character.body.precisePosition;
+    console.log(
+      `[pathfinding-test] stuck:   ${frames.toFixed(0)} frames, ${simSeconds}s sim time, ${completed}/${edges} edges, at (${x.toFixed(1)}, ${y.toFixed(1)})`,
+    );
+    status.value = `pathfinding-test:done stuck ${frames.toFixed(0)} frames ${completed}/${edges} edges at (${x.toFixed(1)}, ${y.toFixed(1)})`;
+  }
+}
+
+watch(canvas, (el) => {
+  if (!el) return;
+  AssetsContainer.instance.onComplete(async () => {
+    const map = await buildZigzagMap(mirror);
+    level = new Level(el, map);
+
+    let activeCharacter: Character | null = null;
+    const stubManager = createStubManager(() => activeCharacter);
+    setGameContext({ level, manager: stubManager as any, server: null });
+
+    testController = new TestController();
+
+    const player = new Player();
+    player.connect("TestBot", Team.empty(), COLORS[0], testController);
+
+    const character = new Character(player, SPAWN_X, 540, "TestBot");
+    activeCharacter = character;
+    trackedCharacter = character;
+    player.addCharacter(character);
+
+    cameraController = new KeyboardController(level.viewport);
+    level.cameraTarget.connect(cameraController);
+    level.cameraTarget.setTarget(character);
+
+    frameCounter = 0;
+    Ticker.shared.add(frameTicker, null, UPDATE_PRIORITY.LOW);
+
+    setBotDebugEnabled(true);
+
+    console.log("[pathfinding-test] character spawned at", character.body.precisePosition);
+
+    const graph = level.buildGraph(character);
+
+    const [spawnX, spawnY] = character.bodyFootCenter;
+    const startNode = graph.getClosestNode(spawnX, spawnY);
+    const targetNode = graph.getClosestNode(TARGET_X, 80);
+
+    graphRef = graph;
+    targetNodeRef = targetNode;
+    replanCount = 0;
+
+    const result = Pathfinding.findPath(startNode, targetNode);
+    if (!result.success) {
+      console.error("[pathfinding-test] no path found from", startNode, "to", targetNode);
+      status.value = "pathfinding-test:done no-path";
+      return;
+    }
+
+    path = new Path(character, result.path);
+    totalEdges = result.path.length;
+    console.log("[pathfinding-test] path built, edges:", result.path.length);
+
+    simFrames = 0;
+    lastEdgeIndex = -1;
+  });
+});
+
+onUnmounted(() => {
+  Ticker.shared.remove(frameTicker, null);
+  cameraController?.destroy();
+  level?.destroy();
+  setGameContext(null);
+});
+</script>
+
+<template>
+  <div class="render-target" ref="canvas"></div>
+  <div v-if="status" class="test-status" data-test-status>{{ status }}</div>
+</template>
+
+<style scoped>
+.render-target {
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.test-status {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 10;
+  padding: 4px 8px;
+  font-family: monospace;
+  font-size: 12px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.7);
+}
+</style>

--- a/src/data/bot/__spec__/physics.spec.ts
+++ b/src/data/bot/__spec__/physics.spec.ts
@@ -7,6 +7,8 @@ import {
   MIN_LAUNCH_SPEED,
   SAFE_LANDING_SPEED,
   WALK_TERMINAL_VELOCITY,
+  brakingLandingOffset,
+  requiredLaunchSpeed,
   runUpDistanceFromRest,
 } from "../physics";
 import {
@@ -131,6 +133,79 @@ describe("physics", () => {
     expect(reached).toBe(true);
     expect(distance).toBeGreaterThan(0);
     expect(distance).toBeLessThan(50);
+  });
+
+  describe("requiredLaunchSpeed", () => {
+    it("a steep jump with meaningful horizontal travel needs more than half walk speed", () => {
+      // Office-map edge jump (252,268)->(263,246): braking to half walk speed
+      // (the follower's reverse-input threshold) tops out ~20px at dx=11,
+      // below the 22px the planner promised.
+      expect(requiredLaunchSpeed(11, 22)).toBeGreaterThan(
+        WALK_TERMINAL_VELOCITY / 2,
+      );
+    });
+
+    it("never exceeds walking terminal velocity", () => {
+      expect(requiredLaunchSpeed(11, 22)).toBeLessThanOrEqual(
+        WALK_TERMINAL_VELOCITY,
+      );
+      expect(requiredLaunchSpeed(25, 1)).toBeLessThanOrEqual(
+        WALK_TERMINAL_VELOCITY,
+      );
+    });
+
+    it("near-vertical and downward jumps need no launch speed", () => {
+      expect(requiredLaunchSpeed(0, 20)).toBe(0);
+      expect(requiredLaunchSpeed(5, -10)).toBe(0);
+    });
+
+    it("verifies against faithful integration: launching at the returned speed reaches the target", () => {
+      const dx = 11;
+      const dyUp = 22;
+      const speed = requiredLaunchSpeed(dx, dyUp);
+      let s = { x: 0, y: 0, xv: speed, yv: -JUMP_STRENGTH };
+      let best = -Infinity;
+      let prev = s;
+      for (let frame = 0; frame < 200 && s.y <= 0.5; frame++) {
+        s = airStep(s, 1);
+        if (prev.x <= dx && s.x >= dx) {
+          const t = (dx - prev.x) / (s.x - prev.x || 1);
+          best = Math.max(best, -(prev.y + t * (s.y - prev.y)));
+        }
+        prev = s;
+      }
+      // The 22px target is only reachable with the landing clamber; the
+      // returned speed must get within clamber range (3px) of it.
+      expect(best).toBeGreaterThanOrEqual(dyUp - 3);
+    });
+  });
+
+  describe("brakingLandingOffset", () => {
+    it("travels less than coasting when braking from a fast overfly", () => {
+      // Office-map edge#7 overfly: apex 35px above the landing at xv ~0.9.
+      const braked = brakingLandingOffset(0.9, 0, 35);
+      let s = { x: 0, y: 0, xv: 0.9, yv: 0 };
+      while (s.y < 35) {
+        s = airStep(s, 1);
+      }
+      expect(braked).toBeLessThan(s.x);
+      expect(braked).toBeGreaterThan(0);
+    });
+
+    it("returns ~0 when already at the landing height", () => {
+      expect(Math.abs(brakingLandingOffset(0.9, 0, 0))).toBeLessThan(2);
+      expect(brakingLandingOffset(0.9, 0, -10)).toBe(0);
+    });
+
+    it("matches faithful integration with the brake held", () => {
+      let s = { x: 0, y: 0, xv: 1.0, yv: -1.5 };
+      let expected = s.x;
+      while (s.y < 20) {
+        s = airStep(s, s.xv > 0 ? -1 : 0);
+        expected = s.x;
+      }
+      expect(brakingLandingOffset(1.0, -1.5, 20)).toBeCloseTo(expected, 5);
+    });
   });
 });
 

--- a/src/data/bot/__spec__/physics.spec.ts
+++ b/src/data/bot/__spec__/physics.spec.ts
@@ -8,6 +8,7 @@ import {
   SAFE_LANDING_SPEED,
   WALK_TERMINAL_VELOCITY,
   brakingLandingOffset,
+  jumpReaches,
   requiredLaunchSpeed,
   runUpDistanceFromRest,
 } from "../physics";
@@ -177,6 +178,27 @@ describe("physics", () => {
       // The 22px target is only reachable with the landing clamber; the
       // returned speed must get within clamber range (3px) of it.
       expect(best).toBeGreaterThanOrEqual(dyUp - 3);
+    });
+  });
+
+  describe("jumpReaches clamber", () => {
+    it("does not grant the landing clamber to near-vertical ascents", () => {
+      // Office-map edge jump (108,148)->(113,124): Δ5,-24 demands the full
+      // apex (~22.8px) plus clamber, but at a near-vertical apex against a
+      // ledge face there is no horizontal motion left to clamber with — the
+      // bot tops out ~1.2px short forever.
+      expect(jumpReaches(5, 24)).toBe(false);
+    });
+
+    it("still grants the clamber to descending arcs sliding onto a lip", () => {
+      // Office-map edge jump (252,268)->(263,246): Δ11,-22 only pencils out
+      // with the clamber and is empirically flyable at the right launch speed.
+      expect(jumpReaches(11, 22)).toBe(true);
+    });
+
+    it("near-vertical jumps within the true apex height still connect", () => {
+      expect(jumpReaches(5, 20)).toBe(true);
+      expect(jumpReaches(0, MAX_JUMP_HEIGHT - 2)).toBe(true);
     });
   });
 

--- a/src/data/bot/debug.ts
+++ b/src/data/bot/debug.ts
@@ -9,6 +9,10 @@ export function isBotDebugEnabled(): boolean {
   return enabled;
 }
 
+export function setBotDebugEnabled(value: boolean) {
+  setEnabled(value);
+}
+
 function setEnabled(value: boolean) {
   enabled = value;
   const layer = getContextOrNull()?.level?.debugLayer;

--- a/src/data/bot/path.ts
+++ b/src/data/bot/path.ts
@@ -6,6 +6,8 @@ import { Edge, EdgeType } from "./edge";
 import {
   MIN_LAUNCH_SPEED,
   WALK_TERMINAL_VELOCITY,
+  brakingLandingOffset,
+  requiredLaunchSpeed,
   runUpDistanceFromRest,
 } from "./physics";
 
@@ -279,6 +281,28 @@ export class Path {
       }
     }
 
+    // Airborne on a jump edge: project where braking right now would land.
+    // If even full braking overshoots the target, brake immediately — holding
+    // toward-target input the whole flight overflies downward jumps and drops
+    // the bot past the landing platform.
+    if (
+      !brakeKey &&
+      destination.type === EdgeType.Jump &&
+      !this.character.body.grounded
+    ) {
+      const jumpDir = destination.direction || 1;
+      const { xVelocity, yVelocity } = this.character.body;
+      if (xVelocity * jumpDir > 0) {
+        const [x, y] = this.character.body.precisePosition;
+        const drop = destination.to.y - (y + 8);
+        const landingX =
+          x + 3 + brakingLandingOffset(xVelocity, yVelocity, drop);
+        if ((landingX - destination.to.x) * jumpDir > 0) {
+          brakeKey = jumpDir > 0 ? Key.Left : Key.Right;
+        }
+      }
+    }
+
     const isSteepJump = (e: Edge | undefined) =>
       !!e && e.type === EdgeType.Jump && e.isSteep;
     const steepJump = isSteepJump(destination)
@@ -286,10 +310,19 @@ export class Path {
       : destination.type !== EdgeType.Jump && isSteepJump(nextDestination)
         ? nextDestination
         : null;
-    if (!brakeKey && steepJump) {
+    // Grounded only: this caps the LAUNCH speed. Once airborne the arc needs
+    // air-control held toward the target (the reach model assumes it); braking
+    // mid-flight starves the jump, and overshoot is already handled above.
+    if (!brakeKey && steepJump && this.character.body.grounded) {
       const jumpDir = steepJump.direction || 1;
       const speedAlong = this.character.body.xVelocity * jumpDir;
-      if (speedAlong > REVERSE_INPUT_SPEED) {
+      // A steep jump with real horizontal travel still needs launch speed —
+      // braking it to a near-standing jump undershoots the ledge corner.
+      const launchSpeed = Math.max(
+        REVERSE_INPUT_SPEED,
+        requiredLaunchSpeed(steepJump.dx, -steepJump.dy),
+      );
+      if (speedAlong > launchSpeed) {
         brakeKey = jumpDir > 0 ? Key.Left : Key.Right;
       }
     }
@@ -401,7 +434,20 @@ export class Path {
       const steep = destination.isSteep;
       const fastEnough = steep || speedAlong >= MIN_LAUNCH_SPEED;
       const overshot = pastEdge > 4 && speedAlong > 0;
-      if ((atLaunchPoint && fastEnough) || overshot) {
+      // Past the launch node but still building speed: if the floor ends
+      // within a few px ahead, jump now with the speed we have — running off
+      // the lip waiting for MIN_LAUNCH_SPEED falls into the gap instead.
+      let lipAhead = false;
+      if (atLaunchPoint && speedAlong > 0 && !fastEnough) {
+        const rX = Math.round(x);
+        const rY = Math.round(y);
+        lipAhead = !getLevel().collidesWith(
+          this.character.body.mask,
+          rX + md * 4,
+          rY + 1,
+        );
+      }
+      if ((atLaunchPoint && fastEnough) || overshot || lipAhead) {
         commands.push({ type: CommandType.KeyDown, key: Key.Up });
       }
     } else if (

--- a/src/data/bot/physics.ts
+++ b/src/data/bot/physics.ts
@@ -76,7 +76,7 @@ export const MAX_SAFE_FALL_HEIGHT: number = (() => {
   return Math.floor(safeHeight);
 })();
 
-const JUMP_HEIGHT_AT_DISTANCE: number[] = (() => {
+const { env: JUMP_HEIGHT_AT_DISTANCE, peakIdx: JUMP_APEX_DISTANCE } = (() => {
   const env: number[] = [0];
   const samples = 24;
   for (let i = 0; i <= samples; i++) {
@@ -102,7 +102,7 @@ const JUMP_HEIGHT_AT_DISTANCE: number[] = (() => {
     if (env[x] > env[peakIdx]) peakIdx = x;
   }
   for (let x = 0; x < peakIdx; x++) env[x] = env[peakIdx];
-  return env;
+  return { env, peakIdx };
 })();
 
 // Body's MAX_STEP (body.ts): feet clamber up this far onto a ledge corner, so a
@@ -114,7 +114,12 @@ export function jumpReaches(dx: number, dyUp: number): boolean {
   if (i >= JUMP_HEIGHT_AT_DISTANCE.length) {
     return false;
   }
-  return dyUp <= JUMP_HEIGHT_AT_DISTANCE[i] + LANDING_CLAMBER;
+  // The clamber only helps on the descending side of the arc, where leftover
+  // horizontal motion slides the feet onto the lip top. A near-vertical ascent
+  // (dx before the apex) meets the ledge face with no sideways motion left, so
+  // it must clear the full height.
+  const clamber = i >= JUMP_APEX_DISTANCE ? LANDING_CLAMBER : 0;
+  return dyUp <= JUMP_HEIGHT_AT_DISTANCE[i] + clamber;
 }
 
 // Height (px) the arc passes through at horizontal distance `dx`, launching at

--- a/src/data/bot/physics.ts
+++ b/src/data/bot/physics.ts
@@ -117,6 +117,92 @@ export function jumpReaches(dx: number, dyUp: number): boolean {
   return dyUp <= JUMP_HEIGHT_AT_DISTANCE[i] + LANDING_CLAMBER;
 }
 
+// Height (px) the arc passes through at horizontal distance `dx`, launching at
+// `launchX` while holding air-control toward the target. -Infinity if the arc
+// lands before reaching dx.
+function jumpHeightAtDistance(launchX: number, dx: number): number {
+  let s = { x: 0, y: 0, xv: launchX, yv: -JUMP_STRENGTH };
+  let prev = s;
+  for (let frame = 1; frame <= 200; frame++) {
+    s = airStep(s, 1);
+    if (prev.x <= dx && s.x >= dx) {
+      const t = (dx - prev.x) / (s.x - prev.x || 1);
+      return -(prev.y + t * (s.y - prev.y));
+    }
+    if (s.y > 0 && frame > 1) {
+      return -Infinity;
+    }
+    prev = s;
+  }
+  return -Infinity;
+}
+
+const requiredLaunchSpeedCache = new Map<string, number>();
+
+// Smallest launch speed whose arc passes the full `dyUp` at horizontal
+// distance `dx`. No clamber discount here: an arc that meets the ledge's wall
+// face even fractionally below the lip is stopped dead, not clambered (the
+// auto-step only applies to grounded movement). Falls back to the best-effort
+// speed when no sampled arc reaches the target.
+export function requiredLaunchSpeed(dx: number, dyUp: number): number {
+  const target = Math.ceil(Math.abs(dx));
+  if (target < 1 || dyUp <= 0) {
+    return 0;
+  }
+
+  const key = `${target},${Math.ceil(dyUp)}`;
+  const cached = requiredLaunchSpeedCache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const samples = 24;
+  let best = 0;
+  let bestHeight = -Infinity;
+  let result: number | undefined;
+  for (let i = 0; i <= samples; i++) {
+    const speed = (WALK_TERMINAL_VELOCITY * i) / samples;
+    const height = jumpHeightAtDistance(speed, target);
+    if (height >= dyUp) {
+      result = speed;
+      break;
+    }
+    if (height > bestHeight) {
+      bestHeight = height;
+      best = speed;
+    }
+  }
+  if (result === undefined) {
+    result = best;
+  }
+  requiredLaunchSpeedCache.set(key, result);
+  return result;
+}
+
+// Horizontal travel of the remaining arc when braking as hard as air-control
+// allows, from velocity (xv, yv), until the arc has descended `dyDown` px below
+// the current height. Lets the follower ask "if I brake right now, where do I
+// land?" — if even that overshoots the target, it must brake immediately.
+export function brakingLandingOffset(
+  xv: number,
+  yv: number,
+  dyDown: number,
+): number {
+  if (dyDown <= 0) {
+    return 0;
+  }
+  const direction = Math.sign(xv);
+  let s = { x: 0, y: 0, xv, yv };
+  for (let frame = 1; frame <= 240; frame++) {
+    const brake = Math.sign(s.xv) === direction ? -direction : 0;
+    s = airStep(s, brake as -1 | 0 | 1);
+    if (s.y >= dyDown) {
+      return s.x;
+    }
+  }
+  return s.x;
+}
+
 export const MIN_LAUNCH_SPEED = WALK_TERMINAL_VELOCITY * 0.75;
 
 export function runUpDistanceFromRest(): number {

--- a/src/data/wfc/fixtures/__spec__/zigzagMap.spec.ts
+++ b/src/data/wfc/fixtures/__spec__/zigzagMap.spec.ts
@@ -1,0 +1,13 @@
+import { buildZigzagGrid } from "../zigzagMap";
+
+describe("buildZigzagGrid", () => {
+  it("is deterministic — two calls produce identical tile id sequences", () => {
+    const a = buildZigzagGrid();
+    const b = buildZigzagGrid();
+    expect(a.length).toBe(8);
+    expect(a[0].length).toBe(12);
+    expect(a.map((row) => row.map((t) => t.id))).toEqual(
+      b.map((row) => row.map((t) => t.id)),
+    );
+  });
+});

--- a/src/data/wfc/fixtures/zigzagMap.ts
+++ b/src/data/wfc/fixtures/zigzagMap.ts
@@ -1,0 +1,153 @@
+import { Map as GameMap, type Config } from "../../map";
+import { socketMultiplier, TILES, TILE_SIZE_PX, type WfcTile } from "../tiles";
+import { gridToBlob } from "../postProcess";
+
+const COLS = 12;
+const ROWS = 8;
+
+// Mirror axis for the map and the spawn/target nodes (mask-space pixels).
+export const MAP_WIDTH = COLS * TILE_SIZE_PX;
+const MAP_HEIGHT = ROWS * TILE_SIZE_PX;
+
+function findTile(id: string): WfcTile {
+  const t = TILES.find((t) => t.id === id);
+  if (!t) {
+    throw new Error(`zigzagMap: tile id '${id}' not found in TILES`);
+  }
+  return t;
+}
+
+// Hand-authored deterministic grid: four floor legs (rows 1/3/5/7) joined by
+// alternating ladder runs, with ramps, floorBox hops and floorHole gaps so the
+// path exercises walk/jump/climb/fall edges. Only a valid findPath matters here
+// — the follower itself need not complete. See docs/bot-pathfinding-test.md.
+const GRID_IDS: string[][] = [
+  ["empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty"],
+  ["floor", "floor", "floorBox", "floor", "doubleFloor", "doubleJumpFloor", "doubleFloorStep", "ramp_m", "floor", "floorHole", "floorLadderTop", "empty"],
+  ["empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "rampEntry_m", "halfLadder_m", "empty"],
+  ["empty", "empty", "empty", "doubleFloor", "floor", "ramp", "doubleJumpFloor", "halfSolid", "highFloorLadderTop", "highFloorRamp_m", "highFloorStep_m", "floorBox"],
+  ["floor", "rampEntry_m", "ramp", "empty", "empty", "empty", "empty", "empty", "halfLadder", "highFloorRamp", "ramp", "solid"],
+  ["solid", "steepWall_m", "floor", "floorBox", "floor", "doubleFloor", "doubleFloorSolid", "ramp_m", "floor", "floorHole", "floor", "floorLadderTop"],
+  ["empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "tubeLadder"],
+  ["floor", "floor", "ramp", "doubleFloor", "doubleFloorStep", "floor", "floorHole", "floor", "ramp", "doubleJumpFloor", "doubleFloorSolid_m", "floorLadder"],
+];
+
+export function buildZigzagGrid(): WfcTile[][] {
+  const grid = GRID_IDS.map((row) => row.map(findTile));
+
+  if (grid.length !== ROWS) throw new Error("row count mismatch");
+  for (const row of grid) {
+    if (row.length !== COLS) throw new Error("col count mismatch");
+  }
+
+  validateEdges(grid);
+  return grid;
+}
+
+// Assert every shared edge connects: a zero multiplier means incompatible
+// sockets (in practice, a LADDER socket facing a non-LADDER neighbour).
+function validateEdges(grid: WfcTile[][]): void {
+  for (let y = 0; y < grid.length; y++) {
+    for (let x = 0; x < grid[y].length; x++) {
+      const tile = grid[y][x];
+
+      const right = grid[y][x + 1];
+      if (right && socketMultiplier(tile.sockets.right, right.sockets.left, 1) === 0) {
+        throw new Error(
+          `zigzagMap: incompatible edge at (${x},${y}) ${tile.id} → ${right.id}`,
+        );
+      }
+
+      const below = grid[y + 1]?.[x];
+      if (below && socketMultiplier(tile.sockets.bottom, below.sockets.top, 1) === 0) {
+        throw new Error(
+          `zigzagMap: incompatible edge at (${x},${y}) ${tile.id} ↓ ${below.id}`,
+        );
+      }
+    }
+  }
+}
+
+async function buildZigzagConfig(mirror = false): Promise<Config> {
+  const grid = buildZigzagGrid();
+  const tilesWithImages = await loadTileImages(grid);
+  const { blob: rawBlob, ladders } = await gridToBlob(tilesWithImages);
+  // Mirror left↔right by flipping the finished mask horizontally — an exact
+  // pixel mirror of the collision geometry (no tile-mirror bookkeeping needed),
+  // and deterministic across engines since it resamples nothing.
+  const blob = mirror
+    ? await flipBlobHorizontally(rawBlob, MAP_WIDTH, MAP_HEIGHT)
+    : rawBlob;
+  const data = await blobToDataUrl(blob);
+
+  return {
+    terrain: { data },
+    layers: [],
+    bbox: { left: 0, top: 0, right: MAP_WIDTH, bottom: MAP_HEIGHT },
+    parallax: { name: "", offset: 0 },
+    scale: 6,
+    ladders: ladders.map((l) => {
+      const cx = mirror ? MAP_WIDTH - l.x : l.x;
+      return {
+        left: cx - l.width / 2,
+        top: l.y,
+        right: cx + l.width / 2,
+        bottom: l.y + l.height,
+      };
+    }),
+  };
+}
+
+export async function buildZigzagMap(mirror = false): Promise<GameMap> {
+  return GameMap.fromConfig(await buildZigzagConfig(mirror));
+}
+
+async function flipBlobHorizontally(
+  blob: Blob,
+  width: number,
+  height: number,
+): Promise<Blob> {
+  const bitmap = await createImageBitmap(blob);
+  const canvas = new OffscreenCanvas(width, height);
+  const ctx = canvas.getContext("2d")!;
+  ctx.imageSmoothingEnabled = false;
+  ctx.translate(width, 0);
+  ctx.scale(-1, 1);
+  ctx.drawImage(bitmap, 0, 0);
+  return canvas.convertToBlob({ type: "image/png" });
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+// Near-duplicate of wfc.worker.ts::loadTileImages — kept separate so this
+// fixture can run on the main thread and preserve the grid shape.
+async function loadTileImages(grid: WfcTile[][]): Promise<WfcTile[][]> {
+  const cache = new Map<string, ImageBitmap>();
+  const result: WfcTile[][] = [];
+  for (const row of grid) {
+    const newRow: WfcTile[] = [];
+    for (const t of row) {
+      if (!t.imagePath) {
+        newRow.push(t);
+        continue;
+      }
+      let img = cache.get(t.imagePath);
+      if (!img) {
+        const res = await fetch(t.imagePath);
+        const b = await res.blob();
+        img = await createImageBitmap(b);
+        cache.set(t.imagePath, img);
+      }
+      newRow.push({ ...t, imageData: img });
+    }
+    result.push(newRow);
+  }
+  return result;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,6 +85,13 @@ const routes: RouteRecordRaw[] = [
   },
 ];
 
+if (import.meta.env.DEV) {
+  routes.push({
+    path: "/test/pathfinding",
+    component: () => import("./components/pages/PathfindingTest.vue"),
+  });
+}
+
 const router = createRouter({
   history: createWebHashHistory(),
   routes,


### PR DESCRIPTION
### Description

Adds a dev-only pathfinding test harness and fixes four bot jump bugs it surfaced on the Office map.

**Harness** (`/#/test/pathfinding`, dev builds only):
- Deterministic zigzag tile-grid fixture exercising walk/jump/climb/fall edges, plus `?mirror=1` for the right-to-left variant
- `?map=<Name>&pair=N` drives bundled maps between their own spawn locations; `?from=x,y&to=x,y` runs arbitrary routes
- `?trace=1` logs the planned path and per-frame body state for root-causing individual edge failures
- Terminal result is written to a `[data-test-status]` DOM marker so automation can wait on it; see `docs/bot-pathfinding-test.md`

**Follower fixes** (`src/data/bot/path.ts`, `physics.ts`):
- Steep jumps were braked to half walk speed, undershooting ledge corners the planner says are reachable — the launch-speed gate is now derived from the same simulated arc physics, and only applies while grounded
- Down-jumps held toward-target input all flight and overflew the landing platform — the follower now projects the braked landing each airborne frame and brakes when even that overshoots
- A jump whose launch node sits a few px from a lip was never taken (the bot ran off the edge while building speed) — it now jumps immediately when the floor ends just ahead

**Planner fix** (`jumpReaches`):
- The 3px landing-clamber bonus is now granted only to descending arcs; near-vertical ascents meet the ledge face with no sideways motion left and must clear the full height, pruning unflyable edges that looped re-plans forever

Results on the Office map: spawn-pair crossings that previously ended `stuck` after 3 re-plans now arrive with 0; corner-to-corner and umbrella-canopy routes all arrive. Zigzag fixture still arrives 307/307 (and 315/315 mirrored) with 0 re-plans.

### Manual check

- `yarn dev`, then open `http://localhost:3000/#/test/pathfinding?map=Office&pair=1` (full reload between runs — the route is hash-based)
- [ ] Status bar ends `arrived … 47/47 edges 0 re-plans` (previously `stuck` after 3 re-plans)
- Open `?map=Office&pair=4`
- [ ] Ends `arrived … 0 re-plans` (previously `stuck`)
- Open `?map=Office&from=140,247&to=120,120`
- [ ] Ends `arrived` with the bot standing on the umbrella canopy top-left of the map
- Open `/#/test/pathfinding` (zigzag regression)
- [ ] Ends `arrived … 307/307 edges 0 re-plans` (~110s sim time)