### PR TITLE
feat(bot): overhaul offensive spell aiming and friendly-fire prediction

### DIFF
--- a/src/data/bot/strategies/__spec__/ballistics.spec.ts
+++ b/src/data/bot/strategies/__spec__/ballistics.spec.ts
@@ -1,0 +1,53 @@
+import {
+  chooseBallisticHeading,
+  simulateBallisticLanding,
+  solveBallisticHeadings,
+} from "../ballistics";
+import { CollisionMask } from "../../../collision/collisionMask";
+
+function emptyMask(w: number, h: number): CollisionMask {
+  const m = CollisionMask.forRect(w, h);
+  m.subtract(CollisionMask.forRect(w, h), 0, 0);
+  return m;
+}
+
+describe("ballistics", () => {
+  it("solves headings whose simulated arc lands on the target", () => {
+    const mask = emptyMask(300, 200);
+    mask.add(CollisionMask.forRect(300, 10), 0, 190); // flat ground
+    const from: [number, number] = [50, 180];
+    const target: [number, number] = [120, 190];
+
+    const headings = solveBallisticHeadings(
+      target[0] - from[0],
+      target[1] - from[1],
+      1.8,
+      0.04,
+    );
+    expect(headings).toHaveLength(2);
+    for (const heading of headings) {
+      const landing = simulateBallisticLanding(mask, from, heading, 1.8, 0.04, 400)!;
+      expect(Math.abs(landing[0] - target[0])).toBeLessThan(10);
+    }
+  });
+
+  it("returns no headings beyond ballistic reach", () => {
+    expect(solveBallisticHeadings(200, 0, 1.8, 0.04)).toHaveLength(0);
+  });
+
+  it("picks the landing closest to the target", () => {
+    const mask = emptyMask(300, 200);
+    mask.add(CollisionMask.forRect(300, 10), 0, 190);
+    const best = chooseBallisticHeading(
+      mask,
+      [50, 180],
+      [120, 190],
+      1.8,
+      0.04,
+      400,
+      15,
+    )!;
+    expect(best).not.toBeNull();
+    expect(Math.hypot(best.landingGame[0] - 120, best.landingGame[1] - 190)).toBeLessThan(6);
+  });
+});

--- a/src/data/bot/strategies/__spec__/flowField.spec.ts
+++ b/src/data/bot/strategies/__spec__/flowField.spec.ts
@@ -1,0 +1,61 @@
+import { FlowField } from "../flowField";
+import { CollisionMask } from "../../../collision/collisionMask";
+
+function emptyMask(w: number, h: number): CollisionMask {
+  const m = CollisionMask.forRect(w, h);
+  m.subtract(CollisionMask.forRect(w, h), 0, 0);
+  return m;
+}
+
+describe("FlowField", () => {
+  it("routes straight toward the target in the open", () => {
+    const mask = emptyMask(200, 200);
+    const field = new FlowField(mask, [180, 100]);
+    const wp = field.waypoint([20, 100], 24)!;
+    expect(wp[0]).toBeGreaterThan(30);
+    expect(Math.abs(wp[1] - 100)).toBeLessThanOrEqual(8);
+  });
+
+  it("routes over a wall between start and target", () => {
+    const mask = emptyMask(200, 200);
+    // Wall from the floor up to y=60, leaving clearance only above it.
+    mask.add(CollisionMask.forRect(12, 140), 94, 60);
+    const field = new FlowField(mask, [180, 180]);
+    const wp = field.waypoint([20, 180], 24)!;
+    // The route's first leg must climb, not head straight at the wall.
+    expect(wp[1]).toBeLessThan(180);
+  });
+
+  it("returns null when the target is sealed off", () => {
+    const mask = emptyMask(200, 200);
+    // Solid block with a hollow center the missile cannot reach.
+    mask.add(CollisionMask.forRect(60, 60), 70, 70);
+    mask.subtract(CollisionMask.forRect(10, 10), 95, 95);
+    const field = new FlowField(mask, [100, 100]);
+    expect(field.waypoint([20, 20], 24)).toBeNull();
+  });
+
+  it("only builds and routes within the given bounds", () => {
+    const mask = emptyMask(400, 200);
+    const bounded = new FlowField(mask, [100, 100], [], 21, {
+      left: 50,
+      top: 50,
+      right: 150,
+      bottom: 150,
+    });
+    expect(bounded.waypoint([60, 100], 24)).not.toBeNull();
+    // Far outside the region there is no field to follow.
+    expect(bounded.waypoint([300, 100], 24)).toBeNull();
+  });
+
+  it("detours around hazard positions when a clear route exists", () => {
+    const mask = emptyMask(300, 120);
+    const direct = new FlowField(mask, [280, 60]);
+    const hazardous = new FlowField(mask, [280, 60], [[150, 60]], 21);
+    const directWp = direct.waypoint([150, 30], 12)!;
+    const hazardWp = hazardous.waypoint([150, 30], 12)!;
+    // With a hazard at (150,60), the route from above it should not descend
+    // toward it the way the unconstrained route does.
+    expect(hazardWp[1]).toBeLessThanOrEqual(directWp[1]);
+  });
+});

--- a/src/data/bot/strategies/__spec__/scoring.spec.ts
+++ b/src/data/bot/strategies/__spec__/scoring.spec.ts
@@ -6,7 +6,6 @@ import {
   predictExplosiveDamage,
   predictImpactDamage,
   predictFallDamage,
-  predictChainTargets,
   scoreCandidate,
   collectAllies,
   hasLineOfSight,
@@ -214,32 +213,5 @@ describe("predictFallDamage", () => {
     // SwordTip range = 80px = ~13.33 game units
     expect(predictFallDamage(10, 80 / 6, 4)).toBe(4);
     expect(predictFallDamage(20, 80 / 6, 4)).toBe(0);
-  });
-});
-
-describe("predictChainTargets", () => {
-  it("counts enemies reachable by chaining within range, capped at maxChains", () => {
-    const start: [number, number] = [0, 0];
-    const enemies: [number, number][] = [
-      [200, 0],   // chain 1 from start
-      [400, 0],   // chain 2 (within 260 of #1)
-      [2000, 0],  // far away — unreachable
-    ];
-    expect(predictChainTargets(start, enemies, 260, 5)).toBe(2);
-  });
-
-  it("never exceeds maxChains", () => {
-    const start: [number, number] = [0, 0];
-    const enemies: [number, number][] = Array.from(
-      { length: 10 },
-      (_, i) => [i * 100, 0] as [number, number],
-    );
-    expect(predictChainTargets(start, enemies, 260, 5)).toBe(5);
-  });
-
-  it("returns 0 when there are no reachable enemies", () => {
-    const start: [number, number] = [0, 0];
-    expect(predictChainTargets(start, [], 260, 5)).toBe(0);
-    expect(predictChainTargets(start, [[1000, 0]], 260, 5)).toBe(0);
   });
 });

--- a/src/data/bot/strategies/acid.ts
+++ b/src/data/bot/strategies/acid.ts
@@ -1,31 +1,128 @@
 import { ACID } from "../../spells";
-import { getManager } from "../../context";
+import { AcidSpray } from "../../spells/acidSpray";
+import { Command, CommandType, Key } from "../../controller/controller";
+import { getLevel, getManager } from "../../context";
 import { Character } from "../../entity/character";
 import { Element } from "../../spells/types";
 import { Graph } from "../graph";
 import { InstantPressCast } from "./instantPressCast";
-import { hasLineOfSight, predictFallDamage } from "./scoring";
+import { predictFallDamage } from "./scoring";
 import { evaluateAOECandidates } from "./aoeEvaluation";
+import { chooseBallisticHeading } from "./ballistics";
 
 // 90 = Acid shape's range in screen px (fallDamage.ts); ÷6 → game units.
 const ACID_RANGE_GAME = 90 / 6;
 const PER_DROPLET_BASE = 3;
-// Of the ~13 droplets over the spray, a few land near a stationary target.
+// Of the ~10 droplets over the spray, a few land near a stationary target.
 // Conservative starting value — refine during playtesting.
 const EXPECTED_DROPLETS = 4;
-const MAX_RANGE_SCREEN = 500;
 const MIN_RANGE_SCREEN = 80;
+// Droplet ballistics — match AcidSpray.dropletSpeed and AcidDroplet's gravity.
+const DROPLET_SPEED = 1.8;
+const DROPLET_GRAVITY = 0.04;
+const DROPLET_TIMEOUT = 200;
+// The spray leaves the staff tip, not the body center (see AcidSpray.getStaffTip).
+const STAFF_FORWARD_GAME = 56 / 6;
+const STAFF_LIFT_GAME = 23 / 6;
+// Landing must be within splash range of the target, with margin for spray spread.
+const MAX_LANDING_MISS_GAME = ACID_RANGE_GAME;
+const AIM_PROJECTION_SCREEN = 300;
+
+interface BallisticAim {
+  heading: number;
+  landingGame: [number, number];
+}
 
 export class Acid extends InstantPressCast {
   public static spell = ACID;
 
+  private step = 0;
+  private sprayTime = 0;
+
+  // Aim one tick before pressing so the look direction flips before the cast
+  // animation blocks it (the droplets spawn at the staff tip on the facing side,
+  // and a back-tip spawn can clip the caster's own body). Then keep the ballistic
+  // aim held until our spray entity is gone — the spray re-reads the mouse every
+  // tick for its full ~130-tick duration.
+  execute(dt: number): Command[] | null {
+    this.sprayTime += dt;
+    const [x, y] = this.aimPoint();
+
+    if (this.step === 0) {
+      this.step = 1;
+      return [
+        { type: CommandType.ResetKeys },
+        { type: CommandType.MouseMove, x, y },
+      ];
+    }
+
+    if (this.step === 1) {
+      this.step = 2;
+      return [
+        { type: CommandType.MouseMove, x, y },
+        { type: CommandType.KeyPress, key: Key.M1 },
+      ];
+    }
+
+    const sprayAlive = (() => {
+      let found = false;
+      getLevel().entities.forEach((entity) => {
+        if (entity instanceof AcidSpray && entity.owner === this.character) {
+          found = true;
+        }
+      });
+      return found;
+    })();
+
+    // Give the cast a few ticks to spawn the spray before checking liveness.
+    if (this.sprayTime > 10 && !sprayAlive) return null;
+    if (this.sprayTime > 300) return null;
+    return [{ type: CommandType.MouseMove, x, y }];
+  }
+
   protected aimPoint(): [number, number] {
-    return this.evaluation!.target.centerScreen;
+    const [cx, cy] = this.character.getCenter();
+    const aim = this.solveAim(this.evaluation!.target.centerScreen);
+    // The evaluation only accepted ballistically reachable targets, so aim is
+    // present; fall back to the raw target just in case the bot moved.
+    const heading = aim
+      ? aim.heading
+      : Math.atan2(
+          this.evaluation!.target.centerScreen[1] - cy,
+          this.evaluation!.target.centerScreen[0] - cx,
+        );
+    return [
+      cx + Math.cos(heading) * AIM_PROJECTION_SCREEN,
+      cy + Math.sin(heading) * AIM_PROJECTION_SCREEN,
+    ];
   }
 
   static predictDamageAt(distanceGameUnits: number, lifeValue: number): number {
     const perDroplet = PER_DROPLET_BASE + lifeValue;
     return predictFallDamage(distanceGameUnits, ACID_RANGE_GAME, perDroplet) * EXPECTED_DROPLETS;
+  }
+
+  // The heading + landing spot that brings the spray closest to `targetScreen`,
+  // picked across both ballistic roots so the spray's ±spread loses as few
+  // droplets as possible to a landing that is merely "within splash range".
+  private solveAim(targetScreen: [number, number]): BallisticAim | null {
+    const surface = getLevel().terrain.collisionMask;
+    const [cx, cy] = this.character.getCenter();
+    const facing = Math.sign(targetScreen[0] - cx) || 1;
+    const staff: [number, number] = [
+      cx / 6 + facing * STAFF_FORWARD_GAME,
+      cy / 6 - STAFF_LIFT_GAME,
+    ];
+
+    return chooseBallisticHeading(
+      surface,
+      staff,
+      [targetScreen[0] / 6, targetScreen[1] / 6],
+      DROPLET_SPEED,
+      DROPLET_GRAVITY,
+      DROPLET_TIMEOUT,
+      MAX_LANDING_MISS_GAME,
+    );
   }
 
   evaluate(graph: Graph, targets: Character[]) {
@@ -35,12 +132,13 @@ export class Acid extends InstantPressCast {
     this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
       spell: Acid.spell,
       reachScreen: ACID_RANGE_GAME * 6,
-      impactPoint: (target, { myCenter, surface }) => {
+      impactPoint: (target, { myCenter }) => {
         const center = target.getCenter();
         const distance = Math.hypot(center[0] - myCenter[0], center[1] - myCenter[1]);
-        if (distance > MAX_RANGE_SCREEN || distance < MIN_RANGE_SCREEN) return null;
-        if (!hasLineOfSight(surface, myCenter, center)) return null;
-        return center;
+        if (distance < MIN_RANGE_SCREEN) return null;
+        const aim = this.solveAim(center);
+        if (!aim) return null;
+        return [aim.landingGame[0] * 6, aim.landingGame[1] * 6];
       },
       predictDamageAt: (d) => Acid.predictDamageAt(d, life),
     });

--- a/src/data/bot/strategies/acid.ts
+++ b/src/data/bot/strategies/acid.ts
@@ -1,6 +1,6 @@
 import { ACID } from "../../spells";
 import { AcidSpray } from "../../spells/acidSpray";
-import { Command, CommandType, Key } from "../../controller/controller";
+import { Command, CommandType } from "../../controller/controller";
 import { getLevel, getManager } from "../../context";
 import { Character } from "../../entity/character";
 import { Element } from "../../spells/types";
@@ -36,48 +36,24 @@ interface BallisticAim {
 export class Acid extends InstantPressCast {
   public static spell = ACID;
 
-  private step = 0;
-  private sprayTime = 0;
-
-  // Aim one tick before pressing so the look direction flips before the cast
-  // animation blocks it (the droplets spawn at the staff tip on the facing side,
-  // and a back-tip spawn can clip the caster's own body). Then keep the ballistic
-  // aim held until our spray entity is gone — the spray re-reads the mouse every
-  // tick for its full ~130-tick duration.
-  execute(dt: number): Command[] | null {
-    this.sprayTime += dt;
-    const [x, y] = this.aimPoint();
-
-    if (this.step === 0) {
-      this.step = 1;
-      return [
-        { type: CommandType.ResetKeys },
-        { type: CommandType.MouseMove, x, y },
-      ];
-    }
-
-    if (this.step === 1) {
-      this.step = 2;
-      return [
-        { type: CommandType.MouseMove, x, y },
-        { type: CommandType.KeyPress, key: Key.M1 },
-      ];
-    }
-
-    const sprayAlive = (() => {
-      let found = false;
-      getLevel().entities.forEach((entity) => {
-        if (entity instanceof AcidSpray && entity.owner === this.character) {
-          found = true;
-        }
-      });
-      return found;
-    })();
-
+  // Keep the ballistic aim held until our spray entity is gone — the spray
+  // re-reads the mouse every tick for its full ~130-tick duration.
+  protected afterPress(castTime: number): Command[] | null {
     // Give the cast a few ticks to spawn the spray before checking liveness.
-    if (this.sprayTime > 10 && !sprayAlive) return null;
-    if (this.sprayTime > 300) return null;
+    if (castTime > 10 && !this.sprayAlive()) return null;
+    if (castTime > 300) return null;
+    const [x, y] = this.aimPoint();
     return [{ type: CommandType.MouseMove, x, y }];
+  }
+
+  private sprayAlive(): boolean {
+    let found = false;
+    getLevel().entities.forEach((entity) => {
+      if (entity instanceof AcidSpray && entity.owner === this.character) {
+        found = true;
+      }
+    });
+    return found;
   }
 
   protected aimPoint(): [number, number] {

--- a/src/data/bot/strategies/aoeEvaluation.ts
+++ b/src/data/bot/strategies/aoeEvaluation.ts
@@ -24,6 +24,9 @@ export interface AOEStrategyConfig {
   impactPoint: (target: Character, context: AOEContext) => [number, number] | null;
   // Damage dealt at `distanceGameUnits` from the impact point (element scaling baked in).
   predictDamageAt: (distanceGameUnits: number) => number;
+  // Ally-specific damage prediction, for spells whose secondary effects (bounces,
+  // lingering areas) can drift beyond the initial blast. Defaults to predictDamageAt.
+  predictAllyDamageAt?: (distanceGameUnits: number) => number;
 }
 
 /**
@@ -64,18 +67,20 @@ export function evaluateAOECandidates(
 
       const impactXGame = impact[0] / 6;
       const impactYGame = impact[1] / 6;
-      const predict = (c: Character) => {
+      const distanceTo = (c: Character) => {
         const [sx, sy] = c.getCenter();
-        const d = Math.sqrt(
+        return Math.sqrt(
           (sx / 6 - impactXGame) ** 2 + (sy / 6 - impactYGame) ** 2,
         );
-        return config.predictDamageAt(d);
       };
 
       const value = scoreAOECandidate({
         target,
         allies,
-        predictDamage: predict,
+        predictDamage: (c) => config.predictDamageAt(distanceTo(c)),
+        predictAllyDamage: config.predictAllyDamageAt
+          ? (c) => config.predictAllyDamageAt!(distanceTo(c))
+          : undefined,
         spell: config.spell,
         currentMana,
       });

--- a/src/data/bot/strategies/babylon.ts
+++ b/src/data/bot/strategies/babylon.ts
@@ -13,6 +13,9 @@ const PER_HIT = 8; // flat, no element scaling (smallSword.ts)
 // Several of the ~10+ swords land near a target under the spread. Conservative
 // starting value — refine during playtesting.
 const EXPECTED_HITS = 4;
+// The rain of swords scatters around the aim column up to roughly this far; allies
+// are scored as if this much closer so neighbours of the target count as friendly fire.
+const SWORD_SPREAD_GAME = 20;
 
 export class Babylon extends ChargedHoldReleaseCast {
   public static spell = BABYLON;
@@ -33,14 +36,20 @@ export class Babylon extends ChargedHoldReleaseCast {
 
     this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
       spell: Babylon.spell,
-      reachScreen: SMALL_SWORD_RANGE_GAME * 6,
-      // The swords land on the ground under the target, not at its body center.
+      reachScreen: (SMALL_SWORD_RANGE_GAME + SWORD_SPREAD_GAME) * 6,
+      // Characters are baked into the collision mask the swords fall against, so
+      // an unobstructed target is struck at its body — and the damage point sits
+      // 10 units below the collision (fallDamage.ts) — not on the ground beside
+      // it. Only terrain above the target's center (a roof) stops the rain.
       impactPoint: (target, { surface }) => {
-        const feetXGame = target.body.position[0] + 3;
-        const feetYGame = probeX(surface, feetXGame);
-        return [feetXGame * 6, feetYGame * 6];
+        const center = target.getCenter();
+        const firstTerrainY = probeX(surface, target.body.position[0] + 3);
+        if (firstTerrainY < center[1] / 6) return null;
+        return center;
       },
       predictDamageAt: (d) => Babylon.predictDamageAt(d),
+      predictAllyDamageAt: (d) =>
+        Babylon.predictDamageAt(Math.max(0, d - SWORD_SPREAD_GAME)),
     });
 
     this.getNextEvaluation();

--- a/src/data/bot/strategies/ballistics.ts
+++ b/src/data/bot/strategies/ballistics.ts
@@ -39,8 +39,11 @@ export function simulateBallisticLanding(
   for (let t = 2; t < maxTicks; t += 2) {
     const x = fromGame[0] + vx * t;
     const y = fromGame[1] + vy * t + (gravity / 2) * t * t;
-    if (y >= surface.height || x < 0 || x > surface.width) return null;
-    if (y >= 0 && surface.collidesWithPoint(Math.round(x), Math.round(y))) {
+    // Bounds-check the rounded sample so the mask is never probed at width/height.
+    const rx = Math.round(x);
+    const ry = Math.round(y);
+    if (ry >= surface.height || rx < 0 || rx >= surface.width) return null;
+    if (ry >= 0 && surface.collidesWithPoint(rx, ry)) {
       return [x, y];
     }
   }

--- a/src/data/bot/strategies/ballistics.ts
+++ b/src/data/bot/strategies/ballistics.ts
@@ -1,0 +1,97 @@
+import { CollisionMask } from "../../collision/collisionMask";
+
+/**
+ * Launch headings (radians, y-down screen orientation) for a projectile fired at
+ * `speed` under `gravity` to pass through `[dx, dy]` relative to its origin: the
+ * flat solution first, the steep lob second, or empty when out of ballistic reach.
+ */
+export function solveBallisticHeadings(
+  dx: number,
+  dy: number,
+  speed: number,
+  gravity: number,
+): number[] {
+  const adx = Math.abs(dx);
+  if (adx < 1) return [];
+  const a = (gravity * adx * adx) / (2 * speed ** 2);
+  const disc = adx * adx - 4 * a * (a - dy);
+  if (disc < 0) return [];
+  const hx = Math.sign(dx);
+  const flat = (-adx + Math.sqrt(disc)) / (2 * a);
+  const steep = (-adx - Math.sqrt(disc)) / (2 * a);
+  return [Math.atan2(flat, hx), Math.atan2(steep, hx)];
+}
+
+/**
+ * Where a projectile fired along `heading` from `fromGame` first strikes the
+ * mask, or null if it leaves the map / outlives `maxTicks` without landing.
+ */
+export function simulateBallisticLanding(
+  surface: CollisionMask,
+  fromGame: [number, number],
+  heading: number,
+  speed: number,
+  gravity: number,
+  maxTicks: number,
+): [number, number] | null {
+  const vx = Math.cos(heading) * speed;
+  const vy = Math.sin(heading) * speed;
+  for (let t = 2; t < maxTicks; t += 2) {
+    const x = fromGame[0] + vx * t;
+    const y = fromGame[1] + vy * t + (gravity / 2) * t * t;
+    if (y >= surface.height || x < 0 || x > surface.width) return null;
+    if (y >= 0 && surface.collidesWithPoint(Math.round(x), Math.round(y))) {
+      return [x, y];
+    }
+  }
+  return null;
+}
+
+/**
+ * The heading whose simulated landing comes closest to `targetGame`, sampling
+ * both ballistic roots plus small perturbations around each (the discrete arc
+ * and rough terrain shift the true optimum off the analytic solution). Returns
+ * null when nothing lands within `maxMissGame` of the target.
+ */
+export function chooseBallisticHeading(
+  surface: CollisionMask,
+  fromGame: [number, number],
+  targetGame: [number, number],
+  speed: number,
+  gravity: number,
+  maxTicks: number,
+  maxMissGame: number,
+): { heading: number; landingGame: [number, number] } | null {
+  let best: { heading: number; landingGame: [number, number] } | null = null;
+  let bestMiss = maxMissGame;
+
+  for (const root of solveBallisticHeadings(
+    targetGame[0] - fromGame[0],
+    targetGame[1] - fromGame[1],
+    speed,
+    gravity,
+  )) {
+    for (const offset of [0, -0.02, 0.02, -0.05, 0.05]) {
+      const heading = root + offset;
+      const landing = simulateBallisticLanding(
+        surface,
+        fromGame,
+        heading,
+        speed,
+        gravity,
+        maxTicks,
+      );
+      if (!landing) continue;
+      const miss = Math.hypot(
+        landing[0] - targetGame[0],
+        landing[1] - targetGame[1],
+      );
+      if (miss <= bestMiss) {
+        bestMiss = miss;
+        best = { heading, landingGame: landing };
+      }
+    }
+  }
+
+  return best;
+}

--- a/src/data/bot/strategies/catastravia.ts
+++ b/src/data/bot/strategies/catastravia.ts
@@ -12,6 +12,11 @@ const MISSILE_MULTIPLIER = 2;
 // starting value — refine during playtesting.
 const EXPECTED_HITS_ON_TARGET = 3;
 const MAX_RANGE_SCREEN = 800;
+// The volley converges on the lock point but missiles overshoot and detonate up
+// to roughly this far around it (observed in the spell-test harness). Allies are
+// scored as if this much closer so a teammate "safely" beside the target still
+// registers as friendly fire.
+const VOLLEY_SCATTER_GAME = 35;
 
 export class Catastravia extends ChargedHoldReleaseCast {
   public static spell = CATASTRAVIA;
@@ -34,7 +39,7 @@ export class Catastravia extends ChargedHoldReleaseCast {
 
     this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
       spell: Catastravia.spell,
-      reachScreen: (MISSILE_RADIUS_GAME + 5) * 6,
+      reachScreen: (MISSILE_RADIUS_GAME + 5 + VOLLEY_SCATTER_GAME) * 6,
       impactPoint: (target, { myCenter, surface }) => {
         const center = target.getCenter();
         if (Math.hypot(center[0] - myCenter[0], center[1] - myCenter[1]) > MAX_RANGE_SCREEN) {
@@ -44,6 +49,8 @@ export class Catastravia extends ChargedHoldReleaseCast {
         return center;
       },
       predictDamageAt: (d) => Catastravia.predictDamageAt(d),
+      predictAllyDamageAt: (d) =>
+        Catastravia.predictDamageAt(Math.max(0, d - VOLLEY_SCATTER_GAME)),
     });
 
     this.getNextEvaluation();

--- a/src/data/bot/strategies/doragate.ts
+++ b/src/data/bot/strategies/doragate.ts
@@ -1,5 +1,6 @@
 import { DORAGATE } from "../../spells";
-import { getManager } from "../../context";
+import { getLevel, getManager } from "../../context";
+import { chooseBallisticHeading } from "./ballistics";
 import { Character } from "../../entity/character";
 import { Element } from "../../spells/types";
 import { Graph } from "../graph";
@@ -13,14 +14,45 @@ const PEBBLE_RADIUS_GAME = 4;
 // starting value — refine during playtesting.
 const EXPECTED_PEBBLES = 2;
 const MAX_RANGE_SCREEN = 600;
+// The pebble volley lands shotgun-like around the lock point, up to roughly this
+// far out (observed in the spell-test harness). Allies are scored as if this much
+// closer, so teammates standing right beside the target count as friendly fire.
+const PEBBLE_SCATTER_GAME = 15;
+// Pebble flight — matches Doragate.launchPower and Pebble's gravity.
+const PEBBLE_SPEED = 6;
+const PEBBLE_GRAVITY = 0.1;
+const PEBBLE_FLIGHT_TICKS = 120;
+// The pebble cloud floats around this offset from the caster's center (game
+// units) when it launches; aim from its centroid so the lead suits the volley.
+const CLOUD_LIFT_GAME = 4;
+const AIM_PROJECTION_SCREEN = 300;
 
 export class Doragate extends ChargedHoldReleaseCast {
   public static spell = DORAGATE;
 
   protected readonly holdTicks = HOLD_TICKS;
 
+  // All pebbles launch along one shared direction; without gravity lead they
+  // arrive ~8 units low over a typical shot and the lower-spawned ones clip the
+  // floor short of the target. Aim the volley's centroid trajectory through the
+  // target's body instead.
   protected aimPoint(): [number, number] {
-    return this.evaluation!.target.centerScreen;
+    const [cx, cy] = this.character.getCenter();
+    const target = this.evaluation!.target.centerScreen;
+    const aim = chooseBallisticHeading(
+      getLevel().terrain.collisionMask,
+      [cx / 6, cy / 6 - CLOUD_LIFT_GAME],
+      [target[0] / 6, target[1] / 6],
+      PEBBLE_SPEED,
+      PEBBLE_GRAVITY,
+      PEBBLE_FLIGHT_TICKS,
+      PEBBLE_SCATTER_GAME,
+    );
+    if (!aim) return target;
+    return [
+      cx + Math.cos(aim.heading) * AIM_PROJECTION_SCREEN,
+      cy + Math.sin(aim.heading) * AIM_PROJECTION_SCREEN,
+    ];
   }
 
   static predictDamageAt(distanceGameUnits: number, arcaneValue: number): number {
@@ -34,7 +66,7 @@ export class Doragate extends ChargedHoldReleaseCast {
 
     this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
       spell: Doragate.spell,
-      reachScreen: (PEBBLE_RADIUS_GAME + 5) * 6,
+      reachScreen: (PEBBLE_RADIUS_GAME + 5 + PEBBLE_SCATTER_GAME) * 6,
       impactPoint: (target, { myCenter, surface }) => {
         const center = target.getCenter();
         if (Math.hypot(center[0] - myCenter[0], center[1] - myCenter[1]) > MAX_RANGE_SCREEN) {
@@ -44,6 +76,8 @@ export class Doragate extends ChargedHoldReleaseCast {
         return center;
       },
       predictDamageAt: (d) => Doragate.predictDamageAt(d, arcane),
+      predictAllyDamageAt: (d) =>
+        Doragate.predictDamageAt(Math.max(0, d - PEBBLE_SCATTER_GAME), arcane),
     });
 
     this.getNextEvaluation();

--- a/src/data/bot/strategies/flowField.ts
+++ b/src/data/bot/strategies/flowField.ts
@@ -1,0 +1,262 @@
+import { CollisionMask } from "../../collision/collisionMask";
+
+// Game units per grid cell. Coarse enough to keep the field cheap, fine enough
+// to route through 32-unit crawl spaces (two open rows at this size) and to
+// never let an 8-unit floor slab slip between the clearance sample points.
+const CELL = 8;
+// Required free space (game units) around a cell center. Keeps routes off walls
+// so the missile's turn lag doesn't clip corners the ray check would clear.
+const CLEARANCE = 6;
+const COST_STRAIGHT = 2;
+const COST_DIAGONAL = 3;
+// Extra cost for cells near a hazard (ally): routes prefer detours over passing
+// right next to a friendly, where any terrain clip means friendly fire.
+const HAZARD_COST = 12;
+
+// Game-unit rectangle the field is built for. Routes cannot leave it, so pad it
+// generously around the engagement — detours (over walls, around roofs) need room
+// beyond the straight start→target box.
+export interface FlowFieldBounds {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/**
+ * Distance field over the terrain, seeded at a target point: every open cell
+ * knows its travel cost to the target, so a guided missile can follow the
+ * downhill gradient through tunnels, around walls, and into overhangs — routes a
+ * greedy line-of-sight steering can never find. Built only within `boundsGame`
+ * (defaults to the whole map), so a cast on a large map samples just the
+ * engagement area.
+ */
+export class FlowField {
+  private cols: number;
+  private rows: number;
+  private minCol: number;
+  private minRow: number;
+  private open: Uint8Array;
+  private dist: Int32Array;
+
+  constructor(
+    surface: CollisionMask,
+    targetGame: [number, number],
+    hazardsGame: [number, number][] = [],
+    hazardRadiusGame = 21,
+    boundsGame?: FlowFieldBounds,
+  ) {
+    const mapCols = Math.ceil(surface.width / CELL);
+    const mapRows = Math.ceil(surface.height / CELL);
+    this.minCol = boundsGame
+      ? Math.min(Math.max(Math.floor(boundsGame.left / CELL), 0), mapCols - 1)
+      : 0;
+    this.minRow = boundsGame
+      ? Math.min(Math.max(Math.floor(boundsGame.top / CELL), 0), mapRows - 1)
+      : 0;
+    const maxCol = boundsGame
+      ? Math.min(Math.max(Math.ceil(boundsGame.right / CELL), this.minCol + 1), mapCols)
+      : mapCols;
+    const maxRow = boundsGame
+      ? Math.min(Math.max(Math.ceil(boundsGame.bottom / CELL), this.minRow + 1), mapRows)
+      : mapRows;
+    this.cols = maxCol - this.minCol;
+    this.rows = maxRow - this.minRow;
+    const size = this.cols * this.rows;
+    this.open = new Uint8Array(size);
+    this.dist = new Int32Array(size).fill(-1);
+
+    const maxX = surface.width - 1;
+    const maxY = surface.height - 1;
+    const solid = (x: number, y: number) =>
+      surface.collidesWithPoint(
+        Math.min(Math.max(x, 0), maxX),
+        Math.min(Math.max(y, 0), maxY),
+      );
+    for (let r = 0; r < this.rows; r++) {
+      for (let c = 0; c < this.cols; c++) {
+        const cx = (this.minCol + c) * CELL + CELL / 2;
+        const cy = (this.minRow + r) * CELL + CELL / 2;
+        this.open[r * this.cols + c] =
+          !solid(cx, cy) &&
+          !solid(cx - CLEARANCE, cy) &&
+          !solid(cx + CLEARANCE, cy) &&
+          !solid(cx, cy - CLEARANCE) &&
+          !solid(cx, cy + CLEARANCE)
+            ? 1
+            : 0;
+      }
+    }
+
+    const hazardCost = new Uint8Array(size);
+    for (const [hx, hy] of hazardsGame) {
+      const rad = Math.ceil(hazardRadiusGame / CELL);
+      const hc = Math.floor(hx / CELL) - this.minCol;
+      const hr = Math.floor(hy / CELL) - this.minRow;
+      for (let r = hr - rad; r <= hr + rad; r++) {
+        for (let c = hc - rad; c <= hc + rad; c++) {
+          if (r < 0 || r >= this.rows || c < 0 || c >= this.cols) continue;
+          const d = Math.hypot(c - hc, r - hr);
+          if (d <= rad) {
+            hazardCost[r * this.cols + c] = Math.max(
+              hazardCost[r * this.cols + c],
+              Math.round(HAZARD_COST * (1 - d / rad)),
+            );
+          }
+        }
+      }
+    }
+
+    // Tight radius: a seed that snaps far from the target can land on the wrong
+    // side of a wall, making a sealed-off target look reachable.
+    const seed = this.nearestOpenCell(targetGame, 2);
+    if (seed === null) return;
+
+    // Dijkstra over the 8-connected grid; diagonals only when both orthogonal
+    // neighbours are open, so routes can't squeeze through corners.
+    const heap: number[] = []; // packed (cost << 20) | index — cost stays well below 2^20
+    const push = (cost: number, index: number) => {
+      heap.push((cost << 20) | index);
+      let i = heap.length - 1;
+      while (i > 0) {
+        const parent = (i - 1) >> 1;
+        if (heap[parent] <= heap[i]) break;
+        [heap[parent], heap[i]] = [heap[i], heap[parent]];
+        i = parent;
+      }
+    };
+    const pop = () => {
+      const top = heap[0];
+      const last = heap.pop()!;
+      if (heap.length) {
+        heap[0] = last;
+        let i = 0;
+        for (;;) {
+          const l = i * 2 + 1;
+          const r = l + 1;
+          let smallest = i;
+          if (l < heap.length && heap[l] < heap[smallest]) smallest = l;
+          if (r < heap.length && heap[r] < heap[smallest]) smallest = r;
+          if (smallest === i) break;
+          [heap[smallest], heap[i]] = [heap[i], heap[smallest]];
+          i = smallest;
+        }
+      }
+      return top;
+    };
+
+    this.dist[seed] = 0;
+    push(0, seed);
+    while (heap.length) {
+      const packed = pop();
+      const cost = packed >> 20;
+      const index = packed & 0xfffff;
+      if (cost > this.dist[index]) continue;
+      const c = index % this.cols;
+      const r = (index / this.cols) | 0;
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          if (!dr && !dc) continue;
+          const nc = c + dc;
+          const nr = r + dr;
+          if (nc < 0 || nc >= this.cols || nr < 0 || nr >= this.rows) continue;
+          const ni = nr * this.cols + nc;
+          if (!this.open[ni]) continue;
+          if (
+            dr &&
+            dc &&
+            (!this.open[r * this.cols + nc] || !this.open[nr * this.cols + c])
+          ) {
+            continue;
+          }
+          const step = dr && dc ? COST_DIAGONAL : COST_STRAIGHT;
+          const next = cost + step + hazardCost[ni];
+          if (this.dist[ni] === -1 || next < this.dist[ni]) {
+            this.dist[ni] = next;
+            push(next, ni);
+          }
+        }
+      }
+    }
+  }
+
+  // Closest open cell to a point, searched in growing rings (the point itself is
+  // often inside the clearance margin — e.g. a character standing on the ground).
+  private nearestOpenCell(
+    [x, y]: [number, number],
+    maxRadius: number,
+  ): number | null {
+    const rawC = Math.floor(x / CELL) - this.minCol;
+    const rawR = Math.floor(y / CELL) - this.minRow;
+    // Points beyond the search ring's reach outside the built region have no
+    // meaningful cell — snapping them to the region edge would fabricate a route.
+    if (
+      rawC < -maxRadius ||
+      rawC >= this.cols + maxRadius ||
+      rawR < -maxRadius ||
+      rawR >= this.rows + maxRadius
+    ) {
+      return null;
+    }
+    const c0 = Math.min(Math.max(rawC, 0), this.cols - 1);
+    const r0 = Math.min(Math.max(rawR, 0), this.rows - 1);
+    for (let radius = 0; radius <= maxRadius; radius++) {
+      let best: number | null = null;
+      let bestD = Infinity;
+      for (let r = r0 - radius; r <= r0 + radius; r++) {
+        for (let c = c0 - radius; c <= c0 + radius; c++) {
+          if (r < 0 || r >= this.rows || c < 0 || c >= this.cols) continue;
+          if (Math.max(Math.abs(r - r0), Math.abs(c - c0)) !== radius) continue;
+          if (!this.open[r * this.cols + c]) continue;
+          const d = Math.hypot(c - c0, r - r0);
+          if (d < bestD) {
+            bestD = d;
+            best = r * this.cols + c;
+          }
+        }
+      }
+      if (best !== null) return best;
+    }
+    return null;
+  }
+
+  /**
+   * A steering waypoint roughly `aheadGame` units along the downhill route from
+   * `fromGame` toward the target, or null when the field has no route there.
+   */
+  waypoint(
+    fromGame: [number, number],
+    aheadGame: number,
+  ): [number, number] | null {
+    // Wider radius than the seed: the missile often flies just inside the
+    // clearance margin along a wall, and should still pick the route back up.
+    const start = this.nearestOpenCell(fromGame, 4);
+    if (start === null || this.dist[start] === -1) return null;
+
+    let current = start;
+    const steps = Math.max(1, Math.round(aheadGame / CELL));
+    for (let i = 0; i < steps; i++) {
+      const c = current % this.cols;
+      const r = (current / this.cols) | 0;
+      let best = current;
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          if (!dr && !dc) continue;
+          const nc = c + dc;
+          const nr = r + dr;
+          if (nc < 0 || nc >= this.cols || nr < 0 || nr >= this.rows) continue;
+          const ni = nr * this.cols + nc;
+          if (this.dist[ni] === -1) continue;
+          if (this.dist[ni] < this.dist[best]) best = ni;
+        }
+      }
+      if (best === current) break; // at the seed
+      current = best;
+    }
+
+    return [
+      (this.minCol + (current % this.cols)) * CELL + CELL / 2,
+      (this.minRow + ((current / this.cols) | 0)) * CELL + CELL / 2,
+    ];
+  }
+}

--- a/src/data/bot/strategies/flowField.ts
+++ b/src/data/bot/strategies/flowField.ts
@@ -114,7 +114,11 @@ export class FlowField {
 
     // Dijkstra over the 8-connected grid; diagonals only when both orthogonal
     // neighbours are open, so routes can't squeeze through corners.
-    const heap: number[] = []; // packed (cost << 20) | index — cost stays well below 2^20
+    // Packed (cost << 20) | index. Index gets 20 bits; cost must stay below 2^11
+    // or the shift hits the sign bit and heap ordering breaks — routes long enough
+    // to get near that are capped instead (≈1000 cells at COST_STRAIGHT).
+    const MAX_COST = (1 << 11) - 1;
+    const heap: number[] = [];
     const push = (cost: number, index: number) => {
       heap.push((cost << 20) | index);
       let i = heap.length - 1;
@@ -170,7 +174,7 @@ export class FlowField {
             continue;
           }
           const step = dr && dc ? COST_DIAGONAL : COST_STRAIGHT;
-          const next = cost + step + hazardCost[ni];
+          const next = Math.min(cost + step + hazardCost[ni], MAX_COST);
           if (this.dist[ni] === -1 || next < this.dist[ni]) {
             this.dist[ni] = next;
             push(next, ni);
@@ -247,10 +251,20 @@ export class FlowField {
           if (nc < 0 || nc >= this.cols || nr < 0 || nr >= this.rows) continue;
           const ni = nr * this.cols + nc;
           if (this.dist[ni] === -1) continue;
+          // Same corner rule as the build phase: a diagonal neighbour can have a
+          // lower cost via another path, but stepping to it directly would cut a
+          // corner the missile can't fly.
+          if (
+            dr &&
+            dc &&
+            (!this.open[r * this.cols + nc] || !this.open[nr * this.cols + c])
+          ) {
+            continue;
+          }
           if (this.dist[ni] < this.dist[best]) best = ni;
         }
       }
-      if (best === current) break; // at the seed
+      if (best === current) break; // at the seed, or boxed in by the corner rule
       current = best;
     }
 

--- a/src/data/bot/strategies/guidanceHeading.ts
+++ b/src/data/bot/strategies/guidanceHeading.ts
@@ -1,40 +1,95 @@
 import { CollisionMask } from "../../collision/collisionMask";
 
+export interface GuidanceOptions {
+  // Positions (game units) the flight path should keep clear of — typically the
+  // caster and allies, since a detonation near them is friendly fire.
+  hazards?: [number, number][];
+  // How close (game units) a candidate ray may pass a hazard before it gets
+  // penalised. Defaults to the missile blast's effective range.
+  hazardRadius?: number;
+}
+
+const OFFSETS = (() => {
+  const offsets = [0];
+  for (let off = 0.3; off <= 2.11; off += 0.3) {
+    offsets.push(-off, off);
+  }
+  return offsets;
+})();
+
+function pointToSegmentDistance(
+  px: number,
+  py: number,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+): number {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const lengthSquared = dx * dx + dy * dy;
+  const t = lengthSquared
+    ? Math.max(0, Math.min(1, ((px - x1) * dx + (py - y1) * dy) / lengthSquared))
+    : 0;
+  return Math.hypot(px - (x1 + t * dx), py - (y1 + t * dy));
+}
+
 /**
  * Choose a steering heading (radians) for a guided missile at `fromGame` aiming for
  * `targetGame` (game units). Samples the direct heading plus symmetric angular offsets,
- * rejecting any that hit terrain within `lookaheadGameUnits`, and returns the
- * collision-free heading closest to the direct target direction. Falls back to the
- * direct heading if every candidate is blocked (keep homing rather than freeze).
+ * rejecting any that hit terrain within `lookaheadGameUnits`, and picks the
+ * collision-free heading that stays closest to the direct target direction while
+ * keeping clear of `hazards`. Falls back to the direct heading if every candidate
+ * is blocked (keep homing rather than freeze).
  */
 export function chooseGuidanceHeading(
   surface: CollisionMask,
   fromGame: [number, number],
   targetGame: [number, number],
   lookaheadGameUnits: number,
+  options: GuidanceOptions = {},
 ): number {
   const direct = Math.atan2(
     targetGame[1] - fromGame[1],
     targetGame[0] - fromGame[0],
   );
+  const hazards = options.hazards ?? [];
+  const hazardRadius = options.hazardRadius ?? 21;
 
-  const offsets = [0, -0.3, 0.3, -0.6, 0.6, -0.9, 0.9, -1.2, 1.2];
-  for (const off of offsets) {
+  let best: number | null = null;
+  let bestCost = Infinity;
+  for (const off of OFFSETS) {
     const heading = direct + off;
     const ahead: [number, number] = [
       fromGame[0] + Math.cos(heading) * lookaheadGameUnits,
       fromGame[1] + Math.sin(heading) * lookaheadGameUnits,
     ];
     if (
-      !surface.collidesWithLine(
+      surface.collidesWithLine(
         Math.round(fromGame[0]),
         Math.round(fromGame[1]),
         Math.round(ahead[0]),
         Math.round(ahead[1]),
       )
     ) {
-      return heading;
+      continue;
+    }
+
+    // Cost: stay close to the direct heading, but swing wide of hazards. A grazed
+    // hazard costs up to 2 rad of detour, so the missile prefers a long way around
+    // over skimming terrain right next to an ally.
+    let cost = Math.abs(off);
+    for (const [hx, hy] of hazards) {
+      const d = pointToSegmentDistance(hx, hy, fromGame[0], fromGame[1], ahead[0], ahead[1]);
+      if (d < hazardRadius) {
+        cost += 2 * (1 - d / hazardRadius);
+      }
+    }
+    if (cost < bestCost) {
+      bestCost = cost;
+      best = heading;
     }
   }
-  return direct;
+
+  return best ?? direct;
 }

--- a/src/data/bot/strategies/instantPressCast.ts
+++ b/src/data/bot/strategies/instantPressCast.ts
@@ -13,12 +13,19 @@ export abstract class InstantPressCast extends RangedStrategy {
   private step = 0;
   private castTime = 0;
 
+  // Commands for the ticks after the press, given the time since the cast began.
+  // The default idles until the cursor observes the press; spells whose effect
+  // keeps reading the mouse afterwards (acid's spray) override this to hold aim.
+  protected afterPress(castTime: number): Command[] | null {
+    return castTime > 6 ? null : [];
+  }
+
   execute(dt: number): Command[] | null {
     this.castTime += dt;
-    const [x, y] = this.aimPoint();
 
     if (this.step === 0) {
       this.step = 1;
+      const [x, y] = this.aimPoint();
       return [
         { type: CommandType.ResetKeys },
         { type: CommandType.MouseMove, x, y },
@@ -27,13 +34,13 @@ export abstract class InstantPressCast extends RangedStrategy {
 
     if (this.step === 1) {
       this.step = 2;
+      const [x, y] = this.aimPoint();
       return [
         { type: CommandType.MouseMove, x, y },
         { type: CommandType.KeyPress, key: Key.M1 },
       ];
     }
 
-    if (this.castTime > 6) return null;
-    return [];
+    return this.afterPress(this.castTime);
   }
 }

--- a/src/data/bot/strategies/instantPressCast.ts
+++ b/src/data/bot/strategies/instantPressCast.ts
@@ -3,29 +3,37 @@ import { RangedStrategy } from "./rangedStrategy";
 
 /**
  * Cast gesture for spells that fire on a single M1 press (ApplyCursor / single-press
- * cursors): one tick of ResetKeys + aim + KeyPress M1, then idle until the cursor
- * observes the press.
+ * cursors): one tick of ResetKeys + aim so the character's look direction updates
+ * (like Melee's two-step swing — a cast animation can block direction changes
+ * afterwards), then aim + KeyPress M1, then idle until the cursor observes the press.
  */
 export abstract class InstantPressCast extends RangedStrategy {
   protected abstract aimPoint(): [number, number];
 
-  private pressed = false;
+  private step = 0;
   private castTime = 0;
 
   execute(dt: number): Command[] | null {
     this.castTime += dt;
+    const [x, y] = this.aimPoint();
 
-    if (!this.pressed) {
-      this.pressed = true;
-      const [x, y] = this.aimPoint();
+    if (this.step === 0) {
+      this.step = 1;
       return [
         { type: CommandType.ResetKeys },
+        { type: CommandType.MouseMove, x, y },
+      ];
+    }
+
+    if (this.step === 1) {
+      this.step = 2;
+      return [
         { type: CommandType.MouseMove, x, y },
         { type: CommandType.KeyPress, key: Key.M1 },
       ];
     }
 
-    if (this.castTime > 5) return null;
+    if (this.castTime > 6) return null;
     return [];
   }
 }

--- a/src/data/bot/strategies/lightning.ts
+++ b/src/data/bot/strategies/lightning.ts
@@ -43,6 +43,9 @@ export class Lightning extends ChargedHoldReleaseCast {
    * along `direction`, in hit order. Mirrors `ChainLightning.cast`: the first hop
    * goes to the smallest angular offset within a ±45° cone (range-limited), every
    * later hop to the nearest not-yet-hit character — friend or foe alike.
+   *
+   * Known gap: the real cast hops over any HurtableEntity and Shields divert or
+   * absorb the chain; only characters are modelled here.
    */
   static simulateChain(
     originScreen: [number, number],

--- a/src/data/bot/strategies/lightning.ts
+++ b/src/data/bot/strategies/lightning.ts
@@ -6,13 +6,24 @@ import { Cluster } from "../cluster";
 import { Graph } from "../graph";
 import { Evaluation } from "./strategy";
 import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
-import { hasLineOfSight, predictChainTargets, scoreCandidate } from "./scoring";
+import { angleDiff, getAngle, getSquareDistance } from "../../../util/math";
+import { hasLineOfSight, scoreCandidate } from "./scoring";
 
 const HOLD_TICKS = 35;
+// Chain hop range — matches ChainLightning.maxRange (screen px).
 const CHAIN_RANGE_SCREEN = 260;
+// First-hop acquisition cone — matches ChainLightning.maxAngle.
+const MAX_FIRST_HOP_ANGLE = Math.PI / 4;
 const MAX_CHAINS = 5;
-// Same value as CHAIN_RANGE_SCREEN: the first hop uses the same range as later hops.
-const MAX_RANGE_SCREEN = 260;
+// Where to stand: close enough that the first hop reaches the target with margin
+// for the path follower not stopping on the exact pixel.
+const STANDOFF_GAME = Math.floor(CHAIN_RANGE_SCREEN / 6) - 10;
+// Longest repositioning walk (game units, straight-line) the spell is worth: a
+// cross-map march burns the whole turn and exposes the bot on the way.
+const MAX_APPROACH_GAME = 150;
+// Only reposition along roughly level ground. Approaches that drop off ledges
+// take unpredicted fall damage on the way in.
+const MAX_APPROACH_CLIMB_GAME = 20;
 
 export class Lightning extends ChargedHoldReleaseCast {
   public static spell = LIGHTNING;
@@ -27,60 +38,131 @@ export class Lightning extends ChargedHoldReleaseCast {
     return 20 + elementalValue * 5;
   }
 
+  /**
+   * The characters the chain actually hits when cast from `originScreen` aimed
+   * along `direction`, in hit order. Mirrors `ChainLightning.cast`: the first hop
+   * goes to the smallest angular offset within a ±45° cone (range-limited), every
+   * later hop to the nearest not-yet-hit character — friend or foe alike.
+   */
+  static simulateChain(
+    originScreen: [number, number],
+    direction: number,
+    characters: Character[],
+  ): Character[] {
+    const hits: Character[] = [];
+    let [checkX, checkY] = originScreen;
+
+    for (let i = 0; i < MAX_CHAINS; i++) {
+      let best: Character | null = null;
+      let bestKey = Infinity;
+      for (const candidate of characters) {
+        if (hits.includes(candidate)) continue;
+        const center = candidate.getCenter();
+        const distanceSquared = getSquareDistance(checkX, checkY, ...center);
+        if (distanceSquared > CHAIN_RANGE_SCREEN ** 2) continue;
+
+        const key =
+          i === 0
+            ? Math.abs(angleDiff(direction, getAngle(checkX, checkY, ...center)))
+            : distanceSquared;
+        if (i === 0 && key >= MAX_FIRST_HOP_ANGLE) continue;
+        if (key < bestKey) {
+          bestKey = key;
+          best = candidate;
+        }
+      }
+      if (!best) break;
+      hits.push(best);
+      [checkX, checkY] = best.getCenter();
+    }
+
+    return hits;
+  }
+
   evaluate(graph: Graph, targets: Character[]) {
     this.graph = graph;
-    const myCenter = this.character.getCenter();
-    const myNode = graph.getClosestNode(...this.character.bodyFootCenter);
     const surface = getLevel().terrain.collisionMask;
     const currentMana = this.character.player.mana;
     const perTarget = Lightning.predictPerTarget(
       getManager().getElementValue(Element.Elemental),
     );
 
-    const enemies: Character[] = [];
-    getLevel().withNearbyEntities(
-      myCenter[0],
-      myCenter[1],
-      CHAIN_RANGE_SCREEN * MAX_CHAINS,
-      (entity) => {
-        if (entity instanceof Character && entity.player !== this.character.player) {
-          enemies.push(entity);
-        }
-      },
-    );
+    // Every character on the level: the chain is simulated from the stand-off
+    // spot beside the target, which can be far from where the bot stands now.
+    const allCharacters: Character[] = [];
+    getLevel().entities.forEach((entity) => {
+      if (entity instanceof Character && entity !== this.character) {
+        allCharacters.push(entity);
+      }
+    });
 
     this.evaluations = targets
       .slice(0, 3)
       .map((target) => {
-        const targetCenter = target.getCenter();
-        const dx = targetCenter[0] - myCenter[0];
-        const dy = targetCenter[1] - myCenter[1];
-        if (Math.sqrt(dx * dx + dy * dy) > MAX_RANGE_SCREEN) return null;
-        if (!hasLineOfSight(surface, myCenter, targetCenter)) return null;
+        // The chain is short-ranged, so walk to a stand-off spot beside the
+        // target and predict the cast from there rather than from where the bot
+        // happens to be standing now.
+        const targetFoot = target.body.position;
+        const standCandidates = [
+          graph.getClosestNode(targetFoot[0] - STANDOFF_GAME, targetFoot[1] + 8),
+          graph.getClosestNode(targetFoot[0] + 6 + STANDOFF_GAME, targetFoot[1] + 8),
+        ];
 
-        // Chains start at the primary target and hop to other nearby enemies.
-        // +1 counts the primary target; MAX_CHAINS - 1 caps the hops that follow it,
-        // keeping total hits within the spell's chain limit.
-        const otherEnemies = enemies
-          .filter((e) => e !== target)
-          .map((e) => e.getCenter());
-        const hits =
-          predictChainTargets(targetCenter, otherEnemies, CHAIN_RANGE_SCREEN, MAX_CHAINS - 1) + 1;
-        const enemyDamage = perTarget * hits;
+        const myFoot = this.character.bodyFootCenter;
+        let best: Evaluation | null = null;
+        for (const node of standCandidates) {
+          if (!node) continue;
+          if (
+            getSquareDistance(node.x, node.y, ...myFoot) >
+              MAX_APPROACH_GAME ** 2 ||
+            Math.abs(node.y - myFoot[1]) > MAX_APPROACH_CLIMB_GAME
+          ) {
+            continue;
+          }
+          // Cast origin if the bot stands at this node (center is ~8 above feet).
+          const origin: [number, number] = [node.x * 6, (node.y - 8) * 6];
+          const targetCenter = target.getCenter();
+          if (
+            getSquareDistance(...origin, ...targetCenter) >
+            CHAIN_RANGE_SCREEN ** 2
+          ) {
+            continue;
+          }
+          if (!hasLineOfSight(surface, origin, targetCenter)) continue;
 
-        // Chains can hit allies, but ally damage and kill-detection are omitted here.
-        // This underestimates value in clusters and will NOT suppress firing near a
-        // low-HP ally. Accepted as a conservative start; revisit if bots team-kill.
-        const value = scoreCandidate({
-          enemyDamage,
-          friendlyDamage: 0,
-          killsAlly: false,
-          targetHp: target.hp,
-          spellCost: getSpellCost(Lightning.spell),
-          currentMana,
-        });
-        if (value === null) return null;
-        return { target: Cluster.onCharacter(target), value, to: [myNode] };
+          const hits = Lightning.simulateChain(
+            origin,
+            getAngle(...origin, ...targetCenter),
+            allCharacters,
+          );
+          if (!hits.includes(target)) continue;
+
+          let enemyDamage = 0;
+          let friendlyDamage = 0;
+          let killsAlly = false;
+          for (const hit of hits) {
+            if (hit.player === this.character.player) {
+              friendlyDamage += perTarget;
+              if (perTarget >= hit.hp) killsAlly = true;
+            } else {
+              enemyDamage += perTarget;
+            }
+          }
+
+          const value = scoreCandidate({
+            enemyDamage,
+            friendlyDamage,
+            killsAlly,
+            targetHp: target.hp,
+            spellCost: getSpellCost(Lightning.spell),
+            currentMana,
+          });
+          if (value === null) continue;
+          if (!best || value > best.value) {
+            best = { target: Cluster.onCharacter(target), value, to: [node] };
+          }
+        }
+        return best;
       })
       .filter(Boolean)
       .sort((a, b) => b!.value - a!.value) as Evaluation[];

--- a/src/data/bot/strategies/magicMissile.ts
+++ b/src/data/bot/strategies/magicMissile.ts
@@ -9,18 +9,40 @@ import { RangedStrategy } from "./rangedStrategy";
 import { predictExplosiveDamage } from "./scoring";
 import { evaluateAOECandidates } from "./aoeEvaluation";
 import { chooseGuidanceHeading } from "./guidanceHeading";
+import { FlowField } from "./flowField";
 
 const BLAST_RADIUS_GAME = 16;
-const LOOKAHEAD_GAME = 40;
+// Local-avoidance ray length while following flow-field waypoints; the global
+// route is the field's job, the ray only keeps the missile off nearby walls.
+const LOOKAHEAD_GAME = 14;
+// Ray length for the no-route fallback, where the ray is all the guidance there is.
+const FALLBACK_LOOKAHEAD_GAME = 40;
+// How far ahead along the flow-field route to place the steering waypoint. More
+// than the missile's turn radius (speed 1.5 / turn rate 0.1 = 15 game units) so
+// turns are anticipated rather than reacted to.
+const WAYPOINT_AHEAD_GAME = 24;
+// Padding around the launch→target box the flow field is built for, so the field
+// doesn't sample the whole map. Detours need room beyond the straight-line box:
+// the widest in the test arena (off a roof, U-turn back underneath) stays within
+// ~60 game units of it.
+const ROUTE_MARGIN_GAME = 100;
 const MAX_RANGE_SCREEN = 1500;
 const SAFETY_TIMEOUT = 600; // ticks; bail if the missile never reports gone
 // Screen-px vector length used to turn a steering heading into a mouse position —
 // long enough that the missile tracks the angle, not the cursor's distance.
 const AIM_PROJECTION_SCREEN = 300;
-// target.centerScreen is the foot center (≈ ground level for a grounded character).
-// Aim at the body instead so the missile flies above the terrain and strikes the
-// enemy's body, rather than nosediving into the ground at our own feet. Empirical.
-const AIM_LIFT_PIXELS = 24;
+// target.centerScreen is the body center. During cruise, aim slightly above it so
+// the missile keeps clearance from the ground the target stands on. Empirical.
+const AIM_LIFT_SCREEN = 24;
+// Within this range (game units) of the target, stop avoiding terrain and dive at
+// the ground under the target's feet: the missile only detonates on terrain, so
+// the slab below the enemy is the closest reliable detonation point. Slightly
+// under the blast's effective range (BLAST_RADIUS_GAME + 5) so a terminal dive
+// always lands meaningful damage.
+const TERMINAL_RANGE_GAME = 18;
+// Body center → feet is 8 game units; overshoot a little so the dive commits into
+// the ground instead of skimming along it.
+const FOOT_DROP_SCREEN = 8 * 6 + 18;
 
 export class MagicMissile extends RangedStrategy {
   public static spell = MAGIC_MISSILE;
@@ -60,6 +82,21 @@ export class MagicMissile extends RangedStrategy {
   private fired = false;
   private castTime = 0;
   private cleanedUp = false;
+  private flowField: FlowField | null = null;
+
+  // Friendly positions (game units) the flight path should swing wide of — the
+  // caster itself included, since the missile detonating next to the bot is just
+  // as much friendly fire as hitting an ally.
+  private friendlyHazards(): [number, number][] {
+    const hazards: [number, number][] = [];
+    getLevel().entities.forEach((entity) => {
+      if (entity instanceof Character && entity.player === this.character.player) {
+        const [x, y] = entity.getCenter();
+        hazards.push([x / 6, y / 6]);
+      }
+    });
+    return hazards;
+  }
 
   // Only our own missile, so a missile fired by another bot/player isn't steered.
   private findMissile(): MagicMissileEntity | null {
@@ -72,17 +109,75 @@ export class MagicMissile extends RangedStrategy {
     return found;
   }
 
+  // Steering heading from `fromScreen` toward the target. Globally the missile
+  // follows the flow field's route (which handles tunnels, U-turns and walls);
+  // locally a short terrain ray with friendly-hazard penalties keeps it off
+  // nearby walls. Within terminal range it dives at the ground under the
+  // target's feet — the closest spot the missile can actually detonate on.
+  private guidanceHeading(fromScreen: [number, number]): number {
+    const surface = getLevel().terrain.collisionMask;
+    const [targetX, centerY] = this.evaluation!.target.centerScreen;
+    const [fx, fy] = fromScreen;
+    const distGame = Math.hypot(targetX - fx, centerY - fy) / 6;
+
+    if (distGame <= TERMINAL_RANGE_GAME) {
+      return Math.atan2(centerY + FOOT_DROP_SCREEN - fy, targetX - fx);
+    }
+
+    const hazards = this.friendlyHazards();
+    if (!this.flowField) {
+      // Built at launch, so fx/fy is the cast position here.
+      this.flowField = new FlowField(
+        surface,
+        [targetX / 6, centerY / 6],
+        hazards,
+        BLAST_RADIUS_GAME + 5,
+        {
+          left: Math.min(fx, targetX) / 6 - ROUTE_MARGIN_GAME,
+          top: Math.min(fy, centerY) / 6 - ROUTE_MARGIN_GAME,
+          right: Math.max(fx, targetX) / 6 + ROUTE_MARGIN_GAME,
+          bottom: Math.max(fy, centerY) / 6 + ROUTE_MARGIN_GAME,
+        },
+      );
+    }
+
+    const waypoint = this.flowField.waypoint([fx / 6, fy / 6], WAYPOINT_AHEAD_GAME);
+    if (waypoint) {
+      return chooseGuidanceHeading(surface, [fx / 6, fy / 6], waypoint, LOOKAHEAD_GAME, {
+        hazards,
+        hazardRadius: BLAST_RADIUS_GAME + 5,
+      });
+    }
+
+    // No route — fall back to greedy steering straight at the target and let the
+    // long ray do what it can.
+    return chooseGuidanceHeading(
+      surface,
+      [fx / 6, fy / 6],
+      [targetX / 6, (centerY - AIM_LIFT_SCREEN) / 6],
+      Math.min(FALLBACK_LOOKAHEAD_GAME, Math.max(distGame, 8)),
+      { hazards, hazardRadius: BLAST_RADIUS_GAME + 5 },
+    );
+  }
+
   execute(dt: number): Command[] | null {
     this.castTime += dt;
-    const surface = getLevel().terrain.collisionMask;
-    const [targetX, footY] = this.evaluation!.target.centerScreen;
-    const targetY = footY - AIM_LIFT_PIXELS;
 
     if (!this.fired) {
       this.fired = true;
+      // The cast fires the missile from the character toward the mouse, so pick a
+      // safe launch heading the same way the missile steers — aiming straight at
+      // the target from inside a platform fires the missile into the ground at
+      // the bot's own feet.
+      const [cx, cy] = this.character.getCenter();
+      const heading = this.guidanceHeading([cx, cy]);
       return [
         { type: CommandType.ResetKeys },
-        { type: CommandType.MouseMove, x: targetX, y: targetY },
+        {
+          type: CommandType.MouseMove,
+          x: cx + Math.cos(heading) * AIM_PROJECTION_SCREEN,
+          y: cy + Math.sin(heading) * AIM_PROJECTION_SCREEN,
+        },
         { type: CommandType.KeyDown, key: Key.M1 },
       ];
     }
@@ -99,16 +194,13 @@ export class MagicMissile extends RangedStrategy {
     }
 
     const [mx, my] = missile.getCenter();
-    const heading = chooseGuidanceHeading(
-      surface,
-      [mx / 6, my / 6],
-      [targetX / 6, targetY / 6],
-      LOOKAHEAD_GAME,
-    );
-    const aimX = mx + Math.cos(heading) * AIM_PROJECTION_SCREEN;
-    const aimY = my + Math.sin(heading) * AIM_PROJECTION_SCREEN;
+    const heading = this.guidanceHeading([mx, my]);
     return [
-      { type: CommandType.MouseMove, x: aimX, y: aimY },
+      {
+        type: CommandType.MouseMove,
+        x: mx + Math.cos(heading) * AIM_PROJECTION_SCREEN,
+        y: my + Math.sin(heading) * AIM_PROJECTION_SCREEN,
+      },
       { type: CommandType.KeyDown, key: Key.M1 },
     ];
   }

--- a/src/data/bot/strategies/meteor.ts
+++ b/src/data/bot/strategies/meteor.ts
@@ -1,12 +1,13 @@
 import { METEOR } from "../../spells";
-import { getManager } from "../../context";
+import { getLevel, getManager } from "../../context";
 import { Character } from "../../entity/character";
 import { Element } from "../../spells/types";
 import { Graph } from "../graph";
 import { ChargedHoldReleaseCast } from "./chargedHoldReleaseCast";
 import { predictExplosiveDamage } from "./scoring";
 import { evaluateAOECandidates } from "./aoeEvaluation";
-import { probeX } from "../../map/utils";
+import { CollisionMask } from "../../collision/collisionMask";
+import { circle30x30 } from "../../collision/precomputed/circles";
 
 // Long enough for the Lock cursor to acquire the target before release — the Lock
 // only casts once locked, so too short a hold would miss the targeting window.
@@ -15,6 +16,15 @@ const BLAST_RADIUS_GAME = 16;
 // Bounces that land near the target before the meteor travels off. Conservative
 // starting value — refine during playtesting.
 const EXPECTED_BOUNCES = 2;
+// After the first explosion the meteor bounces away and keeps exploding every few
+// ticks — those follow-up blasts land up to roughly this far (game units) from the
+// initial impact. Allies are scored as if they were this much closer, so a target
+// with a teammate "safely" outside the first blast still counts as friendly fire.
+const BOUNCE_DRIFT_GAME = 30;
+// The meteor body is a 30x30 circle; the explosion fires from its center.
+const BODY_RADIUS_GAME = 15;
+const SIM_STEP_GAME = 5;
+const SIM_MAX_STEPS = 600;
 
 export class Meteor extends ChargedHoldReleaseCast {
   public static spell = METEOR;
@@ -33,20 +43,69 @@ export class Meteor extends ChargedHoldReleaseCast {
     );
   }
 
+  /**
+   * Where the meteor actually lands when locked onto `lockGame`, or null when it
+   * never hits terrain. Mirrors `Meteor.cast` in spells/meteor.ts: the meteor
+   * spawns above the map, offset 45° to the side the caster faces, and flies a
+   * straight line until its 30x30 body strikes terrain — it does not stop at the
+   * lock point, and anything in the way (walls, platforms, roofs) catches it.
+   */
+  static simulateImpact(
+    surface: CollisionMask,
+    lockGame: [number, number],
+    facing: number,
+  ): [number, number] | null {
+    const [lockX, lockY] = lockGame;
+    const maxAngle = facing === 1 ? -Math.PI / 4 : Math.PI + Math.PI / 4;
+    const spawnX = Math.max(
+      0,
+      Math.min(surface.width, lockX + Math.tan(maxAngle) * lockY),
+    );
+    // Matches getAngle(_x, -32, lockX - 16, lockY - 16) in Meteor.cast.
+    const heading = Math.atan2(lockY - 16 + 32, lockX - 16 - spawnX);
+
+    let x = spawnX;
+    let y = -32;
+    const dx = Math.cos(heading) * SIM_STEP_GAME;
+    const dy = Math.sin(heading) * SIM_STEP_GAME;
+    for (let i = 0; i < SIM_MAX_STEPS; i++) {
+      x += dx;
+      y += dy;
+      if (y >= surface.height || x < -30 || x > surface.width) return null;
+      if (
+        y >= 0 &&
+        surface.collidesWith(circle30x30, Math.round(x), Math.round(y))
+      ) {
+        return [x + BODY_RADIUS_GAME, y + BODY_RADIUS_GAME];
+      }
+    }
+    return null;
+  }
+
   evaluate(graph: Graph, targets: Character[]) {
     this.graph = graph;
     const elemental = getManager().getElementValue(Element.Elemental);
+    const surface = getLevel().terrain.collisionMask;
+    const myX = this.character.getCenter()[0];
 
     this.evaluations = evaluateAOECandidates(this.character, graph, targets, {
       spell: Meteor.spell,
-      reachScreen: (BLAST_RADIUS_GAME + 5) * 6,
-      // The meteor lands on the ground under the target, not at its body center.
-      impactPoint: (target, { surface }) => {
-        const feetXGame = target.body.position[0] + 3;
-        const feetYGame = probeX(surface, feetXGame);
-        return [feetXGame * 6, feetYGame * 6];
+      // Wide enough to gather allies that only the drifting bounce blasts reach.
+      reachScreen: (BLAST_RADIUS_GAME + 5 + BOUNCE_DRIFT_GAME) * 6,
+      impactPoint: (target) => {
+        const lock = target.getCenter();
+        // The bot aims at the lock point, so it faces toward it when casting.
+        const facing = Math.sign(lock[0] - myX) || 1;
+        const impact = Meteor.simulateImpact(
+          surface,
+          [lock[0] / 6, lock[1] / 6],
+          facing,
+        );
+        return impact ? [impact[0] * 6, impact[1] * 6] : null;
       },
       predictDamageAt: (d) => Meteor.predictDamageAt(d, elemental),
+      predictAllyDamageAt: (d) =>
+        Meteor.predictDamageAt(Math.max(0, d - BOUNCE_DRIFT_GAME), elemental),
     });
 
     this.getNextEvaluation();

--- a/src/data/bot/strategies/scoring.ts
+++ b/src/data/bot/strategies/scoring.ts
@@ -69,15 +69,18 @@ export function scoreAOECandidate(args: {
   target: Character;
   allies: Character[];
   predictDamage: (character: Character) => number;
+  // Override for allies when secondary effects drift beyond the initial blast.
+  predictAllyDamage?: (character: Character) => number;
   spell: Spell;
   currentMana: number;
 }): number | null {
   const enemyDamage = args.predictDamage(args.target);
+  const predictAlly = args.predictAllyDamage ?? args.predictDamage;
 
   let friendlyDamage = 0;
   let killsAlly = false;
   for (const ally of args.allies) {
-    const d = args.predictDamage(ally);
+    const d = predictAlly(ally);
     friendlyDamage += d;
     if (d >= ally.hp) killsAlly = true;
   }

--- a/src/data/bot/strategies/scoring.ts
+++ b/src/data/bot/strategies/scoring.ts
@@ -114,37 +114,6 @@ export function predictFallDamage(
   return distanceGameUnits <= rangeGameUnits ? power : 0;
 }
 
-// Greedy estimate of how many enemies a chain effect reaches: from `start`, repeatedly
-// hop to the nearest not-yet-hit enemy within `chainRange` (screen px), up to `maxChains`.
-export function predictChainTargets(
-  start: [number, number],
-  enemiesScreen: [number, number][],
-  chainRange: number,
-  maxChains: number,
-): number {
-  const remaining = enemiesScreen.slice();
-  let from = start;
-  let hits = 0;
-  while (hits < maxChains && remaining.length > 0) {
-    let bestIdx = -1;
-    let bestDist = Infinity;
-    for (let i = 0; i < remaining.length; i++) {
-      const dx = remaining[i][0] - from[0];
-      const dy = remaining[i][1] - from[1];
-      const d = Math.sqrt(dx * dx + dy * dy);
-      if (d <= chainRange && d < bestDist) {
-        bestDist = d;
-        bestIdx = i;
-      }
-    }
-    if (bestIdx === -1) break;
-    from = remaining[bestIdx];
-    remaining.splice(bestIdx, 1);
-    hits++;
-  }
-  return hits;
-}
-
 // Coordinates are screen px; the mask works in game units, hence the ÷6.
 export function hasLineOfSight(
   surface: CollisionMask,

--- a/src/data/spells/acidSpray.ts
+++ b/src/data/spells/acidSpray.ts
@@ -46,6 +46,10 @@ export class AcidSpray extends Container implements Spawnable {
     return this.character.getCenter();
   }
 
+  get owner(): Character {
+    return this.character;
+  }
+
   private getStaffTip(): [number, number] {
     return [
       (this.character.position.x + 18 + this.character.direction * 56) / 6,


### PR DESCRIPTION
## What

Started as guided-missile routing, grew into a sweep of the bot's offensive spell strategies using the dev spell-test harness (tunnel/overhang arena, 5 scenarios: open battlefield, three sheltered targets, and a should-refuse case where the only enemy stands between two allies). Each strategy's prediction was checked against what its spell actually does, and the gaps were large.

**Magic missile** — routes with a per-cast Dijkstra flow field over the terrain (8-unit cells, wall clearance, ally-proximity costs, bounded to a padded launch→target box), with a safe launch heading and a terminal dive at the ground under the target. U-turns under overhangs, tunnel threading, and wall climbs all work; previously it self-blasted when the target sat below its own platform.

**Meteor** — `simulateImpact` mirrors the real cast (spawns above the map offset 45° toward the caster's facing, 30x30 body, straight flight): no more confident casts into walls for 0 damage. Bounce explosions drift, so allies are scored as if 30 units closer.

**Lightning** — never cast before (chain reach ~43 units, strategy only fired from where it stood). Now walks to a level stand-off spot beside the target and `simulateChain` replicates the real hop algorithm — angle-based first hop, nearest-entity after, **allies included**, closing the friendly-fire blind spot the old code punted on.

**Acid** — aimed flat at the target while its droplets are slow ballistic projectiles; the spray landed halfway and splashed the caster. Now solves the launch angle, simulates the arc against terrain (this replaces straight-line LOS), holds the aim for the spray's full duration, and scores from the simulated landing.

**Doragate** — pebbles share one launch direction and dropped ~8 units over a typical shot; now leads the volley ballistically from the pebble cloud centroid (shared `ballistics.ts` module with acid) and scores allies with the observed ~15-unit scatter. It also failed the should-refuse scenario before; it refuses now.

**Babylon** — never cast: it predicted sword impacts on the ground beside the target, always outside the 5-unit splash. The real swords strike the body itself (characters are baked into the collision mask), so it now aims at the body, gates on a clear sky column, and casts over walls that block LOS spells.

**Catastravia** — volley overshoot scatters ~35 units downrange; ally scoring only looked within one missile's blast and a teammate beside the target ate the volley. Scatter-aware ally scoring fixes target choice.

**Cross-cutting** — `InstantPressCast` aims one tick before pressing (cast animations block look-direction changes; acid's first droplet used to spawn at the back staff tip and clip the caster), and AOE scoring accepts an ally-specific damage predictor for drift/scatter effects.

## Verification

- `yarn check-types` clean; `yarn vitest run src/data/bot` 83/83 against this branch (includes new `flowField`/`ballistics` specs).
- Harness sweeps (net damage = enemy − ally, mean over repeats; harness lives on `bot-spell-test-harness`):

| Spell | Before | After |
|---|---|---|
| Magic missile | 67.3 (incl. −40 self-blast) | 228.2, zero friendly fire |
| Meteor | 10.4 (81 ally dmg) | 91.5, zero friendly fire |
| Lightning | 0 (never cast) | 28.8 |
| Acid | −4.8 (only hit itself) | ~42 (8–10 of 10 droplets) |
| Doragate | −5.6 (failed refusal test) | 70.0, refusal restored |
| Babylon | 0 (never cast) | 136.0 |
| Catastravia | 0 (traded ally for enemy) | 100.0, zero friendly fire |

- The should-refuse scenario refuses for every spell; zoltraak, fireball, bakuretsu, nephtear and hairpin were surveyed and left untouched (already healthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)