### PR TITLE
Fix bot jump execution undershooting and overflying planned edges

### DIFF
--- a/src/data/bot/__spec__/physics.spec.ts
+++ b/src/data/bot/__spec__/physics.spec.ts
@@ -7,6 +7,8 @@ import {
   MIN_LAUNCH_SPEED,
   SAFE_LANDING_SPEED,
   WALK_TERMINAL_VELOCITY,
+  brakingLandingOffset,
+  requiredLaunchSpeed,
   runUpDistanceFromRest,
 } from "../physics";
 import {
@@ -131,6 +133,79 @@ describe("physics", () => {
     expect(reached).toBe(true);
     expect(distance).toBeGreaterThan(0);
     expect(distance).toBeLessThan(50);
+  });
+
+  describe("requiredLaunchSpeed", () => {
+    it("a steep jump with meaningful horizontal travel needs more than half walk speed", () => {
+      // Office-map edge jump (252,268)->(263,246): braking to half walk speed
+      // (the follower's reverse-input threshold) tops out ~20px at dx=11,
+      // below the 22px the planner promised.
+      expect(requiredLaunchSpeed(11, 22)).toBeGreaterThan(
+        WALK_TERMINAL_VELOCITY / 2,
+      );
+    });
+
+    it("never exceeds walking terminal velocity", () => {
+      expect(requiredLaunchSpeed(11, 22)).toBeLessThanOrEqual(
+        WALK_TERMINAL_VELOCITY,
+      );
+      expect(requiredLaunchSpeed(25, 1)).toBeLessThanOrEqual(
+        WALK_TERMINAL_VELOCITY,
+      );
+    });
+
+    it("near-vertical and downward jumps need no launch speed", () => {
+      expect(requiredLaunchSpeed(0, 20)).toBe(0);
+      expect(requiredLaunchSpeed(5, -10)).toBe(0);
+    });
+
+    it("verifies against faithful integration: launching at the returned speed reaches the target", () => {
+      const dx = 11;
+      const dyUp = 22;
+      const speed = requiredLaunchSpeed(dx, dyUp);
+      let s = { x: 0, y: 0, xv: speed, yv: -JUMP_STRENGTH };
+      let best = -Infinity;
+      let prev = s;
+      for (let frame = 0; frame < 200 && s.y <= 0.5; frame++) {
+        s = airStep(s, 1);
+        if (prev.x <= dx && s.x >= dx) {
+          const t = (dx - prev.x) / (s.x - prev.x || 1);
+          best = Math.max(best, -(prev.y + t * (s.y - prev.y)));
+        }
+        prev = s;
+      }
+      // The 22px target is only reachable with the landing clamber; the
+      // returned speed must get within clamber range (3px) of it.
+      expect(best).toBeGreaterThanOrEqual(dyUp - 3);
+    });
+  });
+
+  describe("brakingLandingOffset", () => {
+    it("travels less than coasting when braking from a fast overfly", () => {
+      // Office-map edge#7 overfly: apex 35px above the landing at xv ~0.9.
+      const braked = brakingLandingOffset(0.9, 0, 35);
+      let s = { x: 0, y: 0, xv: 0.9, yv: 0 };
+      while (s.y < 35) {
+        s = airStep(s, 1);
+      }
+      expect(braked).toBeLessThan(s.x);
+      expect(braked).toBeGreaterThan(0);
+    });
+
+    it("returns ~0 when already at the landing height", () => {
+      expect(Math.abs(brakingLandingOffset(0.9, 0, 0))).toBeLessThan(2);
+      expect(brakingLandingOffset(0.9, 0, -10)).toBe(0);
+    });
+
+    it("matches faithful integration with the brake held", () => {
+      let s = { x: 0, y: 0, xv: 1.0, yv: -1.5 };
+      let expected = s.x;
+      while (s.y < 20) {
+        s = airStep(s, s.xv > 0 ? -1 : 0);
+        expected = s.x;
+      }
+      expect(brakingLandingOffset(1.0, -1.5, 20)).toBeCloseTo(expected, 5);
+    });
   });
 });
 

--- a/src/data/bot/__spec__/physics.spec.ts
+++ b/src/data/bot/__spec__/physics.spec.ts
@@ -8,6 +8,7 @@ import {
   SAFE_LANDING_SPEED,
   WALK_TERMINAL_VELOCITY,
   brakingLandingOffset,
+  jumpReaches,
   requiredLaunchSpeed,
   runUpDistanceFromRest,
 } from "../physics";
@@ -177,6 +178,27 @@ describe("physics", () => {
       // The 22px target is only reachable with the landing clamber; the
       // returned speed must get within clamber range (3px) of it.
       expect(best).toBeGreaterThanOrEqual(dyUp - 3);
+    });
+  });
+
+  describe("jumpReaches clamber", () => {
+    it("does not grant the landing clamber to near-vertical ascents", () => {
+      // Office-map edge jump (108,148)->(113,124): Δ5,-24 demands the full
+      // apex (~22.8px) plus clamber, but at a near-vertical apex against a
+      // ledge face there is no horizontal motion left to clamber with — the
+      // bot tops out ~1.2px short forever.
+      expect(jumpReaches(5, 24)).toBe(false);
+    });
+
+    it("still grants the clamber to descending arcs sliding onto a lip", () => {
+      // Office-map edge jump (252,268)->(263,246): Δ11,-22 only pencils out
+      // with the clamber and is empirically flyable at the right launch speed.
+      expect(jumpReaches(11, 22)).toBe(true);
+    });
+
+    it("near-vertical jumps within the true apex height still connect", () => {
+      expect(jumpReaches(5, 20)).toBe(true);
+      expect(jumpReaches(0, MAX_JUMP_HEIGHT - 2)).toBe(true);
     });
   });
 

--- a/src/data/bot/path.ts
+++ b/src/data/bot/path.ts
@@ -6,6 +6,8 @@ import { Edge, EdgeType } from "./edge";
 import {
   MIN_LAUNCH_SPEED,
   WALK_TERMINAL_VELOCITY,
+  brakingLandingOffset,
+  requiredLaunchSpeed,
   runUpDistanceFromRest,
 } from "./physics";
 
@@ -292,19 +294,51 @@ export class Path {
       }
     }
 
-    // Brake only narrow steep jumps; a wide steep jump needs its run-up speed
-    // to clear the gap, so braking it would fall short.
+    // Airborne on a jump edge: project where braking right now would land.
+    // If even full braking overshoots the target, brake immediately — holding
+    // toward-target input the whole flight overflies downward jumps and drops
+    // the bot past the landing platform.
+    if (
+      !brakeKey &&
+      destination.type === EdgeType.Jump &&
+      !this.character.body.grounded
+    ) {
+      const jumpDir = destination.direction || 1;
+      const { xVelocity, yVelocity } = this.character.body;
+      if (xVelocity * jumpDir > 0) {
+        const [x, y] = this.character.body.precisePosition;
+        const drop = destination.to.y - (y + 8);
+        const landingX =
+          x + 3 + brakingLandingOffset(xVelocity, yVelocity, drop);
+        if ((landingX - destination.to.x) * jumpDir > 0) {
+          brakeKey = jumpDir > 0 ? Key.Left : Key.Right;
+        }
+      }
+    }
+
+    // The launch-speed threshold below subsumes the previous narrow-only gate:
+    // a wide steep jump's required speed is near its run-up speed, so braking
+    // only trims the excess instead of being skipped entirely.
     const isSteepJump = (e: Edge | undefined) =>
-      !!e && e.type === EdgeType.Jump && e.isSteep && e.isNarrow;
+      !!e && e.type === EdgeType.Jump && e.isSteep;
     const steepJump = isSteepJump(destination)
       ? destination
       : destination.type !== EdgeType.Jump && isSteepJump(nextDestination)
         ? nextDestination
         : null;
-    if (!brakeKey && steepJump) {
+    // Grounded only: this caps the LAUNCH speed. Once airborne the arc needs
+    // air-control held toward the target (the reach model assumes it); braking
+    // mid-flight starves the jump, and overshoot is already handled above.
+    if (!brakeKey && steepJump && this.character.body.grounded) {
       const jumpDir = steepJump.direction || 1;
       const speedAlong = this.character.body.xVelocity * jumpDir;
-      if (speedAlong > REVERSE_INPUT_SPEED) {
+      // A steep jump with real horizontal travel still needs launch speed —
+      // braking it to a near-standing jump undershoots the ledge corner.
+      const launchSpeed = Math.max(
+        REVERSE_INPUT_SPEED,
+        requiredLaunchSpeed(steepJump.dx, -steepJump.dy),
+      );
+      if (speedAlong > launchSpeed) {
         brakeKey = jumpDir > 0 ? Key.Left : Key.Right;
       }
     }
@@ -416,7 +450,20 @@ export class Path {
       const steep = destination.isSteep;
       const fastEnough = steep || speedAlong >= MIN_LAUNCH_SPEED;
       const overshot = pastEdge > 4 && speedAlong > 0;
-      if ((atLaunchPoint && fastEnough) || overshot) {
+      // Past the launch node but still building speed: if the floor ends
+      // within a few px ahead, jump now with the speed we have — running off
+      // the lip waiting for MIN_LAUNCH_SPEED falls into the gap instead.
+      let lipAhead = false;
+      if (atLaunchPoint && speedAlong > 0 && !fastEnough) {
+        const rX = Math.round(x);
+        const rY = Math.round(y);
+        lipAhead = !getLevel().collidesWith(
+          this.character.body.mask,
+          rX + md * 4,
+          rY + 1,
+        );
+      }
+      if ((atLaunchPoint && fastEnough) || overshot || lipAhead) {
         commands.push({ type: CommandType.KeyDown, key: Key.Up });
       }
     } else if (

--- a/src/data/bot/physics.ts
+++ b/src/data/bot/physics.ts
@@ -76,7 +76,7 @@ export const MAX_SAFE_FALL_HEIGHT: number = (() => {
   return Math.floor(safeHeight);
 })();
 
-const JUMP_HEIGHT_AT_DISTANCE: number[] = (() => {
+const { env: JUMP_HEIGHT_AT_DISTANCE, peakIdx: JUMP_APEX_DISTANCE } = (() => {
   const env: number[] = [0];
   const samples = 24;
   for (let i = 0; i <= samples; i++) {
@@ -102,7 +102,7 @@ const JUMP_HEIGHT_AT_DISTANCE: number[] = (() => {
     if (env[x] > env[peakIdx]) peakIdx = x;
   }
   for (let x = 0; x < peakIdx; x++) env[x] = env[peakIdx];
-  return env;
+  return { env, peakIdx };
 })();
 
 // Body's MAX_STEP (body.ts): feet clamber up this far onto a ledge corner, so a
@@ -114,7 +114,12 @@ export function jumpReaches(dx: number, dyUp: number): boolean {
   if (i >= JUMP_HEIGHT_AT_DISTANCE.length) {
     return false;
   }
-  return dyUp <= JUMP_HEIGHT_AT_DISTANCE[i] + LANDING_CLAMBER;
+  // The clamber only helps on the descending side of the arc, where leftover
+  // horizontal motion slides the feet onto the lip top. A near-vertical ascent
+  // (dx before the apex) meets the ledge face with no sideways motion left, so
+  // it must clear the full height.
+  const clamber = i >= JUMP_APEX_DISTANCE ? LANDING_CLAMBER : 0;
+  return dyUp <= JUMP_HEIGHT_AT_DISTANCE[i] + clamber;
 }
 
 // Height (px) the arc passes through at horizontal distance `dx`, launching at

--- a/src/data/bot/physics.ts
+++ b/src/data/bot/physics.ts
@@ -117,6 +117,92 @@ export function jumpReaches(dx: number, dyUp: number): boolean {
   return dyUp <= JUMP_HEIGHT_AT_DISTANCE[i] + LANDING_CLAMBER;
 }
 
+// Height (px) the arc passes through at horizontal distance `dx`, launching at
+// `launchX` while holding air-control toward the target. -Infinity if the arc
+// lands before reaching dx.
+function jumpHeightAtDistance(launchX: number, dx: number): number {
+  let s = { x: 0, y: 0, xv: launchX, yv: -JUMP_STRENGTH };
+  let prev = s;
+  for (let frame = 1; frame <= 200; frame++) {
+    s = airStep(s, 1);
+    if (prev.x <= dx && s.x >= dx) {
+      const t = (dx - prev.x) / (s.x - prev.x || 1);
+      return -(prev.y + t * (s.y - prev.y));
+    }
+    if (s.y > 0 && frame > 1) {
+      return -Infinity;
+    }
+    prev = s;
+  }
+  return -Infinity;
+}
+
+const requiredLaunchSpeedCache = new Map<string, number>();
+
+// Smallest launch speed whose arc passes the full `dyUp` at horizontal
+// distance `dx`. No clamber discount here: an arc that meets the ledge's wall
+// face even fractionally below the lip is stopped dead, not clambered (the
+// auto-step only applies to grounded movement). Falls back to the best-effort
+// speed when no sampled arc reaches the target.
+export function requiredLaunchSpeed(dx: number, dyUp: number): number {
+  const target = Math.ceil(Math.abs(dx));
+  if (target < 1 || dyUp <= 0) {
+    return 0;
+  }
+
+  const key = `${target},${Math.ceil(dyUp)}`;
+  const cached = requiredLaunchSpeedCache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const samples = 24;
+  let best = 0;
+  let bestHeight = -Infinity;
+  let result: number | undefined;
+  for (let i = 0; i <= samples; i++) {
+    const speed = (WALK_TERMINAL_VELOCITY * i) / samples;
+    const height = jumpHeightAtDistance(speed, target);
+    if (height >= dyUp) {
+      result = speed;
+      break;
+    }
+    if (height > bestHeight) {
+      bestHeight = height;
+      best = speed;
+    }
+  }
+  if (result === undefined) {
+    result = best;
+  }
+  requiredLaunchSpeedCache.set(key, result);
+  return result;
+}
+
+// Horizontal travel of the remaining arc when braking as hard as air-control
+// allows, from velocity (xv, yv), until the arc has descended `dyDown` px below
+// the current height. Lets the follower ask "if I brake right now, where do I
+// land?" — if even that overshoots the target, it must brake immediately.
+export function brakingLandingOffset(
+  xv: number,
+  yv: number,
+  dyDown: number,
+): number {
+  if (dyDown <= 0) {
+    return 0;
+  }
+  const direction = Math.sign(xv);
+  let s = { x: 0, y: 0, xv, yv };
+  for (let frame = 1; frame <= 240; frame++) {
+    const brake = Math.sign(s.xv) === direction ? -direction : 0;
+    s = airStep(s, brake as -1 | 0 | 1);
+    if (s.y >= dyDown) {
+      return s.x;
+    }
+  }
+  return s.x;
+}
+
 export const MIN_LAUNCH_SPEED = WALK_TERMINAL_VELOCITY * 0.75;
 
 export function runUpDistanceFromRest(): number {


### PR DESCRIPTION
### Description

Two fixes for the bot's path follower flying Jump edges differently than the planner's reach model assumes. Found by driving the pathfinding test harness (#37) over the Office map; this PR contains just the bot fixes so they can land independently of the harness.

**Follower** (`src/data/bot/path.ts`, `physics.ts`):
- Steep jumps were braked to half walk speed on approach *and mid-flight*, undershooting ledge corners the planner says are reachable. The launch-speed threshold is now derived from the same simulated arc physics (`requiredLaunchSpeed`) and only applies while grounded. This subsumes the narrow-only gate from #38: wide steep jumps now keep their run-up speed because their *required* speed is near it, rather than being exempted from braking entirely.
- Down-jumps held toward-target input all flight (air control has no terminal near walk speed), overflying the landing platform and dropping past its far edge. The follower now projects where full braking would land each airborne frame (`brakingLandingOffset`) and brakes as soon as even that overshoots the target.
- A jump whose launch node sits a few px from the lip was never taken — the bot ran off the edge while still accelerating toward `MIN_LAUNCH_SPEED`. It now jumps immediately when the floor ends within 4px ahead.

**Planner** (`jumpReaches`):
- The 3px landing-clamber bonus is now granted only to descending arcs. A near-vertical ascent meets the ledge face with no sideways motion left to clamber with, and tops out at the true apex (~22.8px) — edges like Δ5,-24 could never be flown and looped re-plans forever. Pruning them lets A* route around instead.

Verified on top of current main with the #37 harness (stacked locally, not included here): Office spawn-pair crossings that previously ended `stuck` after 3 re-plans now arrive with 0, the umbrella-canopy route lands grounded on the canopy, and the zigzag fixture still arrives 307/307 with 0 re-plans. 90 bot unit tests and `yarn check-types` pass.

> [!NOTE]
> `Edge.isNarrow` is now unused outside `edge.ts` — left in place in case other branches use it.

### Manual check

- Check out #37's harness on top of this branch (or merge this first and re-run #37's manual check)
- `yarn dev`, open `http://localhost:3000/#/test/pathfinding?map=Office&pair=1` and `?map=Office&pair=4` (full reload between runs)
- [ ] Both end `arrived … 0 re-plans` (previously `stuck` after 3 re-plans)
- Open `/#/test/pathfinding` (zigzag regression)
- [ ] Ends `arrived … 307/307 edges 0 re-plans`