### PR TITLE
fix(bot): secure terminal jump/fall landings and stop braking wide steep jumps

### DIFF
--- a/src/data/bot/edge.ts
+++ b/src/data/bot/edge.ts
@@ -26,6 +26,7 @@ export class Edge {
   public readonly direction: -1 | 0 | 1;
   public readonly isSteep: boolean;
   public readonly isVertical: boolean;
+  public readonly isNarrow: boolean;
 
   constructor(from: Node, to: Node, type: EdgeType) {
     this.from = from;
@@ -37,6 +38,7 @@ export class Edge {
     this.direction = Math.sign(this.dx) as -1 | 0 | 1;
     this.isSteep = Math.abs(this.dy) > Math.abs(this.dx);
     this.isVertical = this.dx === 0;
+    this.isNarrow = Math.abs(this.dx) < NARROW_JUMP_XDIFF;
 
     const distance = getDistance(to.x, to.y, from.x, from.y);
     if (type === EdgeType.Walk || type === EdgeType.Climb) {

--- a/src/data/bot/path.ts
+++ b/src/data/bot/path.ts
@@ -245,6 +245,19 @@ export class Path {
       hasArrived = true;
     }
 
+    // Hold a final jump/fall until grounded: arriving mid-air stops the
+    // follower, dropping the bot back into the gap before it can land.
+    if (
+      hasArrived &&
+      !nextDestination &&
+      (destination.type === EdgeType.Jump ||
+        destination.type === EdgeType.Fall) &&
+      !this.character.body.grounded &&
+      this.bustedTimer >= Path.BUSTED_TIMER / 2
+    ) {
+      hasArrived = false;
+    }
+
     return hasArrived;
   }
 
@@ -279,8 +292,10 @@ export class Path {
       }
     }
 
+    // Brake only narrow steep jumps; a wide steep jump needs its run-up speed
+    // to clear the gap, so braking it would fall short.
     const isSteepJump = (e: Edge | undefined) =>
-      !!e && e.type === EdgeType.Jump && e.isSteep;
+      !!e && e.type === EdgeType.Jump && e.isSteep && e.isNarrow;
     const steepJump = isSteepJump(destination)
       ? destination
       : destination.type !== EdgeType.Jump && isSteepJump(nextDestination)


### PR DESCRIPTION
## What

Two fixes to the bot path follower, surfaced by running it across the real maps (Playground, Stadium, Castle, Office) on the dev pathfinding harness.

1. **Terminal jump/fall landings** — a final `Jump`/`Fall` edge registered as *arrived* while the body was still airborne at the node, so the follower stopped steering and the bot lost the air control that carries it onto solid ground, dropping back into the gap it had just cleared (a death at a cliff-edge target). A final jump/fall is now only *arrived* once the body is grounded; the existing stall fallback still rescues a genuinely stuck airborne case.

2. **Wide steep jumps** — the brake heuristic fired on any *steep* jump to keep it near-vertical, but a steep jump that also needs horizontal reach must keep its run-up speed or it falls short and stalls into an endless re-plan loop. The brake is now gated to *narrow* steep jumps via the new `Edge.isNarrow`.

## Verification

- `yarn test src/data/bot` — 82/82 pass; `yarn check-types` clean.
- Harness sweeps (5 opposite-side spawn pairs per map): Playground 5/5 and Stadium 5/5 arrive (previously a silent death and a hard stuck); Castle/Office connected pairs arrive.
- Zigzag regression: 307/307 (6449 frames, vs 6509 before — marginally faster), mirrored zigzag 315/315.

The harness changes used to find these live separately on `bot-pathfinding-test-local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)