### PR TITLE
Procedural terrain painting for WFC-generated maps

### DIFF
--- a/src/components/organisms/TerrainPaintDialog.vue
+++ b/src/components/organisms/TerrainPaintDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, shallowRef, watch } from "vue";
+import { computed, ref, shallowRef, watch } from "vue";
 import Dialog from "../molecules/Dialog.vue";
 import {
   paintTerrain,
@@ -23,7 +23,9 @@ const props = defineProps<{
   onClose: () => void;
 }>();
 
-const seed = ref(1);
+const SEED = 1;
+const MIXED = "mixed";
+
 const overrides = ref<Record<number, string>>({});
 const zones = ref<ZoneInfo[]>([]);
 const selectedZone = ref<number | null>(null);
@@ -55,7 +57,7 @@ watch(
 const previewCanvas = ref<HTMLCanvasElement>();
 
 watch(
-  [alphaData, seed, overrides, () => props.ladders],
+  [alphaData, overrides, () => props.ladders],
   () => {
     const ad = alphaData.value;
     if (!ad) return;
@@ -65,7 +67,7 @@ watch(
       width: ad.width,
       height: ad.height,
       ladders: props.ladders,
-      seed: seed.value,
+      seed: SEED,
       themeOverrides: overrides.value,
     });
     result.value = res;
@@ -138,18 +140,29 @@ const handlePreviewClick = (event: MouseEvent) => {
 };
 
 const handleThemeChange = (event: Event) => {
-  if (selectedZone.value === null) return;
-  setOverride(selectedZone.value, (event.target as HTMLSelectElement).value);
-};
-
-const handleReroll = () => {
-  seed.value++;
-  overrides.value = {};
+  const themeId = (event.target as HTMLSelectElement).value;
+  if (selectedZone.value !== null) {
+    setOverride(selectedZone.value, themeId);
+  } else {
+    const all: Record<number, string> = {};
+    for (const zone of zones.value) {
+      all[zone.id] = themeId;
+    }
+    overrides.value = all;
+  }
 };
 
 const setOverride = (zoneId: number, themeId: string) => {
   overrides.value = { ...overrides.value, [zoneId]: themeId };
 };
+
+const selectValue = computed(() => {
+  if (selectedZone.value !== null) {
+    return zones.value[selectedZone.value]?.themeId ?? MIXED;
+  }
+  const ids = new Set(zones.value.map((zone) => zone.themeId));
+  return ids.size === 1 ? zones.value[0].themeId : MIXED;
+});
 
 const blobToDataUrl = (blob: Blob): Promise<string> =>
   new Promise((resolve) => {
@@ -194,23 +207,28 @@ function handleConfirm() {
         <span>Show background only</span>
       </label>
 
-      <p class="hint" v-if="selectedZone === null">
-        Click a zone in the preview to change its theme.
-      </p>
-      <div class="zone-row" v-else>
-        <span class="label">Zone {{ selectedZone + 1 }}</span>
-        <select :value="zones[selectedZone]?.themeId" @change="handleThemeChange">
+      <div class="zone-row" v-if="zones.length">
+        <span class="label">
+          {{ selectedZone === null ? "All zones" : "Selected zone" }}
+        </span>
+        <select :value="selectValue" @change="handleThemeChange">
+          <option v-if="selectValue === MIXED" disabled :value="MIXED">
+            Mixed
+          </option>
           <option v-for="id in THEME_IDS" :key="id" :value="id">
             {{ THEMES[id].name }}
           </option>
         </select>
       </div>
+      <p class="hint">
+        Click a zone in the preview to change it individually, click empty
+        space to change all zones at once.
+      </p>
 
       <div class="actions">
         <button class="primary" :disabled="zones.length === 0" @click="handleConfirm">
           Confirm
         </button>
-        <button class="secondary" @click="handleReroll">Re-roll</button>
         <button class="secondary" @click="onClose">Cancel</button>
       </div>
     </div>
@@ -244,8 +262,9 @@ function handleConfirm() {
 
 .hint {
   font-family: Eternal;
-  font-size: 24px;
+  font-size: 20px;
   color: var(--primary);
+  opacity: 0.8;
 }
 
 .zone-row {
@@ -257,7 +276,7 @@ function handleConfirm() {
     font-family: Eternal;
     font-size: 24px;
     color: var(--primary);
-    min-width: 80px;
+    min-width: 130px;
   }
 
   select {

--- a/src/components/organisms/TerrainPaintDialog.vue
+++ b/src/components/organisms/TerrainPaintDialog.vue
@@ -54,11 +54,10 @@ watch(
 const previewCanvas = ref<HTMLCanvasElement>();
 
 watch(
-  [alphaData, seed, overrides, previewCanvas, showBackgroundOnly, () => props.ladders],
+  [alphaData, seed, overrides, () => props.ladders],
   () => {
     const ad = alphaData.value;
-    const canvas = previewCanvas.value;
-    if (!ad || !canvas) return;
+    if (!ad) return;
 
     const res = paintTerrain({
       alpha: ad.alpha,
@@ -70,6 +69,19 @@ watch(
     });
     result.value = res;
     zones.value = res.zones;
+  },
+  { immediate: true }
+);
+
+// composing the preview is cheap; repainting is not — keep them separate so
+// toggling the background view doesn't re-run the whole paint pipeline
+watch(
+  [result, previewCanvas, showBackgroundOnly],
+  () => {
+    const ad = alphaData.value;
+    const res = result.value;
+    const canvas = previewCanvas.value;
+    if (!ad || !res || !canvas) return;
 
     const compose = new OffscreenCanvas(ad.width, ad.height);
     const cctx = compose.getContext("2d")!;

--- a/src/components/organisms/TerrainPaintDialog.vue
+++ b/src/components/organisms/TerrainPaintDialog.vue
@@ -26,6 +26,7 @@ const props = defineProps<{
 const seed = ref(1);
 const overrides = ref<Record<number, string>>({});
 const zones = ref<ZoneInfo[]>([]);
+const selectedZone = ref<number | null>(null);
 const showBackgroundOnly = ref(false);
 
 const alphaData = ref<{ alpha: Uint8Array; width: number; height: number }>();
@@ -69,6 +70,9 @@ watch(
     });
     result.value = res;
     zones.value = res.zones;
+    if (selectedZone.value !== null && selectedZone.value >= res.zones.length) {
+      selectedZone.value = null;
+    }
   },
   { immediate: true }
 );
@@ -76,7 +80,7 @@ watch(
 // composing the preview is cheap; repainting is not — keep them separate so
 // toggling the background view doesn't re-run the whole paint pipeline
 watch(
-  [result, previewCanvas, showBackgroundOnly],
+  [result, previewCanvas, showBackgroundOnly, selectedZone],
   () => {
     const ad = alphaData.value;
     const res = result.value;
@@ -98,9 +102,45 @@ watch(
     ctx.imageSmoothingEnabled = false;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.drawImage(compose, 0, 0, canvas.width, canvas.height);
+
+    const zone =
+      selectedZone.value !== null ? res.zones[selectedZone.value] : undefined;
+    if (zone) {
+      const { left, top, right, bottom } = zone.bbox;
+      const rect = [
+        left * PREVIEW_SCALE - 1,
+        top * PREVIEW_SCALE - 1,
+        (right - left) * PREVIEW_SCALE + 2,
+        (bottom - top) * PREVIEW_SCALE + 2,
+      ] as const;
+      ctx.setLineDash([6, 4]);
+      ctx.strokeStyle = "#000000";
+      ctx.lineWidth = 3;
+      ctx.strokeRect(...rect);
+      ctx.strokeStyle = "#ffffff";
+      ctx.lineWidth = 1.5;
+      ctx.strokeRect(...rect);
+      ctx.setLineDash([]);
+    }
   },
   { immediate: true }
 );
+
+const handlePreviewClick = (event: MouseEvent) => {
+  const res = result.value;
+  const ad = alphaData.value;
+  if (!res || !ad) return;
+  const x = Math.floor(event.offsetX / PREVIEW_SCALE);
+  const y = Math.floor(event.offsetY / PREVIEW_SCALE);
+  if (x < 0 || y < 0 || x >= ad.width || y >= ad.height) return;
+  const zone = res.zoneMap[y * ad.width + x];
+  selectedZone.value = zone >= 0 ? zone : null;
+};
+
+const handleThemeChange = (event: Event) => {
+  if (selectedZone.value === null) return;
+  setOverride(selectedZone.value, (event.target as HTMLSelectElement).value);
+};
 
 const handleReroll = () => {
   seed.value++;
@@ -146,7 +186,7 @@ function handleConfirm() {
   <Dialog open :onClose="onClose" title="Paint terrain">
     <div class="paint-dialog">
       <div class="preview-scroll">
-        <canvas ref="previewCanvas" class="preview" />
+        <canvas ref="previewCanvas" class="preview" @click="handlePreviewClick" />
       </div>
 
       <label class="checkbox-control">
@@ -154,18 +194,16 @@ function handleConfirm() {
         <span>Show background only</span>
       </label>
 
-      <div class="zones" v-if="zones.length">
-        <div class="zone-row" v-for="zone in zones" :key="zone.id">
-          <span class="label">Zone {{ zone.id + 1 }}</span>
-          <select
-            :value="zone.themeId"
-            @change="(e) => setOverride(zone.id, (e.target as HTMLSelectElement).value)"
-          >
-            <option v-for="id in THEME_IDS" :key="id" :value="id">
-              {{ THEMES[id].name }}
-            </option>
-          </select>
-        </div>
+      <p class="hint" v-if="selectedZone === null">
+        Click a zone in the preview to change its theme.
+      </p>
+      <div class="zone-row" v-else>
+        <span class="label">Zone {{ selectedZone + 1 }}</span>
+        <select :value="zones[selectedZone]?.themeId" @change="handleThemeChange">
+          <option v-for="id in THEME_IDS" :key="id" :value="id">
+            {{ THEMES[id].name }}
+          </option>
+        </select>
       </div>
 
       <div class="actions">
@@ -198,16 +236,16 @@ function handleConfirm() {
 }
 
 .preview {
+  display: block;
+  cursor: pointer;
   image-rendering: pixelated;
   background: repeating-conic-gradient(#ccc 0% 25%, #eee 0% 50%) 0 0 / 16px 16px;
 }
 
-.zones {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  max-height: 160px;
-  overflow-y: auto;
+.hint {
+  font-family: Eternal;
+  font-size: 24px;
+  color: var(--primary);
 }
 
 .zone-row {
@@ -224,6 +262,21 @@ function handleConfirm() {
 
   select {
     flex: 1;
+    background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
+    border: 1px solid var(--border-accent-faint);
+    border-radius: var(--small-radius);
+    padding: 10px;
+    box-shadow: inset 0 1px 3px rgba(30, 15, 5, 0.1);
+    outline: none;
+    font-size: inherit;
+    font-family: inherit;
+    color: var(--primary);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+
+    &:focus {
+      border-color: var(--border-accent);
+      box-shadow: inset 0 1px 3px rgba(30, 15, 5, 0.1), 0 0 8px var(--glow-warm-soft);
+    }
   }
 }
 

--- a/src/components/organisms/TerrainPaintDialog.vue
+++ b/src/components/organisms/TerrainPaintDialog.vue
@@ -30,6 +30,7 @@ const overrides = ref<Record<number, string>>({});
 const zones = ref<ZoneInfo[]>([]);
 const selectedZone = ref<number | null>(null);
 const showBackgroundOnly = ref(false);
+const error = ref("");
 
 const alphaData = ref<{ alpha: Uint8Array; width: number; height: number }>();
 const result = shallowRef<PaintResult>();
@@ -37,7 +38,11 @@ const result = shallowRef<PaintResult>();
 watch(
   () => props.alphaSrc,
   (src) => {
+    error.value = "";
     const img = new Image();
+    img.onerror = () => {
+      error.value = "Failed to load the terrain image.";
+    };
     img.onload = () => {
       const canvas = new OffscreenCanvas(img.width, img.height);
       const ctx = canvas.getContext("2d")!;
@@ -225,6 +230,8 @@ function handleConfirm() {
         space to change all zones at once.
       </p>
 
+      <p v-if="error" class="error">{{ error }}</p>
+
       <div class="actions">
         <button class="primary" :disabled="zones.length === 0" @click="handleConfirm">
           Confirm
@@ -265,6 +272,11 @@ function handleConfirm() {
   font-size: 20px;
   color: var(--primary);
   opacity: 0.8;
+}
+
+.error {
+  color: var(--highlight);
+  font-size: 13px;
 }
 
 .zone-row {

--- a/src/components/organisms/TerrainPaintDialog.vue
+++ b/src/components/organisms/TerrainPaintDialog.vue
@@ -1,0 +1,240 @@
+<script setup lang="ts">
+import { ref, shallowRef, watch } from "vue";
+import Dialog from "../molecules/Dialog.vue";
+import {
+  paintTerrain,
+  type PaintResult,
+} from "../../data/terrainPaint";
+import { THEMES, THEME_IDS } from "../../data/terrainPaint/palettes";
+import type { ZoneInfo } from "../../data/terrainPaint/zones";
+import type { PlainBBox } from "../../data/map/bbox";
+
+const PREVIEW_SCALE = 2;
+
+const props = defineProps<{
+  alphaSrc: string;
+  ladders: PlainBBox[];
+  onConfirm: (result: {
+    terrain: string;
+    background: string;
+    width: number;
+    height: number;
+  }) => void;
+  onClose: () => void;
+}>();
+
+const seed = ref(1);
+const overrides = ref<Record<number, string>>({});
+const zones = ref<ZoneInfo[]>([]);
+const showBackgroundOnly = ref(false);
+
+const alphaData = ref<{ alpha: Uint8Array; width: number; height: number }>();
+const result = shallowRef<PaintResult>();
+
+watch(
+  () => props.alphaSrc,
+  (src) => {
+    const img = new Image();
+    img.onload = () => {
+      const canvas = new OffscreenCanvas(img.width, img.height);
+      const ctx = canvas.getContext("2d")!;
+      ctx.drawImage(img, 0, 0);
+      const pixels = ctx.getImageData(0, 0, img.width, img.height).data;
+      const alpha = new Uint8Array(img.width * img.height);
+      for (let i = 0; i < alpha.length; i++) {
+        alpha[i] = pixels[i * 4 + 3] > 128 ? 1 : 0;
+      }
+      alphaData.value = { alpha, width: img.width, height: img.height };
+    };
+    img.src = src;
+  },
+  { immediate: true }
+);
+
+const previewCanvas = ref<HTMLCanvasElement>();
+
+watch(
+  [alphaData, seed, overrides, previewCanvas, showBackgroundOnly, () => props.ladders],
+  () => {
+    const ad = alphaData.value;
+    const canvas = previewCanvas.value;
+    if (!ad || !canvas) return;
+
+    const res = paintTerrain({
+      alpha: ad.alpha,
+      width: ad.width,
+      height: ad.height,
+      ladders: props.ladders,
+      seed: seed.value,
+      themeOverrides: overrides.value,
+    });
+    result.value = res;
+    zones.value = res.zones;
+
+    const compose = new OffscreenCanvas(ad.width, ad.height);
+    const cctx = compose.getContext("2d")!;
+    cctx.putImageData(res.background, 0, 0);
+    if (!showBackgroundOnly.value) {
+      const terrainCanvas = new OffscreenCanvas(ad.width, ad.height);
+      terrainCanvas.getContext("2d")!.putImageData(res.terrain, 0, 0);
+      cctx.drawImage(terrainCanvas, 0, 0);
+    }
+
+    canvas.width = ad.width * PREVIEW_SCALE;
+    canvas.height = ad.height * PREVIEW_SCALE;
+    const ctx = canvas.getContext("2d")!;
+    ctx.imageSmoothingEnabled = false;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(compose, 0, 0, canvas.width, canvas.height);
+  },
+  { immediate: true }
+);
+
+const handleReroll = () => {
+  seed.value++;
+  overrides.value = {};
+};
+
+const setOverride = (zoneId: number, themeId: string) => {
+  overrides.value = { ...overrides.value, [zoneId]: themeId };
+};
+
+const blobToDataUrl = (blob: Blob): Promise<string> =>
+  new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.readAsDataURL(blob);
+  });
+
+function handleConfirm() {
+  const ad = alphaData.value;
+  const res = result.value;
+  if (!ad || !res || res.zones.length === 0) return;
+
+  const toDataUrl = (img: ImageData) => {
+    const canvas = new OffscreenCanvas(ad.width, ad.height);
+    canvas.getContext("2d")!.putImageData(img, 0, 0);
+    return canvas.convertToBlob({ type: "image/png" }).then(blobToDataUrl);
+  };
+
+  Promise.all([toDataUrl(res.terrain), toDataUrl(res.background)]).then(
+    ([terrain, background]) => {
+      props.onConfirm({
+        terrain,
+        background,
+        width: ad.width,
+        height: ad.height,
+      });
+    }
+  );
+}
+</script>
+
+<template>
+  <Dialog open :onClose="onClose" title="Paint terrain">
+    <div class="paint-dialog">
+      <div class="preview-scroll">
+        <canvas ref="previewCanvas" class="preview" />
+      </div>
+
+      <label class="checkbox-control">
+        <input type="checkbox" v-model="showBackgroundOnly" />
+        <span>Show background only</span>
+      </label>
+
+      <div class="zones" v-if="zones.length">
+        <div class="zone-row" v-for="zone in zones" :key="zone.id">
+          <span class="label">Zone {{ zone.id + 1 }}</span>
+          <select
+            :value="zone.themeId"
+            @change="(e) => setOverride(zone.id, (e.target as HTMLSelectElement).value)"
+          >
+            <option v-for="id in THEME_IDS" :key="id" :value="id">
+              {{ THEMES[id].name }}
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <div class="actions">
+        <button class="primary" :disabled="zones.length === 0" @click="handleConfirm">
+          Confirm
+        </button>
+        <button class="secondary" @click="handleReroll">Re-roll</button>
+        <button class="secondary" @click="onClose">Cancel</button>
+      </div>
+    </div>
+  </Dialog>
+</template>
+
+<style lang="scss" scoped>
+.paint-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 400px;
+}
+
+.preview-scroll {
+  overflow: auto;
+  max-width: 600px;
+  max-height: 300px;
+  border: 1px solid var(--border-accent-faint);
+  border-radius: 4px;
+  scrollbar-color: var(--background-dark) transparent;
+  scrollbar-width: thin;
+}
+
+.preview {
+  image-rendering: pixelated;
+  background: repeating-conic-gradient(#ccc 0% 25%, #eee 0% 50%) 0 0 / 16px 16px;
+}
+
+.zones {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.zone-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  .label {
+    font-family: Eternal;
+    font-size: 24px;
+    color: var(--primary);
+    min-width: 80px;
+  }
+
+  select {
+    flex: 1;
+  }
+}
+
+.checkbox-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-family: Eternal;
+  font-size: 24px;
+  color: var(--primary);
+
+  input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--primary);
+    cursor: pointer;
+  }
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+</style>

--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -320,6 +320,11 @@ const handleTerrainPaintConfirm = (result: {
   // stored mask so the built map derives collision from terrain alpha
   advancedSettings.value.customMask = false;
   advancedSettings.value.bbox = BBox.create(result.width, result.height);
+  // painted backgrounds are transparent outside the debris, so a parallax
+  // is expected to fill the sky
+  if (!advancedSettings.value.parallaxName) {
+    advancedSettings.value.parallaxName = "Ocean";
+  }
   showTerrainPaint.value = false;
 };
 

--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -19,6 +19,8 @@ import upload from "pixelarticons/svg/upload.svg";
 import Collapsible from "../atoms/Collapsible.vue";
 import WfcDialog, { type WfcSettings } from "../organisms/WfcDialog.vue";
 import AiAlignDialog from "../organisms/AiAlignDialog.vue";
+import TerrainPaintDialog from "../organisms/TerrainPaintDialog.vue";
+import paintBucket from "pixelarticons/svg/paint-bucket.svg";
 import type { LadderInfo } from "../../data/wfc/postProcess";
 import WfcWorker from "../../data/wfc/wfc.worker?worker";
 import { useBuilderLayers } from "./composables/useBuilderLayers";
@@ -144,7 +146,7 @@ const generateWfc = () => {
 
 const handleKeydown = (e: KeyboardEvent) => {
   if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-  if (showWfcDialog.value || showAiAlign.value) return;
+  if (showWfcDialog.value || showAiAlign.value || showTerrainPaint.value) return;
   if (e.key === "g" || e.key === "G") {
     generateWfc();
   }
@@ -304,6 +306,23 @@ const handleAiAlignConfirm = (result: {
   showAiAlign.value = false;
 };
 
+const showTerrainPaint = ref(false);
+
+const handleTerrainPaintConfirm = (result: {
+  terrain: string;
+  background: string;
+  width: number;
+  height: number;
+}) => {
+  terrain.value = { data: result.terrain, visible: true };
+  background.value = { data: result.background, visible: true };
+  // terrain alpha now IS the wallmask; the customMask watcher clears the
+  // stored mask so the built map derives collision from terrain alpha
+  advancedSettings.value.customMask = false;
+  advancedSettings.value.bbox = BBox.create(result.width, result.height);
+  showTerrainPaint.value = false;
+};
+
 watch(
   () => advancedSettings.value.scale,
   (scale) => {
@@ -369,6 +388,12 @@ const handleBBoxChange = (newBBox: BBox) => {
             title="Import AI-generated terrain"
             :onClick="handleImportAITerrain"
             :icon="upload"
+          />
+          <IconButton
+            v-if="mask.data || terrain.data"
+            title="Paint terrain procedurally"
+            :onClick="() => (showTerrainPaint = true)"
+            :icon="paintBucket"
           />
           <input
             ref="aiTerrainInput"
@@ -649,6 +674,13 @@ const handleBBoxChange = (newBBox: BBox) => {
       :aiSrc="aiAlignSrc"
       :onConfirm="handleAiAlignConfirm"
       :onClose="() => (showAiAlign = false)"
+    />
+    <TerrainPaintDialog
+      v-if="showTerrainPaint"
+      :alphaSrc="mask.data || terrain.data"
+      :ladders="ladders.map((l) => l.toJS())"
+      :onConfirm="handleTerrainPaintConfirm"
+      :onClose="() => (showTerrainPaint = false)"
     />
   </div>
 </template>

--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -681,7 +681,7 @@ const handleBBoxChange = (newBBox: BBox) => {
       :onClose="() => (showAiAlign = false)"
     />
     <TerrainPaintDialog
-      v-if="showTerrainPaint"
+      v-if="showTerrainPaint && (mask.data || terrain.data)"
       :alphaSrc="mask.data || terrain.data"
       :ladders="ladders.map((l) => l.toJS())"
       :onConfirm="handleTerrainPaintConfirm"

--- a/src/data/terrainPaint/__spec__/backwall.spec.ts
+++ b/src/data/terrainPaint/__spec__/backwall.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "vitest";
+import { buildBackwall } from "../backwall";
+import { computeZones } from "../zones";
+import { THEMES } from "../palettes";
+import { createImageData, hexToRgb } from "../pixel";
+import { bitmap } from "./helpers";
+
+// Blocks are wide (>= 2*EDGE_WOBBLE+1) so the ragged-edge wobble never reaches
+// the interior columns the tests assert on.
+// left block cols0-9 (ceiling row1, floor row4). col10: open sky.
+// right block cols11-19 (ceiling row1, no floor -> floorless to the bottom).
+const W = 20;
+const ROOF = [
+  "....................",
+  "##########.#########",
+  "....................",
+  "....................",
+  "##########..........",
+  "....................",
+];
+
+function backwallFor(
+  rows: string[],
+  themeByCeil: Record<number, string> = {},
+  seed = 1
+) {
+  const { alpha, width, height } = bitmap(rows);
+  const { zoneMap, zones } = computeZones(alpha, width, height, seed);
+  // themeByCeil maps a "solid pixel index" to a themeId for that pixel's zone
+  for (const key of Object.keys(themeByCeil)) {
+    const zi = zoneMap[Number(key)];
+    if (zi >= 0) zones[zi].themeId = themeByCeil[Number(key)];
+  }
+  const background = createImageData(width, height);
+  buildBackwall({ background, width, height, zoneMap, zones, seed });
+  return { background, alpha, zoneMap, zones, width, height };
+}
+
+const alphaAt = (data: Uint8ClampedArray, i: number) => data[i * 4 + 3];
+
+// Shading multiplies every channel of a ramp color by one factor f in (0, 1].
+// A painted pixel belongs to a theme if it is such a uniform scaling of any of
+// that theme's ramp colors.
+const isScaledRampColor = (
+  data: Uint8ClampedArray,
+  i: number,
+  themeId: string
+): boolean => {
+  const px = [data[i * 4], data[i * 4 + 1], data[i * 4 + 2]];
+  return THEMES[themeId].backwall!.ramp.some((hex) => {
+    const c = hexToRgb(hex);
+    const factors: number[] = [];
+    for (let k = 0; k < 3; k++) {
+      if (c[k] === 0) {
+        if (px[k] > 2) return false;
+        continue;
+      }
+      const f = px[k] / c[k];
+      if (f < 0.3 || f > 1.05) return false;
+      factors.push(f);
+    }
+    return Math.max(...factors) - Math.min(...factors) < 0.06;
+  });
+};
+
+describe("buildBackwall", () => {
+  test("open-sky pixels (no solid above) stay transparent", () => {
+    const { background, width } = backwallFor(ROOF);
+    // col 10, row 2: the gap column has nothing solid above it
+    expect(alphaAt(background.data, 2 * width + 10)).toBe(0);
+  });
+
+  test("a roofed empty pixel is filled opaque", () => {
+    const { background, width } = backwallFor(ROOF);
+    // col 4, row 2: solid ceiling at row 1 above it
+    expect(alphaAt(background.data, 2 * width + 4)).toBe(255);
+  });
+
+  test("a roofed pixel takes the ceiling theme, not the floor's", () => {
+    const { background, width } = backwallFor(ROOF, {
+      [1 * W + 4]: "cave", // left ceiling (row1 col4)
+      [4 * W + 4]: "grassland", // left floor (row4 col4)
+    });
+    // row2 col4: under the cave ceiling
+    expect(isScaledRampColor(background.data, 2 * width + 4, "cave")).toBe(true);
+    // row5 col4: under the grassland floor acting as the nearest ceiling
+    expect(
+      isScaledRampColor(background.data, 5 * width + 4, "grassland")
+    ).toBe(true);
+  });
+
+  test("a floorless roofed column fills down to the bottom row", () => {
+    const { background, width, height } = backwallFor(ROOF);
+    // col 15: ceiling at row1, no floor below -> bottom row filled
+    expect(alphaAt(background.data, (height - 1) * width + 15)).toBe(255);
+  });
+
+  test("a theme without a back-wall (toon) leaves its pockets transparent", () => {
+    const { background, width } = backwallFor(ROOF, {
+      [1 * W + 15]: "toon", // right ceiling (row1 col15)
+    });
+    expect(alphaAt(background.data, 2 * width + 15)).toBe(0);
+  });
+
+  test("fills behind solid terrain so erosion reveals the wall", () => {
+    const { background, width } = backwallFor(ROOF);
+    // row1 col4 is solid ceiling: its backing must be painted, not transparent
+    expect(alphaAt(background.data, 1 * width + 4)).toBe(255);
+  });
+
+  test("never paints open sky above the first solid pixel", () => {
+    const { background, alpha, width, height } = backwallFor(ROOF);
+    const data = background.data;
+    for (let x = 0; x < width; x++) {
+      let seenSolid = false;
+      for (let y = 0; y < height; y++) {
+        const i = y * width + x;
+        if (alpha[i]) seenSolid = true;
+        // a painted pixel must have solid terrain at or above it in its column
+        if (alphaAt(data, i) !== 0) expect(seenSolid).toBe(true);
+      }
+    }
+  });
+
+  test("is deterministic for the same seed", () => {
+    const a = backwallFor(ROOF, {}, 5);
+    const b = backwallFor(ROOF, {}, 5);
+    expect(Array.from(a.background.data)).toEqual(
+      Array.from(b.background.data)
+    );
+  });
+});

--- a/src/data/terrainPaint/__spec__/debris.spec.ts
+++ b/src/data/terrainPaint/__spec__/debris.spec.ts
@@ -60,6 +60,22 @@ describe("buildDebris", () => {
     expect(debrisCount).toBeLessThan(solidCount);
   });
 
+  test("erosion from the top of a span is capped for deep terrain", () => {
+    const width = 6;
+    const height = 200;
+    const rows = Array.from({ length: height }, () => "#".repeat(width));
+    const { background } = debrisFor(rows);
+    const data = background.data;
+    for (let x = 0; x < width; x++) {
+      let opaque = 0;
+      for (let y = 0; y < height; y++) {
+        if (data[(y * width + x) * 4 + 3] !== 0) opaque++;
+      }
+      // MAX_EROSION_PX = 48: at most 48px may be removed from the top
+      expect(opaque).toBeGreaterThanOrEqual(height - 48);
+    }
+  });
+
   test("all pixels are fully opaque or fully transparent", () => {
     const { background } = debrisFor(HILL);
     const data = background.data;

--- a/src/data/terrainPaint/__spec__/debris.spec.ts
+++ b/src/data/terrainPaint/__spec__/debris.spec.ts
@@ -71,8 +71,8 @@ describe("buildDebris", () => {
       for (let y = 0; y < height; y++) {
         if (data[(y * width + x) * 4 + 3] !== 0) opaque++;
       }
-      // MAX_EROSION_PX = 48: at most 48px may be removed from the top
-      expect(opaque).toBeGreaterThanOrEqual(height - 48);
+      // MAX_EROSION_PX = 10: at most 10px may be removed from the top
+      expect(opaque).toBeGreaterThanOrEqual(height - 10);
     }
   });
 

--- a/src/data/terrainPaint/__spec__/debris.spec.ts
+++ b/src/data/terrainPaint/__spec__/debris.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { buildDebris } from "../debris";
+import { createImageData } from "../pixel";
 import { computeZones } from "../zones";
 import { bitmap } from "./helpers";
 
@@ -15,7 +16,9 @@ function debrisFor(
     height,
     seed
   );
-  const background = buildDebris({
+  const background = createImageData(width, height);
+  buildDebris({
+    background,
     width,
     height,
     zoneMap,
@@ -144,5 +147,21 @@ describe("buildDebris", () => {
     const data = background.data;
     // top-left corner: empty in the input, far from any ladder
     expect(data[(0 * width + 0) * 4 + 3]).toBe(0);
+  });
+
+  test("a ladder shadows the wall behind it along its full length", () => {
+    const width = 40;
+    const height = 40;
+    const rows = Array.from({ length: height }, () => "#".repeat(width));
+    const ladder = { left: 16, top: 4, right: 28, bottom: 30 };
+    const withLadder = debrisFor(rows, [ladder]);
+    const without = debrisFor(rows, []);
+    // a debris pixel beside the ladder, mid-length (not on a rail or rung)
+    const i = 20 * width + 30;
+    const sum = (d: Uint8ClampedArray) => d[i * 4] + d[i * 4 + 1] + d[i * 4 + 2];
+    expect(withLadder.background.data[i * 4 + 3]).toBe(255);
+    expect(sum(withLadder.background.data)).toBeLessThan(
+      sum(without.background.data)
+    );
   });
 });

--- a/src/data/terrainPaint/__spec__/debris.spec.ts
+++ b/src/data/terrainPaint/__spec__/debris.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "vitest";
+import { buildDebris } from "../debris";
+import { computeZones } from "../zones";
+import { bitmap } from "./helpers";
+
+function debrisFor(
+  rows: string[],
+  ladders: { left: number; top: number; right: number; bottom: number }[] = [],
+  seed = 1
+) {
+  const { alpha, width, height } = bitmap(rows);
+  const { zoneMap, landmassMap, zones } = computeZones(
+    alpha,
+    width,
+    height,
+    seed
+  );
+  const background = buildDebris({
+    width,
+    height,
+    zoneMap,
+    landmassMap,
+    zones,
+    ladders,
+    seed,
+  });
+  return { background, alpha, width, height };
+}
+
+const HILL = [
+  "..........",
+  "....##....",
+  "...####...",
+  "..######..",
+  ".########.",
+  "##########",
+];
+
+describe("buildDebris", () => {
+  test("debris pixels are a strict subset of the original solid pixels", () => {
+    const { background, alpha } = debrisFor(HILL);
+    const data = background.data;
+    for (let i = 0; i < alpha.length; i++) {
+      if (data[i * 4 + 3] !== 0) {
+        expect(alpha[i]).toBe(1);
+      }
+    }
+  });
+
+  test("debris exists but is smaller than the original terrain", () => {
+    const { background, alpha } = debrisFor(HILL);
+    const data = background.data;
+    let solidCount = 0;
+    let debrisCount = 0;
+    for (let i = 0; i < alpha.length; i++) {
+      if (alpha[i]) solidCount++;
+      if (data[i * 4 + 3] !== 0) debrisCount++;
+    }
+    expect(debrisCount).toBeGreaterThan(0);
+    expect(debrisCount).toBeLessThan(solidCount);
+  });
+
+  test("all pixels are fully opaque or fully transparent", () => {
+    const { background } = debrisFor(HILL);
+    const data = background.data;
+    for (let i = 3; i < data.length; i += 4) {
+      expect(data[i] === 0 || data[i] === 255).toBe(true);
+    }
+  });
+
+  test("is deterministic for the same seed", () => {
+    const a = debrisFor(HILL, [], 9);
+    const b = debrisFor(HILL, [], 9);
+    expect(Array.from(a.background.data)).toEqual(
+      Array.from(b.background.data)
+    );
+  });
+
+  test("ladders are drawn in empty space with rails and rungs", () => {
+    const ladder = { left: 2, top: 0, right: 16, bottom: 24 };
+    const rows = [
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+      "####################",
+    ];
+    const { background, width } = debrisFor(rows, [ladder]);
+    const data = background.data;
+    // rail pixel (left edge of the bbox, above the terrain)
+    expect(data[(5 * width + 2) * 4 + 3]).toBe(255);
+    // rail pixel on the right edge
+    expect(data[(5 * width + 15) * 4 + 3]).toBe(255);
+    // rung row: top of the bbox is a rung, spanning the middle
+    expect(data[(0 * width + 8) * 4 + 3]).toBe(255);
+    // between rungs and rails: transparent (y=5 is no rung row, x=8 is no rail)
+    expect(data[(5 * width + 8) * 4 + 3]).toBe(0);
+  });
+
+  test("pixels outside debris and ladders stay transparent", () => {
+    const { background, width } = debrisFor(HILL);
+    const data = background.data;
+    // top-left corner: empty in the input, far from any ladder
+    expect(data[(0 * width + 0) * 4 + 3]).toBe(0);
+  });
+});

--- a/src/data/terrainPaint/__spec__/debris.spec.ts
+++ b/src/data/terrainPaint/__spec__/debris.spec.ts
@@ -60,20 +60,27 @@ describe("buildDebris", () => {
     expect(debrisCount).toBeLessThan(solidCount);
   });
 
-  test("erosion from the top of a span is capped for deep terrain", () => {
-    const width = 6;
+  test("erosion is capped for deep terrain but the edge stays rough", () => {
+    const width = 64;
     const height = 200;
     const rows = Array.from({ length: height }, () => "#".repeat(width));
     const { background } = debrisFor(rows);
     const data = background.data;
+    const tops: number[] = [];
     for (let x = 0; x < width; x++) {
-      let opaque = 0;
+      let top = height;
       for (let y = 0; y < height; y++) {
-        if (data[(y * width + x) * 4 + 3] !== 0) opaque++;
+        if (data[(y * width + x) * 4 + 3] !== 0) {
+          top = y;
+          break;
+        }
       }
       // MAX_EROSION_PX = 10: at most 10px may be removed from the top
-      expect(opaque).toBeGreaterThanOrEqual(height - 10);
+      expect(top).toBeLessThanOrEqual(10);
+      tops.push(top);
     }
+    // the capped edge must still vary, not track the silhouette flatly
+    expect(new Set(tops).size).toBeGreaterThanOrEqual(3);
   });
 
   test("all pixels are fully opaque or fully transparent", () => {

--- a/src/data/terrainPaint/__spec__/field.spec.ts
+++ b/src/data/terrainPaint/__spec__/field.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+import { computeField } from "../field";
+import { bitmap } from "./helpers";
+
+describe("computeField depth", () => {
+  test("empty pixels have depth 0", () => {
+    const { alpha, width, height } = bitmap([".....", ".....", "....."]);
+    const { depth } = computeField(alpha, width, height);
+    for (let i = 0; i < depth.length; i++) {
+      expect(depth[i]).toBe(0);
+    }
+  });
+
+  test("depth grows toward the center of a blob", () => {
+    const { alpha, width, height } = bitmap([
+      ".....",
+      ".###.",
+      ".###.",
+      ".###.",
+      ".....",
+    ]);
+    const { depth } = computeField(alpha, width, height);
+    // ring pixels are 1px from empty, the center is 2px
+    expect(depth[1 * width + 1]).toBe(1);
+    expect(depth[2 * width + 2]).toBe(2);
+  });
+
+  test("diagonal steps cost 4/3 (chamfer 3-4)", () => {
+    const { alpha, width, height } = bitmap([".####", "#####", "#####"]);
+    const { depth } = computeField(alpha, width, height);
+    // (1,1)'s only nearby empty pixel is (0,0), one diagonal step away
+    expect(depth[1 * width + 1]).toBeCloseTo(4 / 3);
+  });
+
+  test("out-of-bounds counts as solid (no empty influence past the border)", () => {
+    const { alpha, width, height } = bitmap(["#####", "#####", "#####"]);
+    const { depth } = computeField(alpha, width, height);
+    // fully solid map: no empty pixel anywhere, all depths stay huge
+    for (let i = 0; i < depth.length; i++) {
+      expect(depth[i]).toBeGreaterThan(width + height);
+    }
+  });
+});
+
+describe("computeField sky", () => {
+  test("counts pixels up to the first empty pixel in the column", () => {
+    const { alpha, width, height } = bitmap([".", "#", "#", "#"]);
+    const { sky } = computeField(alpha, width, height);
+    expect(sky[0]).toBe(0); // empty
+    expect(sky[1 * width]).toBe(1);
+    expect(sky[2 * width]).toBe(2);
+    expect(sky[3 * width]).toBe(3);
+  });
+
+  test("columns solid from the top edge have huge sky distance", () => {
+    const { alpha, width, height } = bitmap(["#", "#"]);
+    const { sky } = computeField(alpha, width, height);
+    expect(sky[0]).toBeGreaterThan(height);
+    expect(sky[width]).toBeGreaterThan(height);
+  });
+
+  test("sky resets below an overhang gap", () => {
+    const { alpha, width, height } = bitmap(["#", ".", "#"]);
+    const { sky } = computeField(alpha, width, height);
+    expect(sky[1 * width]).toBe(0); // the gap
+    expect(sky[2 * width]).toBe(1); // restarts below the gap
+  });
+});

--- a/src/data/terrainPaint/__spec__/helpers.ts
+++ b/src/data/terrainPaint/__spec__/helpers.ts
@@ -1,0 +1,16 @@
+/** Build an alpha bitmap from ASCII art: '#' = solid, anything else = empty. */
+export function bitmap(rows: string[]): {
+  alpha: Uint8Array;
+  width: number;
+  height: number;
+} {
+  const height = rows.length;
+  const width = rows[0].length;
+  const alpha = new Uint8Array(width * height);
+  rows.forEach((row, y) => {
+    for (let x = 0; x < width; x++) {
+      if (row[x] === "#") alpha[y * width + x] = 1;
+    }
+  });
+  return { alpha, width, height };
+}

--- a/src/data/terrainPaint/__spec__/index.spec.ts
+++ b/src/data/terrainPaint/__spec__/index.spec.ts
@@ -67,6 +67,18 @@ describe("paintTerrain", () => {
     expect(overridden.zones[0].themeId).toBe("snow");
   });
 
+  test("exposes the zone map for UI hit-testing", () => {
+    const { result, alpha, width, height } = paint();
+    expect(result.zoneMap.length).toBe(width * height);
+    for (let i = 0; i < alpha.length; i++) {
+      if (alpha[i]) {
+        expect(result.zoneMap[i]).toBeGreaterThanOrEqual(0);
+      } else {
+        expect(result.zoneMap[i]).toBe(-1);
+      }
+    }
+  });
+
   test("solid pixels get a non-black color from the theme", () => {
     const { result, alpha, width } = paint();
     // a deep pixel in the floor: row 5, column 10

--- a/src/data/terrainPaint/__spec__/index.spec.ts
+++ b/src/data/terrainPaint/__spec__/index.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { paintTerrain } from "../index";
-import { THEME_IDS } from "../palettes";
+import { THEMES, THEME_IDS } from "../palettes";
+import { hexToRgb } from "../pixel";
 import { bitmap } from "./helpers";
 
 const MAP = [
@@ -106,5 +107,89 @@ describe("paintTerrain", () => {
     for (let i = 3; i < result.terrain.data.length; i += 4) {
       expect(result.terrain.data[i]).toBe(0);
     }
+  });
+
+  test("paints a themed back-wall into roofed pockets", () => {
+    // a wide roof over open empty space, no floor: pockets must fill
+    const roof = [
+      "....................",
+      "####################",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+    ];
+    const { alpha, width, height } = bitmap(roof);
+    const result = paintTerrain({
+      alpha,
+      width,
+      height,
+      ladders: [],
+      seed: 1,
+    });
+    const data = result.background.data;
+    let filled = 0;
+    for (let x = 0; x < width; x++) {
+      // row 3 sits under the solid roof at row 1
+      if (data[(3 * width + x) * 4 + 3] === 255) filled++;
+    }
+    expect(filled).toBe(width);
+  });
+
+  test("a zone theme override drives its roofed pocket's back-wall", () => {
+    // one landmass -> zone 0; overriding it must reach the back-wall colors
+    const roof = [
+      "....................",
+      "####################",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+    ];
+    const { alpha, width, height } = bitmap(roof);
+    const result = paintTerrain({
+      alpha,
+      width,
+      height,
+      ladders: [],
+      seed: 1,
+      themeOverrides: { 0: "urban" },
+    });
+    expect(result.zones[0].themeId).toBe("urban");
+    // shading scales every channel of a ramp color by one factor; the painted
+    // pixel must be a uniform scaling of some urban back-wall color.
+    const data = result.background.data;
+    const o = (3 * width + 5) * 4;
+    const px = [data[o], data[o + 1], data[o + 2]];
+    const matches = THEMES.urban.backwall!.ramp.some((hex) => {
+      const c = hexToRgb(hex);
+      const factors: number[] = [];
+      for (let k = 0; k < 3; k++) {
+        if (c[k] === 0) return px[k] <= 2;
+        const f = px[k] / c[k];
+        if (f < 0.3 || f > 1.05) return false;
+        factors.push(f);
+      }
+      return Math.max(...factors) - Math.min(...factors) < 0.06;
+    });
+    expect(matches).toBe(true);
+  });
+
+  test("a ladder casts a contact shadow onto the terrain at its base", () => {
+    const width = 40;
+    const height = 40;
+    const rows = Array.from({ length: height }, () => "#".repeat(width));
+    const { alpha } = bitmap(rows);
+    const ladder = { left: 16, top: 4, right: 28, bottom: 30 };
+    const shade = (ladders: typeof ladder[]) =>
+      paintTerrain({ alpha, width, height, ladders, seed: 1 }).terrain.data;
+    const withLadder = shade([ladder]);
+    const without = shade([]);
+    // a solid-terrain pixel near the ladder's base center (22, 30)
+    const i = 30 * width + 30;
+    const sum = (d: Uint8ClampedArray) => d[i * 4] + d[i * 4 + 1] + d[i * 4 + 2];
+    // still opaque terrain, just darkened by the contact shadow
+    expect(withLadder[i * 4 + 3]).toBe(255);
+    expect(sum(withLadder)).toBeLessThan(sum(without));
   });
 });

--- a/src/data/terrainPaint/__spec__/index.spec.ts
+++ b/src/data/terrainPaint/__spec__/index.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "vitest";
+import { paintTerrain } from "../index";
+import { THEME_IDS } from "../palettes";
+import { bitmap } from "./helpers";
+
+const MAP = [
+  "....................",
+  "......####..........",
+  ".....######....##...",
+  "....########..####..",
+  "####################",
+  "####################",
+];
+
+function paint(seed = 1, themeOverrides?: Record<number, string>) {
+  const { alpha, width, height } = bitmap(MAP);
+  return {
+    result: paintTerrain({
+      alpha,
+      width,
+      height,
+      ladders: [],
+      seed,
+      themeOverrides,
+    }),
+    alpha,
+    width,
+    height,
+  };
+}
+
+describe("paintTerrain", () => {
+  test("terrain alpha equals input alpha exactly", () => {
+    const { result, alpha } = paint();
+    const data = result.terrain.data;
+    for (let i = 0; i < alpha.length; i++) {
+      expect(data[i * 4 + 3]).toBe(alpha[i] ? 255 : 0);
+    }
+  });
+
+  test("terrain and background alphas are binary", () => {
+    const { result } = paint();
+    for (const img of [result.terrain, result.background]) {
+      for (let i = 3; i < img.data.length; i += 4) {
+        expect(img.data[i] === 0 || img.data[i] === 255).toBe(true);
+      }
+    }
+  });
+
+  test("same input and seed produce byte-identical output", () => {
+    const a = paint(7).result;
+    const b = paint(7).result;
+    expect(Array.from(a.terrain.data)).toEqual(Array.from(b.terrain.data));
+    expect(Array.from(a.background.data)).toEqual(
+      Array.from(b.background.data)
+    );
+    expect(a.zones).toEqual(b.zones);
+  });
+
+  test("returns zone info with valid themes and honors overrides", () => {
+    const auto = paint(1).result;
+    expect(auto.zones.length).toBeGreaterThan(0);
+    for (const zone of auto.zones) {
+      expect(THEME_IDS).toContain(zone.themeId);
+    }
+    const overridden = paint(1, { 0: "snow" }).result;
+    expect(overridden.zones[0].themeId).toBe("snow");
+  });
+
+  test("solid pixels get a non-black color from the theme", () => {
+    const { result, alpha, width } = paint();
+    // a deep pixel in the floor: row 5, column 10
+    const i = 5 * width + 10;
+    expect(alpha[i]).toBe(1);
+    const o = i * 4;
+    const [r, g, b] = [
+      result.terrain.data[o],
+      result.terrain.data[o + 1],
+      result.terrain.data[o + 2],
+    ];
+    expect(r + g + b).toBeGreaterThan(0);
+  });
+
+  test("handles an empty map without crashing", () => {
+    const { alpha, width, height } = bitmap(["....", "...."]);
+    const result = paintTerrain({
+      alpha,
+      width,
+      height,
+      ladders: [],
+      seed: 1,
+    });
+    expect(result.zones).toHaveLength(0);
+    for (let i = 3; i < result.terrain.data.length; i += 4) {
+      expect(result.terrain.data[i]).toBe(0);
+    }
+  });
+});

--- a/src/data/terrainPaint/__spec__/palettes.spec.ts
+++ b/src/data/terrainPaint/__spec__/palettes.spec.ts
@@ -4,12 +4,13 @@ import { THEMES, THEME_IDS } from "../palettes";
 const HEX = /^#[0-9a-f]{6}$/;
 
 describe("THEMES", () => {
-  test("contains the five themes", () => {
+  test("contains the six themes", () => {
     expect([...THEME_IDS].sort()).toEqual([
       "cave",
       "grassland",
       "planks",
       "snow",
+      "toon",
       "urban",
     ]);
   });
@@ -41,19 +42,38 @@ describe("THEMES", () => {
     }
   });
 
-  test("only cave uses pillow-shading outlines", () => {
+  test("only toon uses pillow-shading outlines", () => {
     const outlined = THEME_IDS.filter((id) => THEMES[id].outline);
-    expect(outlined).toEqual(["cave"]);
+    expect(outlined).toEqual(["toon"]);
   });
 
   test("urban brick pattern returns the mortar (last) index on mortar rows", () => {
     const brick = THEMES.urban.shallow;
     const len = brick.ramp.length;
-    // y % 6 === 5 is always a horizontal mortar line
-    expect(brick.pattern!(3, 5, 0, len)).toBe(len - 1);
-    expect(brick.pattern!(20, 11, 1, len)).toBe(len - 1);
+    // y % 4 === 3 is always a horizontal mortar line
+    expect(brick.pattern!(3, 3, 0, len)).toBe(len - 1);
+    expect(brick.pattern!(20, 7, 1, len)).toBe(len - 1);
     // inside a brick body the index never lands on the mortar color
-    expect(brick.pattern!(2, 2, 0, len)).toBeLessThan(len - 1);
+    expect(brick.pattern!(2, 1, 0, len)).toBeLessThan(len - 1);
+  });
+
+  test("cave rock pattern produces fracture seams and bounded facets", () => {
+    const rock = THEMES.cave.shallow;
+    const len = rock.ramp.length;
+    let seams = 0;
+    let bodies = 0;
+    for (let y = 0; y < 60; y++) {
+      for (let x = 0; x < 60; x++) {
+        const idx = rock.pattern!(x, y, 0, len);
+        expect(idx).toBeGreaterThanOrEqual(0);
+        expect(idx).toBeLessThan(len);
+        if (idx === len - 1) seams++;
+        else bodies++;
+      }
+    }
+    // fracture seams exist but the body dominates
+    expect(seams).toBeGreaterThan(0);
+    expect(bodies).toBeGreaterThan(seams * 5);
   });
 
   test("plank pattern returns the seam (last) index on board seams", () => {

--- a/src/data/terrainPaint/__spec__/palettes.spec.ts
+++ b/src/data/terrainPaint/__spec__/palettes.spec.ts
@@ -4,8 +4,14 @@ import { THEMES, THEME_IDS } from "../palettes";
 const HEX = /^#[0-9a-f]{6}$/;
 
 describe("THEMES", () => {
-  test("contains the four initial themes", () => {
-    expect([...THEME_IDS].sort()).toEqual(["cave", "grassland", "snow", "urban"]);
+  test("contains the five themes", () => {
+    expect([...THEME_IDS].sort()).toEqual([
+      "cave",
+      "grassland",
+      "planks",
+      "snow",
+      "urban",
+    ]);
   });
 
   test("every theme is structurally valid", () => {
@@ -29,18 +35,35 @@ describe("THEMES", () => {
       }
       expect(theme.ladder.rail).toMatch(HEX);
       expect(theme.ladder.rung).toMatch(HEX);
-      expect(theme.outline).toMatch(HEX);
+      if (theme.outline !== undefined) {
+        expect(theme.outline).toMatch(HEX);
+      }
     }
+  });
+
+  test("only cave uses pillow-shading outlines", () => {
+    const outlined = THEME_IDS.filter((id) => THEMES[id].outline);
+    expect(outlined).toEqual(["cave"]);
   });
 
   test("urban brick pattern returns the mortar (last) index on mortar rows", () => {
     const brick = THEMES.urban.shallow;
     const len = brick.ramp.length;
-    // y % 8 === 7 is always a horizontal mortar line
-    expect(brick.pattern!(3, 7, 0, len)).toBe(len - 1);
-    expect(brick.pattern!(20, 15, 1, len)).toBe(len - 1);
+    // y % 6 === 5 is always a horizontal mortar line
+    expect(brick.pattern!(3, 5, 0, len)).toBe(len - 1);
+    expect(brick.pattern!(20, 11, 1, len)).toBe(len - 1);
     // inside a brick body the index never lands on the mortar color
     expect(brick.pattern!(2, 2, 0, len)).toBeLessThan(len - 1);
+  });
+
+  test("plank pattern returns the seam (last) index on board seams", () => {
+    const planks = THEMES.planks.shallow;
+    const len = planks.ramp.length;
+    // y % 6 === 5 is always a horizontal board seam
+    expect(planks.pattern!(7, 5, 0, len)).toBe(len - 1);
+    expect(planks.pattern!(40, 11, 1, len)).toBe(len - 1);
+    // inside a board the index never lands on the seam color
+    expect(planks.pattern!(2, 2, 0, len)).toBeLessThan(len - 1);
   });
 
   test("patterns are pure functions of position", () => {

--- a/src/data/terrainPaint/__spec__/palettes.spec.ts
+++ b/src/data/terrainPaint/__spec__/palettes.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import { THEMES, THEME_IDS } from "../palettes";
+
+const HEX = /^#[0-9a-f]{6}$/;
+
+describe("THEMES", () => {
+  test("contains the four initial themes", () => {
+    expect([...THEME_IDS].sort()).toEqual(["cave", "grassland", "snow", "urban"]);
+  });
+
+  test("every theme is structurally valid", () => {
+    for (const id of THEME_IDS) {
+      const theme = THEMES[id];
+      expect(theme.id).toBe(id);
+      expect(theme.name.length).toBeGreaterThan(0);
+      expect(theme.surface.thickness).toBeGreaterThan(0);
+      expect(theme.shallow.depth).toBeGreaterThan(theme.surface.thickness);
+      for (const band of [
+        theme.surface,
+        theme.shallow,
+        theme.deep,
+        theme.rubble,
+      ]) {
+        // patterned bands reserve the last color as accent, so need >= 2
+        expect(band.ramp.length).toBeGreaterThanOrEqual(band.pattern ? 2 : 1);
+        for (const color of band.ramp) {
+          expect(color).toMatch(HEX);
+        }
+      }
+      expect(theme.ladder.rail).toMatch(HEX);
+      expect(theme.ladder.rung).toMatch(HEX);
+      expect(theme.outline).toMatch(HEX);
+    }
+  });
+
+  test("urban brick pattern returns the mortar (last) index on mortar rows", () => {
+    const brick = THEMES.urban.shallow;
+    const len = brick.ramp.length;
+    // y % 8 === 7 is always a horizontal mortar line
+    expect(brick.pattern!(3, 7, 0, len)).toBe(len - 1);
+    expect(brick.pattern!(20, 15, 1, len)).toBe(len - 1);
+    // inside a brick body the index never lands on the mortar color
+    expect(brick.pattern!(2, 2, 0, len)).toBeLessThan(len - 1);
+  });
+
+  test("patterns are pure functions of position", () => {
+    for (const id of THEME_IDS) {
+      const theme = THEMES[id];
+      for (const band of [theme.shallow, theme.deep, theme.rubble]) {
+        if (!band.pattern) continue;
+        const len = band.ramp.length;
+        const first = band.pattern(13, 9, 1, len);
+        band.pattern(99, 99, 0, len);
+        expect(band.pattern(13, 9, 1, len)).toBe(first);
+      }
+    }
+  });
+});

--- a/src/data/terrainPaint/__spec__/palettes.spec.ts
+++ b/src/data/terrainPaint/__spec__/palettes.spec.ts
@@ -98,4 +98,45 @@ describe("THEMES", () => {
       }
     }
   });
+
+  test("every theme except toon defines a valid back-wall band", () => {
+    for (const id of THEME_IDS) {
+      const band = THEMES[id].backwall;
+      if (id === "toon") {
+        expect(band).toBeUndefined();
+        continue;
+      }
+      expect(band).toBeDefined();
+      expect(band!.ramp.length).toBeGreaterThanOrEqual(band!.pattern ? 2 : 1);
+      for (const color of band!.ramp) {
+        expect(color).toMatch(HEX);
+      }
+    }
+  });
+
+  test("back-wall patterns are pure functions of position", () => {
+    for (const id of THEME_IDS) {
+      const band = THEMES[id].backwall;
+      if (!band?.pattern) continue;
+      const len = band.ramp.length;
+      const first = band.pattern(13, 9, 0, len);
+      band.pattern(99, 99, 0, len);
+      expect(band.pattern(13, 9, 0, len)).toBe(first);
+    }
+  });
+
+  test("back-wall patterns stay within ramp bounds", () => {
+    for (const id of THEME_IDS) {
+      const band = THEMES[id].backwall;
+      if (!band?.pattern) continue;
+      const len = band.ramp.length;
+      for (let y = 0; y < 60; y++) {
+        for (let x = 0; x < 60; x++) {
+          const idx = band.pattern(x, y, 0, len);
+          expect(idx).toBeGreaterThanOrEqual(0);
+          expect(idx).toBeLessThan(len);
+        }
+      }
+    }
+  });
 });

--- a/src/data/terrainPaint/__spec__/pixel.spec.ts
+++ b/src/data/terrainPaint/__spec__/pixel.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "vitest";
+import { createImageData, hexToRgb, pickZone, rampIndex } from "../pixel";
+
+describe("hexToRgb", () => {
+  test("parses hex colors", () => {
+    expect(hexToRgb("#ff0000")).toEqual([255, 0, 0]);
+    expect(hexToRgb("#8bc34a")).toEqual([139, 195, 74]);
+  });
+});
+
+describe("createImageData", () => {
+  test("creates a zeroed buffer of the right size", () => {
+    const img = createImageData(3, 2);
+    expect(img.width).toBe(3);
+    expect(img.height).toBe(2);
+    expect(img.data.length).toBe(3 * 2 * 4);
+    expect(Array.from(img.data).every((v) => v === 0)).toBe(true);
+  });
+
+  test("falls back to a plain shape when ImageData is unavailable", () => {
+    const orig = (globalThis as any).ImageData;
+    delete (globalThis as any).ImageData;
+    try {
+      const img = createImageData(4, 2);
+      expect(img.width).toBe(4);
+      expect(img.height).toBe(2);
+      expect(img.data.length).toBe(32);
+    } finally {
+      (globalThis as any).ImageData = orig;
+    }
+  });
+});
+
+describe("rampIndex", () => {
+  const band = { ramp: ["#aaaaaa", "#888888", "#666666"] };
+
+  test("maps band position to ramp index, light to dark", () => {
+    // collect indices across many positions per t bucket; dither shifts
+    // by at most 1, so the median must land on the base index
+    for (const [t, expected] of [
+      [0.1, 0],
+      [0.5, 1],
+      [0.9, 2],
+    ] as const) {
+      const indices: number[] = [];
+      for (let x = 0; x < 50; x++) {
+        indices.push(rampIndex(band, t, x, 7, 1));
+      }
+      indices.sort((a, b) => a - b);
+      expect(indices[25]).toBe(expected);
+      for (const idx of indices) {
+        expect(Math.abs(idx - expected)).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  test("stays within ramp bounds", () => {
+    for (let x = 0; x < 100; x++) {
+      for (const t of [0, 0.33, 0.66, 0.999, 1, 1.5]) {
+        const idx = rampIndex(band, t, x, x * 3, 42);
+        expect(idx).toBeGreaterThanOrEqual(0);
+        expect(idx).toBeLessThan(band.ramp.length);
+      }
+    }
+  });
+
+  test("applies the band pattern after dithering", () => {
+    const patterned = {
+      ramp: ["#aaaaaa", "#888888"],
+      pattern: () => 0,
+    };
+    for (let x = 0; x < 20; x++) {
+      expect(rampIndex(patterned, 0.9, x, 0, 1)).toBe(0);
+    }
+  });
+});
+
+describe("pickZone", () => {
+  test("returns the pixel's own zone away from seams", () => {
+    // one big zone: jitter can never escape it
+    const width = 64;
+    const height = 64;
+    const zoneMap = new Int32Array(width * height).fill(0);
+    expect(pickZone(zoneMap, width, height, 32, 32, 1)).toBe(0);
+  });
+
+  test("never returns -1 for a solid pixel even when jitter lands on empty", () => {
+    const width = 32;
+    const height = 32;
+    const zoneMap = new Int32Array(width * height).fill(-1);
+    // only one solid pixel; all jitter targets are empty
+    zoneMap[16 * width + 16] = 3;
+    expect(pickZone(zoneMap, width, height, 16, 16, 1)).toBe(3);
+  });
+
+  test("is deterministic per position and seed", () => {
+    const width = 32;
+    const height = 32;
+    const zoneMap = new Int32Array(width * height);
+    for (let i = 0; i < zoneMap.length; i++) {
+      zoneMap[i] = i % width < 16 ? 0 : 1;
+    }
+    for (let x = 10; x < 22; x++) {
+      expect(pickZone(zoneMap, width, height, x, 5, 7)).toBe(
+        pickZone(zoneMap, width, height, x, 5, 7)
+      );
+    }
+  });
+});

--- a/src/data/terrainPaint/__spec__/pixel.spec.ts
+++ b/src/data/terrainPaint/__spec__/pixel.spec.ts
@@ -106,4 +106,34 @@ describe("pickZone", () => {
       );
     }
   });
+
+  test("clamps jitter to the pixel's own landmass when a map is given", () => {
+    // two adjacent landmasses meeting at x=16, each one solid zone. Within
+    // SEAM_JITTER (8px) a left-side pixel's jitter can reach the right zone.
+    const width = 32;
+    const height = 32;
+    const zoneMap = new Int32Array(width * height);
+    const landmassMap = new Int32Array(width * height);
+    for (let i = 0; i < zoneMap.length; i++) {
+      const right = i % width >= 16;
+      zoneMap[i] = right ? 1 : 0;
+      landmassMap[i] = right ? 1 : 0;
+    }
+
+    // baseline: without the landmass map, jitter bleeds the right zone across
+    let bledWithoutMap = false;
+    for (let x = 10; x < 16; x++) {
+      for (let y = 0; y < height; y++) {
+        if (pickZone(zoneMap, width, height, x, y, 7) === 1) bledWithoutMap = true;
+      }
+    }
+    expect(bledWithoutMap).toBe(true);
+
+    // with the map, a left-landmass pixel never adopts the right zone
+    for (let x = 10; x < 16; x++) {
+      for (let y = 0; y < height; y++) {
+        expect(pickZone(zoneMap, width, height, x, y, 7, landmassMap)).toBe(0);
+      }
+    }
+  });
 });

--- a/src/data/terrainPaint/__spec__/rng.spec.ts
+++ b/src/data/terrainPaint/__spec__/rng.spec.ts
@@ -1,37 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { mulberry32, noise2d } from "../rng";
-
-describe("mulberry32", () => {
-  test("same seed produces the same sequence", () => {
-    const a = mulberry32(42);
-    const b = mulberry32(42);
-    for (let i = 0; i < 100; i++) {
-      expect(a()).toBe(b());
-    }
-  });
-
-  test("different seeds produce different sequences", () => {
-    const a = mulberry32(1);
-    const b = mulberry32(2);
-    const valuesA = Array.from({ length: 10 }, () => a());
-    const valuesB = Array.from({ length: 10 }, () => b());
-    expect(valuesA).not.toEqual(valuesB);
-  });
-
-  test("values are in [0, 1)", () => {
-    const rng = mulberry32(7);
-    for (let i = 0; i < 1000; i++) {
-      const v = rng();
-      expect(v).toBeGreaterThanOrEqual(0);
-      expect(v).toBeLessThan(1);
-    }
-  });
-
-  test("golden value: seed 1 first draw", () => {
-    const rng = mulberry32(1);
-    expect(rng()).toBeCloseTo(0.6270739405881613, 6);
-  });
-});
+import { noise2d } from "../rng";
 
 describe("noise2d", () => {
   test("is position-stable regardless of evaluation order", () => {

--- a/src/data/terrainPaint/__spec__/rng.spec.ts
+++ b/src/data/terrainPaint/__spec__/rng.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { mulberry32, noise2d } from "../rng";
+
+describe("mulberry32", () => {
+  test("same seed produces the same sequence", () => {
+    const a = mulberry32(42);
+    const b = mulberry32(42);
+    for (let i = 0; i < 100; i++) {
+      expect(a()).toBe(b());
+    }
+  });
+
+  test("different seeds produce different sequences", () => {
+    const a = mulberry32(1);
+    const b = mulberry32(2);
+    const valuesA = Array.from({ length: 10 }, () => a());
+    const valuesB = Array.from({ length: 10 }, () => b());
+    expect(valuesA).not.toEqual(valuesB);
+  });
+
+  test("values are in [0, 1)", () => {
+    const rng = mulberry32(7);
+    for (let i = 0; i < 1000; i++) {
+      const v = rng();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  test("golden value: seed 1 first draw", () => {
+    const rng = mulberry32(1);
+    expect(rng()).toBeCloseTo(0.6270739405881613, 6);
+  });
+});
+
+describe("noise2d", () => {
+  test("is position-stable regardless of evaluation order", () => {
+    const first = noise2d(5, 17, 23);
+    noise2d(5, 99, 99);
+    noise2d(5, 0, 0);
+    expect(noise2d(5, 17, 23)).toBe(first);
+  });
+
+  test("varies across coordinates and seeds", () => {
+    const values = new Set<number>();
+    for (let x = 0; x < 10; x++) {
+      for (let y = 0; y < 10; y++) {
+        values.add(noise2d(1, x, y));
+      }
+    }
+    expect(values.size).toBeGreaterThan(90);
+    expect(noise2d(1, 3, 4)).not.toBe(noise2d(2, 3, 4));
+  });
+
+  test("values are in [0, 1)", () => {
+    for (let i = 0; i < 500; i++) {
+      const v = noise2d(3, i * 13, i * 7);
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+    const zero = noise2d(0, 0, 0);
+    expect(zero).toBeGreaterThan(0);
+    expect(zero).toBeLessThan(1);
+  });
+});

--- a/src/data/terrainPaint/__spec__/zones.spec.ts
+++ b/src/data/terrainPaint/__spec__/zones.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+import { computeZones, MAX_ZONE_WIDTH } from "../zones";
+import { THEME_IDS } from "../palettes";
+import { bitmap } from "./helpers";
+
+describe("computeZones", () => {
+  test("two islands become two zones with distinct labels", () => {
+    const { alpha, width, height } = bitmap([
+      "##..##",
+      "##..##",
+      "......",
+    ]);
+    const { zoneMap, zones } = computeZones(alpha, width, height, 1);
+    expect(zones).toHaveLength(2);
+    expect(zoneMap[0]).not.toBe(zoneMap[4]);
+    expect(zoneMap[2]).toBe(-1); // empty pixel
+    // bboxes are refined to actual pixels (right/bottom exclusive)
+    const left = zones.find((z) => z.id === zoneMap[0])!;
+    expect(left.bbox).toEqual({ left: 0, top: 0, right: 2, bottom: 2 });
+  });
+
+  test("an empty map yields zero zones", () => {
+    const { alpha, width, height } = bitmap(["....", "...."]);
+    const { zones } = computeZones(alpha, width, height, 1);
+    expect(zones).toHaveLength(0);
+  });
+
+  test("a landmass wider than MAX_ZONE_WIDTH is split", () => {
+    const width = MAX_ZONE_WIDTH * 2 + 100;
+    const height = 4;
+    const alpha = new Uint8Array(width * height).fill(1);
+    const { zones } = computeZones(alpha, width, height, 1);
+    expect(zones.length).toBe(3); // ceil(2020 / 960)
+  });
+
+  test("same seed gives identical zones and themes; output is deterministic", () => {
+    const width = MAX_ZONE_WIDTH + 200;
+    const height = 8;
+    const alpha = new Uint8Array(width * height).fill(1);
+    const a = computeZones(alpha, width, height, 5);
+    const b = computeZones(alpha, width, height, 5);
+    expect(Array.from(a.zoneMap)).toEqual(Array.from(b.zoneMap));
+    expect(a.zones).toEqual(b.zones);
+  });
+
+  test("horizontally consecutive zones get different themes", () => {
+    const width = MAX_ZONE_WIDTH * 3;
+    const height = 4;
+    const alpha = new Uint8Array(width * height).fill(1);
+    const { zones } = computeZones(alpha, width, height, 9);
+    const ordered = [...zones].sort((a, b) => a.bbox.left - b.bbox.left);
+    for (let i = 1; i < ordered.length; i++) {
+      expect(ordered[i].themeId).not.toBe(ordered[i - 1].themeId);
+    }
+  });
+
+  test("every assigned theme is a known theme id", () => {
+    const { alpha, width, height } = bitmap(["####", "####"]);
+    const { zones } = computeZones(alpha, width, height, 3);
+    for (const zone of zones) {
+      expect(THEME_IDS).toContain(zone.themeId);
+    }
+  });
+
+  test("overrides win; unknown override ids fall back to the auto pick", () => {
+    const { alpha, width, height } = bitmap(["##..##", "##..##"]);
+    const { zones } = computeZones(alpha, width, height, 1, {
+      0: "urban",
+      1: "not-a-theme",
+    });
+    expect(zones[0].themeId).toBe("urban");
+    expect(THEME_IDS).toContain(zones[1].themeId);
+  });
+
+  test("adjacent zones may share a theme when both are overridden", () => {
+    const { alpha, width, height } = bitmap(["##..##", "##..##"]);
+    const { zones } = computeZones(alpha, width, height, 1, {
+      0: "snow",
+      1: "snow",
+    });
+    expect(zones[0].themeId).toBe("snow");
+    expect(zones[1].themeId).toBe("snow");
+  });
+
+  test("the slice boundary moves with the seed (wobble is live)", () => {
+    const width = MAX_ZONE_WIDTH * 2;
+    const height = 4;
+    const alpha = new Uint8Array(width * height).fill(1);
+    const boundary = (seed: number) => {
+      const { zoneMap } = computeZones(alpha, width, height, seed);
+      let x = 0;
+      while (x < width && zoneMap[x] === zoneMap[0]) x++;
+      return x;
+    };
+    expect(boundary(1)).not.toBe(boundary(2));
+  });
+});

--- a/src/data/terrainPaint/__spec__/zones.spec.ts
+++ b/src/data/terrainPaint/__spec__/zones.spec.ts
@@ -43,14 +43,14 @@ describe("computeZones", () => {
     expect(a.zones).toEqual(b.zones);
   });
 
-  test("horizontally consecutive zones get different themes", () => {
+  test("zones default to grassland", () => {
     const width = MAX_ZONE_WIDTH * 3;
     const height = 4;
     const alpha = new Uint8Array(width * height).fill(1);
     const { zones } = computeZones(alpha, width, height, 9);
-    const ordered = [...zones].sort((a, b) => a.bbox.left - b.bbox.left);
-    for (let i = 1; i < ordered.length; i++) {
-      expect(ordered[i].themeId).not.toBe(ordered[i - 1].themeId);
+    expect(zones.length).toBeGreaterThan(1);
+    for (const zone of zones) {
+      expect(zone.themeId).toBe("grassland");
     }
   });
 
@@ -62,24 +62,14 @@ describe("computeZones", () => {
     }
   });
 
-  test("overrides win; unknown override ids fall back to the auto pick", () => {
+  test("overrides win; unknown override ids fall back to the default", () => {
     const { alpha, width, height } = bitmap(["##..##", "##..##"]);
     const { zones } = computeZones(alpha, width, height, 1, {
       0: "urban",
       1: "not-a-theme",
     });
     expect(zones[0].themeId).toBe("urban");
-    expect(THEME_IDS).toContain(zones[1].themeId);
-  });
-
-  test("adjacent zones may share a theme when both are overridden", () => {
-    const { alpha, width, height } = bitmap(["##..##", "##..##"]);
-    const { zones } = computeZones(alpha, width, height, 1, {
-      0: "snow",
-      1: "snow",
-    });
-    expect(zones[0].themeId).toBe("snow");
-    expect(zones[1].themeId).toBe("snow");
+    expect(zones[1].themeId).toBe("grassland");
   });
 
   test("the slice boundary moves with the seed (wobble is live)", () => {

--- a/src/data/terrainPaint/backwall.ts
+++ b/src/data/terrainPaint/backwall.ts
@@ -16,7 +16,9 @@ export interface BackwallInput {
 // empty pixels within this distance below their ceiling are progressively
 // darkened — a downward contact shadow cast by the surface above them
 const AO_RADIUS = 18;
-const AO_MIN = 0.5;
+// darkest ambient-occlusion multiplier; debris reuses it so eroded terrain
+// reads as the same deep-shadow tone as a fully occluded pocket
+export const AO_MIN = 0.5;
 // how far the back-wall's edge against open sky is allowed to wander
 const EDGE_WOBBLE = 4;
 

--- a/src/data/terrainPaint/backwall.ts
+++ b/src/data/terrainPaint/backwall.ts
@@ -1,0 +1,115 @@
+import { THEMES } from "./palettes";
+import { hexToRgb, rampIndex } from "./pixel";
+import { noise2d } from "./rng";
+import type { ZoneInfo } from "./zones";
+
+export interface BackwallInput {
+  /** Shared background buffer; back-wall is painted before debris/ladders. */
+  background: ImageData;
+  width: number;
+  height: number;
+  zoneMap: Int32Array;
+  zones: ZoneInfo[];
+  seed: number;
+}
+
+// empty pixels within this distance below their ceiling are progressively
+// darkened — a downward contact shadow cast by the surface above them
+const AO_RADIUS = 18;
+const AO_MIN = 0.5;
+// how far the back-wall's edge against open sky is allowed to wander
+const EDGE_WOBBLE = 4;
+
+/**
+ * Paint the back-wall behind the terrain. Every solid pixel gets the back-wall
+ * of its own zone (so erosion reveals the wall rather than empty sky), and every
+ * empty pixel that has solid terrain above it gets the back-wall of the nearest
+ * solid pixel above (its "ceiling"). Debris is drawn on top afterwards, so the
+ * wall effectively runs down to the eroded edge of each span. Open sky (nothing
+ * solid above) and themes without a back-wall (e.g. toon) stay transparent.
+ *
+ * Shading: ambient occlusion darkens each pocket pixel toward the surface above
+ * it (never toward a floor below), and low-frequency noise mottles the rest, so
+ * the wall reads as a lit surface rather than a flat fill. The wall's edge
+ * against open sky is roughened with a wobbled lookup so it isn't dead straight.
+ */
+export function buildBackwall(input: BackwallInput): void {
+  const { background, width, height, zoneMap, zones, seed } = input;
+  const data = background.data;
+  const n = width * height;
+
+  // Pass 1: per column, resolve each pixel's back-wall zone and ambient factor.
+  // zoneOf is -1 for open sky (nothing solid above). aoOf folds in the
+  // below-the-ceiling occlusion so the paint pass only samples and mottles.
+  const zoneOf = new Int32Array(n).fill(-1);
+  const aoOf = new Float32Array(n);
+  for (let x = 0; x < width; x++) {
+    let ceilingZone = -1;
+    let ceilingY = -1;
+    for (let y = 0; y < height; y++) {
+      const i = y * width + x;
+      const zi = zoneMap[i];
+      if (zi !== -1) {
+        zoneOf[i] = zi;
+        aoOf[i] = 1; // behind terrain: no open recess to occlude
+        ceilingZone = zi;
+        ceilingY = y;
+      } else if (ceilingZone !== -1) {
+        zoneOf[i] = ceilingZone;
+        const d = y - ceilingY;
+        aoOf[i] = AO_MIN + (1 - AO_MIN) * Math.min(1, d / AO_RADIUS);
+      }
+    }
+  }
+
+  const colorCache = new Map<string, [number, number, number][]>();
+  const colorsFor = (themeId: string) => {
+    let c = colorCache.get(themeId);
+    if (!c) {
+      c = THEMES[themeId].backwall!.ramp.map(hexToRgb);
+      colorCache.set(themeId, c);
+    }
+    return c;
+  };
+
+  // Pass 2: paint. A wobbled horizontal lookup raggedizes two boundaries at once:
+  // the wall's edge against open sky (an empty pixel whose neighbour is sky is
+  // eroded) and the seam between two adjacent zones (a pixel adopts the
+  // neighbour zone's theme). Solid backing is never eroded, and the interior
+  // shading still comes from each pixel's own column.
+  for (let x = 0; x < width; x++) {
+    for (let y = 0; y < height; y++) {
+      const i = y * width + x;
+      const zoneIdx = zoneOf[i];
+      if (zoneIdx === -1) continue; // open sky
+
+      const off = Math.round(
+        (noise2d(seed ^ 0x2c1f51ed, x >> 3, y >> 2) - 0.5) * 2 * EDGE_WOBBLE
+      );
+      const xs = Math.min(width - 1, Math.max(0, x + off));
+      const sampled = zoneOf[y * width + xs];
+      let zone = zoneIdx;
+      if (sampled === -1) {
+        if (zoneMap[i] === -1) continue; // empty pocket: ragged edge against sky
+        // solid backing stays filled with its own zone
+      } else {
+        zone = sampled; // ragged seam between adjacent zones
+      }
+
+      const themeId = zones[zone].themeId;
+      const band = THEMES[themeId].backwall;
+      if (!band) continue; // theme opts out (toon)
+      const colors = colorsFor(themeId);
+      const [r, g, b] = colors[rampIndex(band, 0, x, y, seed)];
+
+      const mottle = 0.88 + 0.12 * noise2d(seed ^ 0x5bd1e995, x >> 2, y >> 2);
+      const f = aoOf[i] * mottle;
+
+      const o = i * 4;
+      data[o] = r * f;
+      data[o + 1] = g * f;
+      data[o + 2] = b * f;
+      data[o + 3] = 255;
+    }
+  }
+}

--- a/src/data/terrainPaint/debris.ts
+++ b/src/data/terrainPaint/debris.ts
@@ -77,6 +77,8 @@ export function buildDebris(input: DebrisInput): ImageData {
       let best = 0;
       let bestDist = Infinity;
       for (const zone of zones) {
+        // slices eaten by boundary wobble have an empty bbox; never match them
+        if (zone.bbox.right === 0 && zone.bbox.bottom === 0) continue;
         const zx = (zone.bbox.left + zone.bbox.right) / 2;
         const zy = (zone.bbox.top + zone.bbox.bottom) / 2;
         const dist = (zx - cx) ** 2 + (zy - cy) ** 2;

--- a/src/data/terrainPaint/debris.ts
+++ b/src/data/terrainPaint/debris.ts
@@ -1,0 +1,113 @@
+import type { PlainBBox } from "../map/bbox";
+import { THEMES } from "./palettes";
+import { createImageData, hexToRgb, pickZone, rampIndex } from "./pixel";
+import { noise2d } from "./rng";
+import type { ZoneInfo } from "./zones";
+
+export interface DebrisInput {
+  width: number;
+  height: number;
+  zoneMap: Int32Array;
+  landmassMap: Int32Array;
+  zones: ZoneInfo[];
+  ladders: PlainBBox[];
+  seed: number;
+}
+
+const KEEP_BASE = 0.4;
+const KEEP_VARIATION = 0.2;
+const ROUGHEN_PX = 3;
+const RUBBLE_BAND_PX = 22;
+const RAIL_WIDTH = 2;
+const RUNG_SPACING = 8;
+const RUNG_HEIGHT = 2;
+
+/**
+ * Build the destroyed-terrain background: every landmass collapses into a
+ * debris mound that is a strict subset of its original silhouette, plus
+ * ladders drawn in empty space. Everything else stays fully transparent.
+ */
+export function buildDebris(input: DebrisInput): ImageData {
+  const { width, height, zoneMap, landmassMap, zones, ladders, seed } = input;
+  const rubbleColors = zones.map((zone) =>
+    THEMES[zone.themeId].rubble.ramp.map(hexToRgb)
+  );
+  const background = createImageData(width, height);
+  const data = background.data;
+
+  // per column, per landmass span: keep only the bottom portion
+  for (let x = 0; x < width; x++) {
+    let y = 0;
+    while (y < height) {
+      const lm = landmassMap[y * width + x];
+      if (lm === -1) {
+        y++;
+        continue;
+      }
+      let end = y;
+      while (end < height && landmassMap[end * width + x] === lm) end++;
+      const spanH = end - y;
+      // coarse noise (8-column steps) shapes the mound; fine noise roughens it
+      const keep =
+        KEEP_BASE + noise2d(seed, lm * 131 + (x >> 3), 0) * KEEP_VARIATION;
+      const roughen = Math.floor(noise2d(seed, x, lm + 1) * ROUGHEN_PX);
+      const kept = Math.max(0, Math.floor(spanH * keep) - roughen);
+      const newTop = Math.max(y, end - kept);
+      for (let yy = newTop; yy < end; yy++) {
+        const zi = pickZone(zoneMap, width, height, x, yy, seed);
+        const colors = rubbleColors[zi];
+        const t = Math.min(0.999, (yy - newTop) / (RUBBLE_BAND_PX * colors.length));
+        const idx = rampIndex(THEMES[zones[zi].themeId].rubble, t, x, yy, seed);
+        const [r, g, b] = colors[idx];
+        const o = (yy * width + x) * 4;
+        data[o] = r;
+        data[o + 1] = g;
+        data[o + 2] = b;
+        data[o + 3] = 255;
+      }
+      y = end;
+    }
+  }
+
+  // ladders: rails on both edges, rungs every RUNG_SPACING rows
+  if (zones.length > 0) {
+    for (const ladder of ladders) {
+      const cx = (ladder.left + ladder.right) / 2;
+      const cy = (ladder.top + ladder.bottom) / 2;
+      let best = 0;
+      let bestDist = Infinity;
+      for (const zone of zones) {
+        const zx = (zone.bbox.left + zone.bbox.right) / 2;
+        const zy = (zone.bbox.top + zone.bbox.bottom) / 2;
+        const dist = (zx - cx) ** 2 + (zy - cy) ** 2;
+        if (dist < bestDist) {
+          bestDist = dist;
+          best = zone.id;
+        }
+      }
+      const theme = THEMES[zones[best].themeId];
+      const rail = hexToRgb(theme.ladder.rail);
+      const rung = hexToRgb(theme.ladder.rung);
+
+      const left = Math.max(0, Math.round(ladder.left));
+      const right = Math.min(width, Math.round(ladder.right));
+      const top = Math.max(0, Math.round(ladder.top));
+      const bottom = Math.min(height, Math.round(ladder.bottom));
+      for (let yy = top; yy < bottom; yy++) {
+        for (let xx = left; xx < right; xx++) {
+          const isRail = xx < left + RAIL_WIDTH || xx >= right - RAIL_WIDTH;
+          const isRung = (yy - top) % RUNG_SPACING < RUNG_HEIGHT;
+          if (!isRail && !isRung) continue;
+          const [r, g, b] = isRail ? rail : rung;
+          const o = (yy * width + xx) * 4;
+          data[o] = r;
+          data[o + 1] = g;
+          data[o + 2] = b;
+          data[o + 3] = 255;
+        }
+      }
+    }
+  }
+
+  return background;
+}

--- a/src/data/terrainPaint/debris.ts
+++ b/src/data/terrainPaint/debris.ts
@@ -2,7 +2,7 @@ import type { PlainBBox } from "../map/bbox";
 import { THEMES } from "./palettes";
 import { createImageData, hexToRgb, pickZone, rampIndex } from "./pixel";
 import { noise2d } from "./rng";
-import type { ZoneInfo } from "./zones";
+import { isEmptyZone, type ZoneInfo } from "./zones";
 
 export interface DebrisInput {
   width: number;
@@ -86,7 +86,7 @@ export function buildDebris(input: DebrisInput): ImageData {
       let bestDist = Infinity;
       for (const zone of zones) {
         // slices eaten by boundary wobble have an empty bbox; never match them
-        if (zone.bbox.right === 0 && zone.bbox.bottom === 0) continue;
+        if (isEmptyZone(zone)) continue;
         const zx = (zone.bbox.left + zone.bbox.right) / 2;
         const zy = (zone.bbox.top + zone.bbox.bottom) / 2;
         const dist = (zx - cx) ** 2 + (zy - cy) ** 2;

--- a/src/data/terrainPaint/debris.ts
+++ b/src/data/terrainPaint/debris.ts
@@ -1,10 +1,11 @@
 import type { PlainBBox } from "../map/bbox";
 import { THEMES } from "./palettes";
-import { createImageData, hexToRgb, pickZone, rampIndex } from "./pixel";
+import { hexToRgb, pickZone, rampIndex } from "./pixel";
 import { noise2d } from "./rng";
 import { isEmptyZone, type ZoneInfo } from "./zones";
 
 export interface DebrisInput {
+  background: ImageData;
   width: number;
   height: number;
   zoneMap: Int32Array;
@@ -17,24 +18,44 @@ export interface DebrisInput {
 const KEEP_BASE = 0.4;
 const KEEP_VARIATION = 0.2;
 const ROUGHEN_PX = 3;
+// eroded terrain reads as deep shadow: darken the wall to the back-wall's
+// darkest ambient-occlusion level (AO_MIN) so debris matches those shadows
+const DEBRIS_SHADE = 0.5;
 // deep terrain shouldn't crater: never erode more than this from a span's top
 const MAX_EROSION_PX = 10;
 const RUBBLE_BAND_PX = 22;
 const RAIL_WIDTH = 2;
 const RUNG_SPACING = 8;
 const RUNG_HEIGHT = 2;
+// darkest multiplier of the contact shadow pooled at a ladder's base
+const LADDER_AO_MIN = 0.72;
+// darkest multiplier of the shadow a ladder casts on the wall along its length
+const LADDER_SHADOW_MIN = 0.74;
 
 /**
  * Build the destroyed-terrain background: every landmass collapses into a
  * debris mound that is a strict subset of its original silhouette, plus
  * ladders drawn in empty space. Everything else stays fully transparent.
  */
-export function buildDebris(input: DebrisInput): ImageData {
-  const { width, height, zoneMap, landmassMap, zones, ladders, seed } = input;
-  const rubbleColors = zones.map((zone) =>
-    THEMES[zone.themeId].rubble.ramp.map(hexToRgb)
+export function buildDebris(input: DebrisInput): void {
+  const { background, width, height, zoneMap, landmassMap, zones, ladders, seed } =
+    input;
+  // shade the back-wall ramp (the same material seen behind terrain) down to the
+  // occlusion-shadow level; fall back to rubble for themes without a back-wall
+  const debrisBands = zones.map((zone) => {
+    const theme = THEMES[zone.themeId];
+    return { ramp: (theme.backwall ?? theme.rubble).ramp };
+  });
+  const debrisColors = debrisBands.map((band) =>
+    band.ramp.map((hex) => {
+      const [r, g, b] = hexToRgb(hex);
+      return [r * DEBRIS_SHADE, g * DEBRIS_SHADE, b * DEBRIS_SHADE] as [
+        number,
+        number,
+        number
+      ];
+    })
   );
-  const background = createImageData(width, height);
   const data = background.data;
 
   // per column, per landmass span: keep only the bottom portion
@@ -63,9 +84,9 @@ export function buildDebris(input: DebrisInput): ImageData {
       const newTop = y + erosion;
       for (let yy = newTop; yy < end; yy++) {
         const zi = pickZone(zoneMap, width, height, x, yy, seed);
-        const colors = rubbleColors[zi];
+        const colors = debrisColors[zi];
         const t = Math.min(0.999, (yy - newTop) / (RUBBLE_BAND_PX * colors.length));
-        const idx = rampIndex(THEMES[zones[zi].themeId].rubble, t, x, yy, seed);
+        const idx = rampIndex(debrisBands[zi], t, x, yy, seed);
         const [r, g, b] = colors[idx];
         const o = (yy * width + x) * 4;
         data[o] = r;
@@ -103,6 +124,25 @@ export function buildDebris(input: DebrisInput): ImageData {
       const right = Math.min(width, Math.round(ladder.right));
       const top = Math.max(0, Math.round(ladder.top));
       const bottom = Math.min(height, Math.round(ladder.bottom));
+
+      // soft shadow the ladder casts on the wall behind it, the full length,
+      // fading out sideways; only darkens existing opaque wall/debris
+      const sHalf = (right - left) * 0.9 + 3;
+      const ssLo = Math.max(0, Math.floor(cx - sHalf));
+      const ssHi = Math.min(width, Math.ceil(cx + sHalf));
+      for (let yy = top; yy < bottom; yy++) {
+        for (let xx = ssLo; xx < ssHi; xx++) {
+          const o = (yy * width + xx) * 4;
+          if (data[o + 3] !== 255) continue;
+          const dx = Math.abs(xx - cx) / sHalf;
+          if (dx >= 1) continue;
+          const k = LADDER_SHADOW_MIN + (1 - LADDER_SHADOW_MIN) * dx;
+          data[o] *= k;
+          data[o + 1] *= k;
+          data[o + 2] *= k;
+        }
+      }
+
       for (let yy = top; yy < bottom; yy++) {
         for (let xx = left; xx < right; xx++) {
           const isRail = xx < left + RAIL_WIDTH || xx >= right - RAIL_WIDTH;
@@ -118,6 +158,43 @@ export function buildDebris(input: DebrisInput): ImageData {
       }
     }
   }
+}
 
-  return background;
+/**
+ * Pool a soft radial contact shadow on the given layer around each ladder's
+ * base, fading up and outward. Applied to the terrain layer so the shadow lands
+ * on the ledge the ladder rests on; only darkens existing opaque pixels.
+ */
+export function shadeLadderBases(
+  image: ImageData,
+  ladders: PlainBBox[],
+  width: number,
+  height: number
+): void {
+  const data = image.data;
+  for (const ladder of ladders) {
+    const baseX = Math.round((ladder.left + ladder.right) / 2);
+    const bottom = Math.min(height, Math.round(ladder.bottom));
+    // wide, shallow ellipse so the shadow spreads sideways more than it sinks
+    const rx = Math.max(16, Math.round((ladder.right - ladder.left) * 1.6));
+    const ry = Math.round(rx * 0.6);
+    const syLo = Math.max(0, bottom - ry);
+    const syHi = Math.min(height, bottom + (ry >> 1));
+    const sxLo = Math.max(0, baseX - rx);
+    const sxHi = Math.min(width, baseX + rx);
+    for (let yy = syLo; yy < syHi; yy++) {
+      for (let xx = sxLo; xx < sxHi; xx++) {
+        const o = (yy * width + xx) * 4;
+        if (data[o + 3] !== 255) continue;
+        const dx = (xx - baseX) / rx;
+        const dy = (yy - bottom) / ry;
+        const d = Math.sqrt(dx * dx + dy * dy);
+        if (d >= 1) continue;
+        const k = LADDER_AO_MIN + (1 - LADDER_AO_MIN) * d;
+        data[o] *= k;
+        data[o + 1] *= k;
+        data[o + 2] *= k;
+      }
+    }
+  }
 }

--- a/src/data/terrainPaint/debris.ts
+++ b/src/data/terrainPaint/debris.ts
@@ -18,7 +18,7 @@ const KEEP_BASE = 0.4;
 const KEEP_VARIATION = 0.2;
 const ROUGHEN_PX = 3;
 // deep terrain shouldn't crater: never erode more than this from a span's top
-const MAX_EROSION_PX = 48;
+const MAX_EROSION_PX = 10;
 const RUBBLE_BAND_PX = 22;
 const RAIL_WIDTH = 2;
 const RUNG_SPACING = 8;

--- a/src/data/terrainPaint/debris.ts
+++ b/src/data/terrainPaint/debris.ts
@@ -1,4 +1,5 @@
 import type { PlainBBox } from "../map/bbox";
+import { AO_MIN } from "./backwall";
 import { THEMES } from "./palettes";
 import { hexToRgb, pickZone, rampIndex } from "./pixel";
 import { noise2d } from "./rng";
@@ -19,8 +20,8 @@ const KEEP_BASE = 0.4;
 const KEEP_VARIATION = 0.2;
 const ROUGHEN_PX = 3;
 // eroded terrain reads as deep shadow: darken the wall to the back-wall's
-// darkest ambient-occlusion level (AO_MIN) so debris matches those shadows
-const DEBRIS_SHADE = 0.5;
+// darkest ambient-occlusion level so debris matches those shadows
+const DEBRIS_SHADE = AO_MIN;
 // deep terrain shouldn't crater: never erode more than this from a span's top
 const MAX_EROSION_PX = 10;
 const RUBBLE_BAND_PX = 22;
@@ -83,7 +84,7 @@ export function buildDebris(input: DebrisInput): void {
       const erosion = Math.min(fractional, Math.max(0, capped));
       const newTop = y + erosion;
       for (let yy = newTop; yy < end; yy++) {
-        const zi = pickZone(zoneMap, width, height, x, yy, seed);
+        const zi = pickZone(zoneMap, width, height, x, yy, seed, landmassMap);
         const colors = debrisColors[zi];
         const t = Math.min(0.999, (yy - newTop) / (RUBBLE_BAND_PX * colors.length));
         const idx = rampIndex(debrisBands[zi], t, x, yy, seed);

--- a/src/data/terrainPaint/debris.ts
+++ b/src/data/terrainPaint/debris.ts
@@ -17,6 +17,8 @@ export interface DebrisInput {
 const KEEP_BASE = 0.4;
 const KEEP_VARIATION = 0.2;
 const ROUGHEN_PX = 3;
+// deep terrain shouldn't crater: never erode more than this from a span's top
+const MAX_EROSION_PX = 48;
 const RUBBLE_BAND_PX = 22;
 const RAIL_WIDTH = 2;
 const RUNG_SPACING = 8;
@@ -51,7 +53,11 @@ export function buildDebris(input: DebrisInput): ImageData {
       const keep =
         KEEP_BASE + noise2d(seed, lm * 131 + (x >> 3), 0) * KEEP_VARIATION;
       const roughen = Math.floor(noise2d(seed, x, lm + 1) * ROUGHEN_PX);
-      const kept = Math.max(0, Math.floor(spanH * keep) - roughen);
+      const kept = Math.max(
+        Math.floor(spanH * keep) - roughen,
+        spanH - MAX_EROSION_PX,
+        0
+      );
       const newTop = Math.max(y, end - kept);
       for (let yy = newTop; yy < end; yy++) {
         const zi = pickZone(zoneMap, width, height, x, yy, seed);

--- a/src/data/terrainPaint/debris.ts
+++ b/src/data/terrainPaint/debris.ts
@@ -50,15 +50,17 @@ export function buildDebris(input: DebrisInput): ImageData {
       while (end < height && landmassMap[end * width + x] === lm) end++;
       const spanH = end - y;
       // coarse noise (8-column steps) shapes the mound; fine noise roughens it
-      const keep =
-        KEEP_BASE + noise2d(seed, lm * 131 + (x >> 3), 0) * KEEP_VARIATION;
+      const mound = noise2d(seed, lm * 131 + (x >> 3), 0);
       const roughen = Math.floor(noise2d(seed, x, lm + 1) * ROUGHEN_PX);
-      const kept = Math.max(
-        Math.floor(spanH * keep) - roughen,
-        spanH - MAX_EROSION_PX,
-        0
-      );
-      const newTop = Math.max(y, end - kept);
+      const keep = KEEP_BASE + mound * KEEP_VARIATION;
+      const fractional = spanH - Math.max(0, Math.floor(spanH * keep) - roughen);
+      // when the fraction would erode deeper than the cap, fall back to a
+      // capped erosion that still varies with the same noise so the edge
+      // stays rough instead of tracking the silhouette as a flat line
+      const capped =
+        MAX_EROSION_PX - Math.floor(mound * (MAX_EROSION_PX / 2)) - roughen;
+      const erosion = Math.min(fractional, Math.max(0, capped));
+      const newTop = y + erosion;
       for (let yy = newTop; yy < end; yy++) {
         const zi = pickZone(zoneMap, width, height, x, yy, seed);
         const colors = rubbleColors[zi];

--- a/src/data/terrainPaint/field.ts
+++ b/src/data/terrainPaint/field.ts
@@ -1,0 +1,73 @@
+const INF = 1e9;
+
+export interface DepthField {
+  /** Distance in px from each solid pixel to the nearest empty pixel; 0 for empty. */
+  depth: Float32Array;
+  /** Distance in px from each solid pixel up to the first empty pixel in its column. */
+  sky: Float32Array;
+}
+
+/**
+ * Chamfer 3-4 distance transform (two passes) plus a per-column sky scan.
+ * Out-of-bounds counts as solid, so terrain touching the map border keeps
+ * full depth instead of reading the border as open air.
+ */
+export function computeField(
+  alpha: Uint8Array,
+  width: number,
+  height: number
+): DepthField {
+  const n = width * height;
+  const depth = new Float32Array(n);
+  for (let i = 0; i < n; i++) depth[i] = alpha[i] ? INF : 0;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = y * width + x;
+      if (depth[i] === 0) continue;
+      let best = depth[i];
+      if (x > 0) best = Math.min(best, depth[i - 1] + 3);
+      if (y > 0) {
+        best = Math.min(best, depth[i - width] + 3);
+        if (x > 0) best = Math.min(best, depth[i - width - 1] + 4);
+        if (x < width - 1) best = Math.min(best, depth[i - width + 1] + 4);
+      }
+      depth[i] = best;
+    }
+  }
+  for (let y = height - 1; y >= 0; y--) {
+    for (let x = width - 1; x >= 0; x--) {
+      const i = y * width + x;
+      if (depth[i] === 0) continue;
+      let best = depth[i];
+      if (x < width - 1) best = Math.min(best, depth[i + 1] + 3);
+      if (y < height - 1) {
+        best = Math.min(best, depth[i + width] + 3);
+        if (x < width - 1) best = Math.min(best, depth[i + width + 1] + 4);
+        if (x > 0) best = Math.min(best, depth[i + width - 1] + 4);
+      }
+      depth[i] = best;
+    }
+  }
+  // chamfer 3-4 weights approximate euclidean distance × 3
+  for (let i = 0; i < n; i++) {
+    if (depth[i] !== 0) depth[i] = depth[i] / 3;
+  }
+
+  const sky = new Float32Array(n);
+  for (let x = 0; x < width; x++) {
+    let run = INF; // the top border counts as solid
+    for (let y = 0; y < height; y++) {
+      const i = y * width + x;
+      if (!alpha[i]) {
+        sky[i] = 0;
+        run = 0;
+      } else {
+        run = run >= INF ? INF : run + 1;
+        sky[i] = run;
+      }
+    }
+  }
+
+  return { depth, sky };
+}

--- a/src/data/terrainPaint/index.ts
+++ b/src/data/terrainPaint/index.ts
@@ -63,7 +63,7 @@ export function paintTerrain(input: PaintInput): PaintResult {
     for (let x = 0; x < width; x++) {
       const i = y * width + x;
       if (!alpha[i]) continue;
-      const zi = pickZone(zoneMap, width, height, x, y, seed);
+      const zi = pickZone(zoneMap, width, height, x, y, seed, landmassMap);
       const theme = THEMES[zones[zi].themeId];
 
       // wobble the depth/sky fields so band boundaries and the color steps

--- a/src/data/terrainPaint/index.ts
+++ b/src/data/terrainPaint/index.ts
@@ -24,7 +24,8 @@ export interface PaintResult {
 }
 
 const OUTLINE_DEPTH = 2.5;
-const DEEP_BAND_PX = 28;
+// each deep-ramp color covers this many px of depth before the next, darker one
+const DEEP_PX_PER_RAMP_STEP = 28;
 
 export function paintTerrain(input: PaintInput): PaintResult {
   const { alpha, width, height, ladders, seed } = input;
@@ -81,7 +82,7 @@ export function paintTerrain(input: PaintInput): PaintResult {
         const t = Math.min(
           0.999,
           (depth[i] - theme.shallow.depth) /
-            (DEEP_BAND_PX * theme.deep.ramp.length)
+            (DEEP_PX_PER_RAMP_STEP * theme.deep.ramp.length)
         );
         hex = theme.deep.ramp[rampIndex(theme.deep, t, x, y, seed)];
       }

--- a/src/data/terrainPaint/index.ts
+++ b/src/data/terrainPaint/index.ts
@@ -21,6 +21,8 @@ export interface PaintResult {
   /** Debris + ladders, transparent elsewhere. */
   background: ImageData;
   zones: ZoneInfo[];
+  /** Zone index per pixel, -1 for empty — lets the UI map clicks to zones. */
+  zoneMap: Int32Array;
 }
 
 const OUTLINE_DEPTH = 2.5;
@@ -58,7 +60,7 @@ export function paintTerrain(input: PaintInput): PaintResult {
       const theme = THEMES[zones[zi].themeId];
 
       let hex: string;
-      if (depth[i] <= OUTLINE_DEPTH) {
+      if (theme.outline && depth[i] <= OUTLINE_DEPTH) {
         hex = theme.outline;
       } else if (sky[i] < theme.surface.thickness) {
         const idx = rampIndex(
@@ -106,5 +108,5 @@ export function paintTerrain(input: PaintInput): PaintResult {
     seed,
   });
 
-  return { terrain, background, zones };
+  return { terrain, background, zones, zoneMap };
 }

--- a/src/data/terrainPaint/index.ts
+++ b/src/data/terrainPaint/index.ts
@@ -1,0 +1,109 @@
+import type { PlainBBox } from "../map/bbox";
+import { buildDebris } from "./debris";
+import { computeField } from "./field";
+import { THEMES } from "./palettes";
+import { createImageData, hexToRgb, pickZone, rampIndex } from "./pixel";
+import { computeZones, type ZoneInfo } from "./zones";
+
+export interface PaintInput {
+  /** Solid bitmap, 1 byte per pixel (non-zero = solid). */
+  alpha: Uint8Array;
+  width: number;
+  height: number;
+  ladders: PlainBBox[];
+  seed: number;
+  themeOverrides?: Record<number, string>;
+}
+
+export interface PaintResult {
+  /** Opaque exactly where the input alpha is solid. */
+  terrain: ImageData;
+  /** Debris + ladders, transparent elsewhere. */
+  background: ImageData;
+  zones: ZoneInfo[];
+}
+
+const OUTLINE_DEPTH = 2.5;
+const DEEP_BAND_PX = 28;
+
+export function paintTerrain(input: PaintInput): PaintResult {
+  const { alpha, width, height, ladders, seed } = input;
+  const { depth, sky } = computeField(alpha, width, height);
+  const { zoneMap, landmassMap, zones } = computeZones(
+    alpha,
+    width,
+    height,
+    seed,
+    input.themeOverrides ?? {}
+  );
+
+  const terrain = createImageData(width, height);
+  const data = terrain.data;
+  const rgbCache = new Map<string, [number, number, number]>();
+  const rgb = (hex: string) => {
+    let v = rgbCache.get(hex);
+    if (!v) {
+      v = hexToRgb(hex);
+      rgbCache.set(hex, v);
+    }
+    return v;
+  };
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = y * width + x;
+      if (!alpha[i]) continue;
+      const zi = pickZone(zoneMap, width, height, x, y, seed);
+      const theme = THEMES[zones[zi].themeId];
+
+      let hex: string;
+      if (depth[i] <= OUTLINE_DEPTH) {
+        hex = theme.outline;
+      } else if (sky[i] < theme.surface.thickness) {
+        const idx = rampIndex(
+          theme.surface,
+          sky[i] / theme.surface.thickness,
+          x,
+          y,
+          seed
+        );
+        hex = theme.surface.ramp[idx];
+      } else if (depth[i] < theme.shallow.depth) {
+        const idx = rampIndex(
+          theme.shallow,
+          depth[i] / theme.shallow.depth,
+          x,
+          y,
+          seed
+        );
+        hex = theme.shallow.ramp[idx];
+      } else {
+        const t = Math.min(
+          0.999,
+          (depth[i] - theme.shallow.depth) /
+            (DEEP_BAND_PX * theme.deep.ramp.length)
+        );
+        hex = theme.deep.ramp[rampIndex(theme.deep, t, x, y, seed)];
+      }
+
+      const [r, g, b] = rgb(hex);
+      const o = i * 4;
+      data[o] = r;
+      data[o + 1] = g;
+      data[o + 2] = b;
+      data[o + 3] = 255;
+    }
+  }
+
+  const background = buildDebris({
+    width,
+    height,
+    zoneMap,
+    landmassMap,
+    zones,
+    ladders,
+    seed,
+  });
+
+  return { terrain, background, zones };
+}

--- a/src/data/terrainPaint/index.ts
+++ b/src/data/terrainPaint/index.ts
@@ -1,8 +1,10 @@
 import type { PlainBBox } from "../map/bbox";
-import { buildDebris } from "./debris";
+import { buildDebris, shadeLadderBases } from "./debris";
+import { buildBackwall } from "./backwall";
 import { computeField } from "./field";
 import { THEMES } from "./palettes";
 import { createImageData, hexToRgb, pickZone, rampIndex } from "./pixel";
+import { noise2d } from "./rng";
 import { computeZones, type ZoneInfo } from "./zones";
 
 export interface PaintInput {
@@ -18,7 +20,7 @@ export interface PaintInput {
 export interface PaintResult {
   /** Opaque exactly where the input alpha is solid. */
   terrain: ImageData;
-  /** Debris + ladders, transparent elsewhere. */
+  /** Themed back-wall + debris + ladders, transparent in open sky. */
   background: ImageData;
   zones: ZoneInfo[];
   /** Zone index per pixel, -1 for empty — lets the UI map clicks to zones. */
@@ -28,6 +30,11 @@ export interface PaintResult {
 const OUTLINE_DEPTH = 2.5;
 // each deep-ramp color covers this many px of depth before the next, darker one
 const DEEP_PX_PER_RAMP_STEP = 28;
+// px of low-frequency wobble added to the sky/depth fields so every depth-based
+// transition — band boundaries AND the color steps within a band — undulates
+// instead of tracing straight contours
+const SKY_JITTER = 4;
+const DEPTH_JITTER = 7;
 
 export function paintTerrain(input: PaintInput): PaintResult {
   const { alpha, width, height, ladders, seed } = input;
@@ -59,22 +66,32 @@ export function paintTerrain(input: PaintInput): PaintResult {
       const zi = pickZone(zoneMap, width, height, x, y, seed);
       const theme = THEMES[zones[zi].themeId];
 
+      // wobble the depth/sky fields so band boundaries and the color steps
+      // within each band undulate; coarse noise keeps the wobble smooth, and
+      // the raw depth still drives the crisp silhouette outline
+      const skyV =
+        sky[i] +
+        (noise2d(seed ^ 0x2f1d35b, x >> 2, y >> 2) - 0.5) * 2 * SKY_JITTER;
+      const depthV =
+        depth[i] +
+        (noise2d(seed ^ 0x77a3c19, x >> 2, y >> 2) - 0.5) * 2 * DEPTH_JITTER;
+
       let hex: string;
       if (theme.outline && depth[i] <= OUTLINE_DEPTH) {
         hex = theme.outline;
-      } else if (sky[i] < theme.surface.thickness) {
+      } else if (skyV < theme.surface.thickness) {
         const idx = rampIndex(
           theme.surface,
-          sky[i] / theme.surface.thickness,
+          skyV / theme.surface.thickness,
           x,
           y,
           seed
         );
         hex = theme.surface.ramp[idx];
-      } else if (depth[i] < theme.shallow.depth) {
+      } else if (depthV < theme.shallow.depth) {
         const idx = rampIndex(
           theme.shallow,
-          depth[i] / theme.shallow.depth,
+          depthV / theme.shallow.depth,
           x,
           y,
           seed
@@ -83,7 +100,7 @@ export function paintTerrain(input: PaintInput): PaintResult {
       } else {
         const t = Math.min(
           0.999,
-          (depth[i] - theme.shallow.depth) /
+          (depthV - theme.shallow.depth) /
             (DEEP_PX_PER_RAMP_STEP * theme.deep.ramp.length)
         );
         hex = theme.deep.ramp[rampIndex(theme.deep, t, x, y, seed)];
@@ -98,7 +115,10 @@ export function paintTerrain(input: PaintInput): PaintResult {
     }
   }
 
-  const background = buildDebris({
+  const background = createImageData(width, height);
+  buildBackwall({ background, width, height, zoneMap, zones, seed });
+  buildDebris({
+    background,
     width,
     height,
     zoneMap,
@@ -107,6 +127,7 @@ export function paintTerrain(input: PaintInput): PaintResult {
     ladders,
     seed,
   });
+  shadeLadderBases(terrain, ladders, width, height);
 
   return { terrain, background, zones, zoneMap };
 }

--- a/src/data/terrainPaint/palettes.ts
+++ b/src/data/terrainPaint/palettes.ts
@@ -18,15 +18,16 @@ export interface Theme {
   deep: MaterialBand;
   rubble: MaterialBand;
   ladder: { rail: string; rung: string };
-  outline: string;
+  /** Pillow-shading silhouette outline; omit to disable for the theme. */
+  outline?: string;
 }
 
-/** Brick coursing: 16×8 bricks offset every other row; last ramp color = mortar. */
+/** Brick coursing: 12×6 bricks offset every other row; last ramp color = mortar. */
 const brickPattern: PatternFn = (x, y, rampIndex, rampLength) => {
-  const row = Math.floor(y / 8);
-  const xo = row % 2 === 1 ? x + 8 : x;
-  if (y % 8 === 7 || xo % 16 === 15) return rampLength - 1;
-  const brickId = Math.floor(xo / 16) + row * 31;
+  const row = Math.floor(y / 6);
+  const xo = row % 2 === 1 ? x + 6 : x;
+  if (y % 6 === 5 || xo % 12 === 11) return rampLength - 1;
+  const brickId = Math.floor(xo / 12) + row * 31;
   return Math.min(rampLength - 2, rampIndex + (brickId % 2));
 };
 
@@ -45,6 +46,15 @@ const rebarPattern: PatternFn = (x, y, rampIndex, rampLength) => {
   return Math.min(rampLength - 2, rampIndex);
 };
 
+/** Horizontal planks: 32×6 boards with staggered end seams; last ramp color = seam. */
+const plankPattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const row = Math.floor(y / 6);
+  const xo = x + ((row * 13) % 32);
+  if (y % 6 === 5 || xo % 32 === 31) return rampLength - 1;
+  const plankId = Math.floor(xo / 32) + row * 17;
+  return Math.min(rampLength - 2, rampIndex + (plankId % 2));
+};
+
 export const THEMES: Record<string, Theme> = {
   grassland: {
     id: "grassland",
@@ -52,9 +62,8 @@ export const THEMES: Record<string, Theme> = {
     surface: { ramp: ["#8bc34a", "#689f38", "#4a7729"], thickness: 12 },
     shallow: { ramp: ["#a9714b", "#8a5a3b", "#6f4730"], depth: 52 },
     deep: { ramp: ["#8a8478", "#6e695f", "#544f47"] },
-    rubble: { ramp: ["#6f5640", "#5a4634", "#463628"] },
+    rubble: { ramp: ["#cbb59b", "#bca68b", "#ad967b"] },
     ladder: { rail: "#6f4730", rung: "#a9714b" },
-    outline: "#2e2a23",
   },
   cave: {
     id: "cave",
@@ -62,7 +71,7 @@ export const THEMES: Record<string, Theme> = {
     surface: { ramp: ["#7d7b74", "#666460"], thickness: 8 },
     shallow: { ramp: ["#5c5a55", "#4c4a46", "#3e3c39"], depth: 48 },
     deep: { ramp: ["#37352f", "#2c2a26", "#211f1c"] },
-    rubble: { ramp: ["#45433e", "#383631", "#2b2925"] },
+    rubble: { ramp: ["#a8a69f", "#97958e", "#86847d"] },
     ladder: { rail: "#5a4634", rung: "#6f5640" },
     outline: "#15140f",
   },
@@ -72,9 +81,8 @@ export const THEMES: Record<string, Theme> = {
     surface: { ramp: ["#f4f8fb", "#dde7ee", "#c2d2dc"], thickness: 12 },
     shallow: { ramp: ["#9aa8b5", "#828f9c", "#6b7884"], depth: 52 },
     deep: { ramp: ["#5d6a78", "#4a5563", "#3a4350"] },
-    rubble: { ramp: ["#76828d", "#616c77", "#4d5761"] },
+    rubble: { ramp: ["#e2e8ee", "#d2dae2", "#c1cbd5"] },
     ladder: { rail: "#5a4634", rung: "#8a5a3b" },
-    outline: "#27303c",
   },
   urban: {
     id: "urban",
@@ -93,11 +101,24 @@ export const THEMES: Record<string, Theme> = {
     },
     rubble: {
       // last color is the rebar rust
-      ramp: ["#6e6e68", "#5a5a55", "#464642", "#8a5a2b"],
+      ramp: ["#c6c6c0", "#b4b4ae", "#a2a29c", "#b97f50"],
       pattern: rebarPattern,
     },
     ladder: { rail: "#4a4d52", rung: "#6e6e68" },
-    outline: "#1d1e20",
+  },
+  planks: {
+    id: "planks",
+    name: "Wood planks",
+    surface: { ramp: ["#c69a6d", "#b08653", "#997243"], thickness: 10 },
+    shallow: {
+      // last color is the board seam
+      ramp: ["#a87f4f", "#967040", "#855f31", "#5a4226"],
+      depth: 56,
+      pattern: plankPattern,
+    },
+    deep: { ramp: ["#6e5233", "#5d4429", "#4c3720"] },
+    rubble: { ramp: ["#dcc39c", "#cdb189", "#bd9f76"] },
+    ladder: { rail: "#5a4226", rung: "#967040" },
   },
 };
 

--- a/src/data/terrainPaint/palettes.ts
+++ b/src/data/terrainPaint/palettes.ts
@@ -22,12 +22,12 @@ export interface Theme {
   outline?: string;
 }
 
-/** Brick coursing: 12×6 bricks offset every other row; last ramp color = mortar. */
+/** Brick coursing: 8×4 bricks offset every other row; last ramp color = mortar. */
 const brickPattern: PatternFn = (x, y, rampIndex, rampLength) => {
-  const row = Math.floor(y / 6);
-  const xo = row % 2 === 1 ? x + 6 : x;
-  if (y % 6 === 5 || xo % 12 === 11) return rampLength - 1;
-  const brickId = Math.floor(xo / 12) + row * 31;
+  const row = Math.floor(y / 4);
+  const xo = row % 2 === 1 ? x + 4 : x;
+  if (y % 4 === 3 || xo % 8 === 7) return rampLength - 1;
+  const brickId = Math.floor(xo / 8) + row * 31;
   return Math.min(rampLength - 2, rampIndex + (brickId % 2));
 };
 
@@ -44,6 +44,16 @@ const rebarPattern: PatternFn = (x, y, rampIndex, rampLength) => {
   const jitter = (cellX * 7 + cellY * 13) % 11;
   if (y % 16 === jitter && x % 40 < 12 + jitter) return rampLength - 1;
   return Math.min(rampLength - 2, rampIndex);
+};
+
+/** Jagged rock facets: diagonal fracture seams flipping direction per cell. */
+const rockPattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const cx = Math.floor(x / 20);
+  const cy = Math.floor(y / 14);
+  const diag = (cx * 31 + cy * 17) % 2 === 0 ? x + y : x - y;
+  if (((diag % 20) + 20) % 20 === 19) return rampLength - 1;
+  const facet = (cx * 13 + cy * 7 + Math.floor(((diag % 60) + 60) / 20)) % 2;
+  return Math.min(rampLength - 2, rampIndex + facet);
 };
 
 /** Horizontal planks: 32×6 boards with staggered end seams; last ramp color = seam. */
@@ -69,11 +79,19 @@ export const THEMES: Record<string, Theme> = {
     id: "cave",
     name: "Cave",
     surface: { ramp: ["#7d7b74", "#666460"], thickness: 8 },
-    shallow: { ramp: ["#5c5a55", "#4c4a46", "#3e3c39"], depth: 48 },
-    deep: { ramp: ["#37352f", "#2c2a26", "#211f1c"] },
+    shallow: {
+      // last color is the fracture seam
+      ramp: ["#5c5a55", "#4c4a46", "#3e3c39", "#23211e"],
+      depth: 48,
+      pattern: rockPattern,
+    },
+    deep: {
+      // last color is the fracture seam
+      ramp: ["#37352f", "#2c2a26", "#211f1c", "#100f0d"],
+      pattern: rockPattern,
+    },
     rubble: { ramp: ["#a8a69f", "#97958e", "#86847d"] },
     ladder: { rail: "#5a4634", rung: "#6f5640" },
-    outline: "#15140f",
   },
   snow: {
     id: "snow",
@@ -119,6 +137,16 @@ export const THEMES: Record<string, Theme> = {
     deep: { ramp: ["#6e5233", "#5d4429", "#4c3720"] },
     rubble: { ramp: ["#dcc39c", "#cdb189", "#bd9f76"] },
     ladder: { rail: "#5a4226", rung: "#967040" },
+  },
+  toon: {
+    id: "toon",
+    name: "Toon",
+    surface: { ramp: ["#7d7b74", "#666460"], thickness: 8 },
+    shallow: { ramp: ["#5c5a55", "#4c4a46", "#3e3c39"], depth: 48 },
+    deep: { ramp: ["#37352f", "#2c2a26", "#211f1c"] },
+    rubble: { ramp: ["#a8a69f", "#97958e", "#86847d"] },
+    ladder: { rail: "#5a4634", rung: "#6f5640" },
+    outline: "#15140f",
   },
 };
 

--- a/src/data/terrainPaint/palettes.ts
+++ b/src/data/terrainPaint/palettes.ts
@@ -1,0 +1,104 @@
+export type PatternFn = (
+  x: number,
+  y: number,
+  rampIndex: number,
+  rampLength: number
+) => number;
+
+export interface MaterialBand {
+  ramp: string[]; // light → dark hex colors
+  pattern?: PatternFn;
+}
+
+export interface Theme {
+  id: string;
+  name: string;
+  surface: MaterialBand & { thickness: number };
+  shallow: MaterialBand & { depth: number };
+  deep: MaterialBand;
+  rubble: MaterialBand;
+  ladder: { rail: string; rung: string };
+  outline: string;
+}
+
+/** Brick coursing: 16×8 bricks offset every other row; last ramp color = mortar. */
+const brickPattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const row = Math.floor(y / 8);
+  const xo = row % 2 === 1 ? x + 8 : x;
+  if (y % 8 === 7 || xo % 16 === 15) return rampLength - 1;
+  const brickId = Math.floor(xo / 16) + row * 31;
+  return Math.min(rampLength - 2, rampIndex + (brickId % 2));
+};
+
+/** Metal plates: 24×16 cells; last ramp color marks the seams. */
+const platePattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  if (y % 16 === 15 || x % 24 === 23) return rampLength - 1;
+  return Math.min(rampLength - 2, rampIndex);
+};
+
+/** Sparse short horizontal rebar streaks on the last ramp color (rust). */
+const rebarPattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const cellX = Math.floor(x / 40);
+  const cellY = Math.floor(y / 16);
+  const jitter = (cellX * 7 + cellY * 13) % 11;
+  if (y % 16 === jitter && x % 40 < 12 + jitter) return rampLength - 1;
+  return Math.min(rampLength - 2, rampIndex);
+};
+
+export const THEMES: Record<string, Theme> = {
+  grassland: {
+    id: "grassland",
+    name: "Grassland",
+    surface: { ramp: ["#8bc34a", "#689f38", "#4a7729"], thickness: 12 },
+    shallow: { ramp: ["#a9714b", "#8a5a3b", "#6f4730"], depth: 52 },
+    deep: { ramp: ["#8a8478", "#6e695f", "#544f47"] },
+    rubble: { ramp: ["#6f5640", "#5a4634", "#463628"] },
+    ladder: { rail: "#6f4730", rung: "#a9714b" },
+    outline: "#2e2a23",
+  },
+  cave: {
+    id: "cave",
+    name: "Cave",
+    surface: { ramp: ["#7d7b74", "#666460"], thickness: 8 },
+    shallow: { ramp: ["#5c5a55", "#4c4a46", "#3e3c39"], depth: 48 },
+    deep: { ramp: ["#37352f", "#2c2a26", "#211f1c"] },
+    rubble: { ramp: ["#45433e", "#383631", "#2b2925"] },
+    ladder: { rail: "#5a4634", rung: "#6f5640" },
+    outline: "#15140f",
+  },
+  snow: {
+    id: "snow",
+    name: "Snow",
+    surface: { ramp: ["#f4f8fb", "#dde7ee", "#c2d2dc"], thickness: 12 },
+    shallow: { ramp: ["#9aa8b5", "#828f9c", "#6b7884"], depth: 52 },
+    deep: { ramp: ["#5d6a78", "#4a5563", "#3a4350"] },
+    rubble: { ramp: ["#76828d", "#616c77", "#4d5761"] },
+    ladder: { rail: "#5a4634", rung: "#8a5a3b" },
+    outline: "#27303c",
+  },
+  urban: {
+    id: "urban",
+    name: "Urban",
+    surface: { ramp: ["#b9b9b3", "#a3a39d"], thickness: 10 },
+    shallow: {
+      // last color is the mortar line
+      ramp: ["#a8503c", "#8f4434", "#76382b", "#55382f"],
+      depth: 64,
+      pattern: brickPattern,
+    },
+    deep: {
+      // last color is the plate seam
+      ramp: ["#5a5e63", "#4a4d52", "#3b3e42", "#2c2e31"],
+      pattern: platePattern,
+    },
+    rubble: {
+      // last color is the rebar rust
+      ramp: ["#6e6e68", "#5a5a55", "#464642", "#8a5a2b"],
+      pattern: rebarPattern,
+    },
+    ladder: { rail: "#4a4d52", rung: "#6e6e68" },
+    outline: "#1d1e20",
+  },
+};
+
+export const THEME_IDS = Object.keys(THEMES);

--- a/src/data/terrainPaint/palettes.ts
+++ b/src/data/terrainPaint/palettes.ts
@@ -1,3 +1,5 @@
+import { noise2d } from "./rng";
+
 export type PatternFn = (
   x: number,
   y: number,
@@ -20,6 +22,8 @@ export interface Theme {
   ladder: { rail: string; rung: string };
   /** Pillow-shading silhouette outline; omit to disable for the theme. */
   outline?: string;
+  /** Lightened background painted into roofed empty pockets; omit to opt out. */
+  backwall?: MaterialBand;
 }
 
 /** Brick coursing: 8×4 bricks offset every other row; last ramp color = mortar. */
@@ -65,6 +69,89 @@ const plankPattern: PatternFn = (x, y, rampIndex, rampLength) => {
   return Math.min(rampLength - 2, rampIndex + (plankId % 2));
 };
 
+// Fixed seed for the position-stable texture noise the back-wall patterns use.
+const PNOISE = 0x51ed2c1f;
+// small ±n integer offset, stable per (x, y), for roughening pattern edges
+const edgeJitter = (x: number, y: number, salt: number, n: number): number =>
+  Math.round((noise2d(PNOISE ^ salt, x, y) - 0.5) * 2 * n);
+
+/** Mineshaft: light rock with crisp vertical timber posts + cross-beams. */
+const minePattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const px = ((x % 40) + 40) % 40;
+  const py = ((y % 56) + 56) % 56;
+  if (px < 7 || py < 6) {
+    if (px === 0 || py === 0) return Math.max(0, rampLength - 3); // lit edge
+    return rampLength - 1; // timber
+  }
+  const mottle = noise2d(PNOISE ^ 9, x >> 1, y >> 1) < 0.4 ? 1 : 0;
+  return Math.min(rampLength - 2, rampIndex + mottle);
+};
+
+/** Dirt: mottled soil with scattered, varied embedded stones. */
+const dirtPattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const cx = Math.floor(x / 17);
+  const cy = Math.floor(y / 15);
+  if (noise2d(PNOISE ^ 21, cx, cy) > 0.74) {
+    const ox = 4 + Math.floor(noise2d(PNOISE ^ 22, cx, cy) * 9);
+    const oy = 4 + Math.floor(noise2d(PNOISE ^ 23, cx, cy) * 7);
+    const rr = 3 + Math.floor(noise2d(PNOISE ^ 24, cx, cy) * 8);
+    const dx = (((x % 17) + 17) % 17) - ox;
+    const dy = (((y % 15) + 15) % 15) - oy;
+    if (dx * dx + dy * dy < rr) {
+      return dy < 0 ? rampLength - 2 : rampLength - 1; // lit top edge / stone
+    }
+  }
+  const clump = noise2d(PNOISE ^ 25, x >> 2, y >> 2);
+  return Math.min(rampLength - 2, clump > 0.6 ? 1 : 0);
+};
+
+/** Girders: light steel with a beveled, riveted I-beam lattice; fuzzy edges. */
+const girderPattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const gx = (((x + edgeJitter(x, y, 1, 2)) % 44) + 44) % 44;
+  const gy = (((y + edgeJitter(x, y, 2, 2)) % 48) + 48) % 48;
+  const onV = gx >= 16 && gx < 28;
+  const onH = gy >= 20 && gy < 29;
+  if ((onV && gy % 12 === 6) || (onH && gx % 12 === 6)) return rampLength - 1; // rivet
+  if (onV || onH) {
+    if ((onV && gx === 16) || (onH && gy === 20)) return 0; // lit edge
+    if ((onV && gx === 27) || (onH && gy === 28)) return rampLength - 2; // shadow edge
+    return rampLength - 3; // beam body
+  }
+  const mottle = noise2d(PNOISE ^ 33, x >> 2, y >> 2) > 0.6 ? 1 : 0;
+  return Math.min(rampLength - 3, rampIndex + mottle);
+};
+
+/** Packed ice: lit strata bands with fuzzy crack seams and embedded stones. */
+const icePattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const yj = y + edgeJitter(x, y, 3, 2);
+  const into = ((yj % 11) + 11) % 11;
+  if (into === 0) return rampLength - 1; // crack seam
+  const cx = Math.floor(x / 24);
+  const cy = Math.floor(y / 19);
+  if (noise2d(PNOISE ^ 31, cx, cy) > 0.8) {
+    const dx = (((x % 24) + 24) % 24) - 6;
+    const dy = (((y % 19) + 19) % 19) - 6;
+    if (dx * dx + dy * dy < 7) return rampLength - 1; // stone
+  }
+  if (into <= 1) return 0; // sheen just below the seam
+  const band = ((Math.floor(yj / 11) % 2) + 2) % 2;
+  return Math.min(rampLength - 2, rampIndex + band);
+};
+
+/** Timber frame: light backing with crisp vertical studs and a diagonal brace. */
+const framePattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const bx = ((x % 34) + 34) % 34;
+  const by = ((y % 34) + 34) % 34;
+  const onStud = bx < 5;
+  const onBrace = Math.abs(bx - by) < 3;
+  if (onStud || onBrace) {
+    if (bx === 0 || bx - by === -2) return Math.max(0, rampLength - 3); // lit edge
+    return rampLength - 1; // timber
+  }
+  const grain = noise2d(PNOISE ^ 41, x >> 2, y) < 0.5 ? 0 : 1;
+  return Math.min(rampLength - 2, rampIndex + grain);
+};
+
 export const THEMES: Record<string, Theme> = {
   grassland: {
     id: "grassland",
@@ -74,6 +161,12 @@ export const THEMES: Record<string, Theme> = {
     deep: { ramp: ["#8a8478", "#6e695f", "#544f47"] },
     rubble: { ramp: ["#cbb59b", "#bca68b", "#ad967b"] },
     ladder: { rail: "#6f4730", rung: "#a9714b" },
+    backwall: {
+      // lightened tints of the foreground dirt (shallow ramp) so the wall reads
+      // as the same earth seen behind the play surface
+      ramp: ["#c89070", "#b27a58", "#996343", "#6f4730"],
+      pattern: dirtPattern,
+    },
   },
   cave: {
     id: "cave",
@@ -92,6 +185,10 @@ export const THEMES: Record<string, Theme> = {
     },
     rubble: { ramp: ["#a8a69f", "#97958e", "#86847d"] },
     ladder: { rail: "#5a4634", rung: "#6f5640" },
+    backwall: {
+      ramp: ["#9a8f82", "#857a6d", "#6b6053", "#43361f"],
+      pattern: minePattern,
+    },
   },
   snow: {
     id: "snow",
@@ -101,6 +198,10 @@ export const THEMES: Record<string, Theme> = {
     deep: { ramp: ["#5d6a78", "#4a5563", "#3a4350"] },
     rubble: { ramp: ["#e2e8ee", "#d2dae2", "#c1cbd5"] },
     ladder: { rail: "#5a4634", rung: "#8a5a3b" },
+    backwall: {
+      ramp: ["#e7eff5", "#d2dde6", "#b9c6d1", "#92a2b0"],
+      pattern: icePattern,
+    },
   },
   urban: {
     id: "urban",
@@ -123,6 +224,10 @@ export const THEMES: Record<string, Theme> = {
       pattern: rebarPattern,
     },
     ladder: { rail: "#4a4d52", rung: "#6e6e68" },
+    backwall: {
+      ramp: ["#bcc1c7", "#a9aeb4", "#969ca3", "#7c848c", "#55606a"],
+      pattern: girderPattern,
+    },
   },
   planks: {
     id: "planks",
@@ -137,6 +242,10 @@ export const THEMES: Record<string, Theme> = {
     deep: { ramp: ["#6e5233", "#5d4429", "#4c3720"] },
     rubble: { ramp: ["#dcc39c", "#cdb189", "#bd9f76"] },
     ladder: { rail: "#5a4226", rung: "#967040" },
+    backwall: {
+      ramp: ["#cba877", "#b1905f", "#8a6c44", "#4f3c24"],
+      pattern: framePattern,
+    },
   },
   toon: {
     id: "toon",

--- a/src/data/terrainPaint/pixel.ts
+++ b/src/data/terrainPaint/pixel.ts
@@ -40,7 +40,7 @@ export function rampIndex(
   if (d < 0.12 && idx > 0) idx--;
   else if (d > 0.88 && idx < len - 1) idx++;
   if (band.pattern) idx = band.pattern(x, y, idx, len);
-  return idx;
+  return Math.max(0, Math.min(len - 1, idx));
 }
 
 /**

--- a/src/data/terrainPaint/pixel.ts
+++ b/src/data/terrainPaint/pixel.ts
@@ -46,6 +46,10 @@ export function rampIndex(
 /**
  * Sample the zone at a jittered position. Near zone seams this dithers
  * pixels between the two zones, producing ragged organic transitions.
+ *
+ * When a landmassMap is given the jittered sample is only adopted if it lands
+ * on the same landmass, so the dither never leaks one island's theme onto a
+ * different island that happens to sit within SEAM_JITTER of it.
  */
 export function pickZone(
   zoneMap: Int32Array,
@@ -53,8 +57,10 @@ export function pickZone(
   height: number,
   x: number,
   y: number,
-  seed: number
+  seed: number,
+  landmassMap?: Int32Array
 ): number {
+  const i = y * width + x;
   const jx = Math.min(
     width - 1,
     Math.max(
@@ -69,6 +75,9 @@ export function pickZone(
       y + Math.round((noise2d(seed ^ 0x85ebca6b, x, y) - 0.5) * 2 * SEAM_JITTER)
     )
   );
-  const zone = zoneMap[jy * width + jx];
-  return zone >= 0 ? zone : zoneMap[y * width + x];
+  const j = jy * width + jx;
+  const zone = zoneMap[j];
+  if (zone < 0) return zoneMap[i];
+  if (landmassMap && landmassMap[j] !== landmassMap[i]) return zoneMap[i];
+  return zone;
 }

--- a/src/data/terrainPaint/pixel.ts
+++ b/src/data/terrainPaint/pixel.ts
@@ -1,0 +1,74 @@
+import type { MaterialBand } from "./palettes";
+import { noise2d } from "./rng";
+
+const SEAM_JITTER = 8;
+
+/** Returns a new tuple; callers in hot loops should cache by hex string. */
+export function hexToRgb(hex: string): [number, number, number] {
+  const v = parseInt(hex.slice(1), 16);
+  return [(v >> 16) & 255, (v >> 8) & 255, v & 255];
+}
+
+/** jsdom has no ImageData constructor in all versions; fall back to a plain shape. */
+export function createImageData(width: number, height: number): ImageData {
+  if (typeof ImageData !== "undefined") {
+    return new ImageData(width, height);
+  }
+  return {
+    data: new Uint8ClampedArray(width * height * 4),
+    width,
+    height,
+    colorSpace: "srgb",
+  } as unknown as ImageData;
+}
+
+/**
+ * Map a position within a band (t in [0, 1), light → dark) to a ramp index,
+ * with ±1 position-stable dither and the band's optional pattern applied last.
+ */
+export function rampIndex(
+  band: MaterialBand,
+  t: number,
+  x: number,
+  y: number,
+  seed: number
+): number {
+  const len = band.ramp.length;
+  let idx = Math.min(len - 1, Math.floor(Math.max(0, t) * len));
+  // decorated seed gives rampIndex a noise stream independent of pickZone's
+  const d = noise2d(seed ^ 0x9e3779b9, x, y);
+  if (d < 0.12 && idx > 0) idx--;
+  else if (d > 0.88 && idx < len - 1) idx++;
+  if (band.pattern) idx = band.pattern(x, y, idx, len);
+  return idx;
+}
+
+/**
+ * Sample the zone at a jittered position. Near zone seams this dithers
+ * pixels between the two zones, producing ragged organic transitions.
+ */
+export function pickZone(
+  zoneMap: Int32Array,
+  width: number,
+  height: number,
+  x: number,
+  y: number,
+  seed: number
+): number {
+  const jx = Math.min(
+    width - 1,
+    Math.max(
+      0,
+      x + Math.round((noise2d(seed, x, y) - 0.5) * 2 * SEAM_JITTER)
+    )
+  );
+  const jy = Math.min(
+    height - 1,
+    Math.max(
+      0,
+      y + Math.round((noise2d(seed ^ 0x85ebca6b, x, y) - 0.5) * 2 * SEAM_JITTER)
+    )
+  );
+  const zone = zoneMap[jy * width + jx];
+  return zone >= 0 ? zone : zoneMap[y * width + x];
+}

--- a/src/data/terrainPaint/rng.ts
+++ b/src/data/terrainPaint/rng.ts
@@ -1,16 +1,3 @@
-export type Rng = () => number;
-
-/** Deterministic PRNG; same seed yields the same sequence on every engine. */
-export function mulberry32(seed: number): Rng {
-  let a = seed >>> 0;
-  return () => {
-    a = (a + 0x6d2b79f5) | 0;
-    let t = Math.imul(a ^ (a >>> 15), 1 | a);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
 /** Position-stable hash noise in [0, 1); independent of evaluation order. */
 export function noise2d(seed: number, x: number, y: number): number {
   let h =

--- a/src/data/terrainPaint/rng.ts
+++ b/src/data/terrainPaint/rng.ts
@@ -1,0 +1,22 @@
+export type Rng = () => number;
+
+/** Deterministic PRNG; same seed yields the same sequence on every engine. */
+export function mulberry32(seed: number): Rng {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Position-stable hash noise in [0, 1); independent of evaluation order. */
+export function noise2d(seed: number, x: number, y: number): number {
+  let h =
+    ((seed | 0) ^ 0x9e3779b9) ^
+    Math.imul(x | 0, 374761393) ^
+    Math.imul(y | 0, 668265263);
+  h = Math.imul(h ^ (h >>> 13), 1274126177);
+  return ((h ^ (h >>> 16)) >>> 0) / 4294967296;
+}

--- a/src/data/terrainPaint/zones.ts
+++ b/src/data/terrainPaint/zones.ts
@@ -1,6 +1,6 @@
 import type { PlainBBox } from "../map/bbox";
-import { THEMES, THEME_IDS } from "./palettes";
-import { mulberry32, noise2d } from "./rng";
+import { THEMES } from "./palettes";
+import { noise2d } from "./rng";
 
 export interface ZoneInfo {
   id: number;
@@ -19,11 +19,9 @@ export interface ZoneResult {
 export const MAX_ZONE_WIDTH = 960; // ~12 WFC tiles
 const BOUNDARY_WOBBLE = 48;
 
-/**
- * Auto-assigned themes never repeat the previous zone's theme (including an
- * overridden one). Overrides are explicit user choices and are exempt: two
- * adjacent overrides may share a theme.
- */
+const DEFAULT_THEME = "grassland";
+
+/** Every zone defaults to grassland; overrides are explicit user choices. */
 export function computeZones(
   alpha: Uint8Array,
   width: number,
@@ -123,18 +121,9 @@ export function computeZones(
     }
   }
 
-  // assign themes left to right, never repeating the previous zone's theme
-  const rng = mulberry32(seed);
-  const order = zones
-    .map((_, idx) => idx)
-    .sort((a, b) => zones[a].bbox.left - zones[b].bbox.left);
-  let prev = "";
-  for (const idx of order) {
-    const candidates = THEME_IDS.filter((t) => t !== prev);
-    const pick = candidates[Math.floor(rng() * candidates.length)];
-    const override = themeOverrides[idx];
-    zones[idx].themeId = override && THEMES[override] ? override : pick;
-    prev = zones[idx].themeId;
+  for (const zone of zones) {
+    const override = themeOverrides[zone.id];
+    zone.themeId = override && THEMES[override] ? override : DEFAULT_THEME;
   }
 
   return { zoneMap, landmassMap, zones };

--- a/src/data/terrainPaint/zones.ts
+++ b/src/data/terrainPaint/zones.ts
@@ -1,0 +1,141 @@
+import type { PlainBBox } from "../map/bbox";
+import { THEMES, THEME_IDS } from "./palettes";
+import { mulberry32, noise2d } from "./rng";
+
+export interface ZoneInfo {
+  id: number;
+  bbox: PlainBBox; // right/bottom exclusive
+  themeId: string;
+}
+
+export interface ZoneResult {
+  /** Zone index per pixel, -1 for empty. */
+  zoneMap: Int32Array;
+  /** Landmass index per pixel, -1 for empty. Zones subdivide landmasses. */
+  landmassMap: Int32Array;
+  zones: ZoneInfo[];
+}
+
+export const MAX_ZONE_WIDTH = 960; // ~12 WFC tiles
+const BOUNDARY_WOBBLE = 48;
+
+/**
+ * Auto-assigned themes never repeat the previous zone's theme (including an
+ * overridden one). Overrides are explicit user choices and are exempt: two
+ * adjacent overrides may share a theme.
+ */
+export function computeZones(
+  alpha: Uint8Array,
+  width: number,
+  height: number,
+  seed: number,
+  themeOverrides: Record<number, string> = {}
+): ZoneResult {
+  const n = width * height;
+  const landmassMap = new Int32Array(n).fill(-1);
+  const landmassBBoxes: PlainBBox[] = [];
+
+  // 4-connected flood fill, iterative
+  const stack: number[] = [];
+  for (let start = 0; start < n; start++) {
+    if (!alpha[start] || landmassMap[start] !== -1) continue;
+    const id = landmassBBoxes.length;
+    const bbox = { left: width, top: height, right: 0, bottom: 0 };
+    landmassMap[start] = id;
+    stack.push(start);
+    while (stack.length) {
+      const i = stack.pop()!;
+      const x = i % width;
+      const y = (i - x) / width;
+      if (x < bbox.left) bbox.left = x;
+      if (x + 1 > bbox.right) bbox.right = x + 1;
+      if (y < bbox.top) bbox.top = y;
+      if (y + 1 > bbox.bottom) bbox.bottom = y + 1;
+      if (x > 0 && alpha[i - 1] && landmassMap[i - 1] === -1) {
+        landmassMap[i - 1] = id;
+        stack.push(i - 1);
+      }
+      if (x < width - 1 && alpha[i + 1] && landmassMap[i + 1] === -1) {
+        landmassMap[i + 1] = id;
+        stack.push(i + 1);
+      }
+      if (y > 0 && alpha[i - width] && landmassMap[i - width] === -1) {
+        landmassMap[i - width] = id;
+        stack.push(i - width);
+      }
+      if (y < height - 1 && alpha[i + width] && landmassMap[i + width] === -1) {
+        landmassMap[i + width] = id;
+        stack.push(i + width);
+      }
+    }
+    landmassBBoxes.push(bbox);
+  }
+
+  // wide landmasses are split into vertical slices with wobbled boundaries
+  const zones: ZoneInfo[] = [];
+  const slicing = landmassBBoxes.map((bbox) => {
+    const count = Math.max(
+      1,
+      Math.ceil((bbox.right - bbox.left) / MAX_ZONE_WIDTH)
+    );
+    const firstZone = zones.length;
+    for (let s = 0; s < count; s++) {
+      zones.push({
+        id: firstZone + s,
+        bbox: { left: width, top: height, right: 0, bottom: 0 },
+        themeId: "",
+      });
+    }
+    return { bbox, count, firstZone };
+  });
+
+  const zoneMap = new Int32Array(n).fill(-1);
+  for (let i = 0; i < n; i++) {
+    const lm = landmassMap[i];
+    if (lm === -1) continue;
+    const x = i % width;
+    const y = (i - x) / width;
+    const { bbox, count, firstZone } = slicing[lm];
+    if (count === 1) {
+      zoneMap[i] = firstZone;
+    } else {
+      const sliceWidth = (bbox.right - bbox.left) / count;
+      let slice = 0;
+      for (let s = 1; s < count; s++) {
+        // coarse row granularity keeps the wobble smooth-ish; the paint
+        // pass dithers the seam so the 16px steps never show
+        const wobble =
+          (noise2d(seed, lm * 97 + s, y >> 4) - 0.5) * BOUNDARY_WOBBLE;
+        if (x >= bbox.left + s * sliceWidth + wobble) slice = s;
+      }
+      zoneMap[i] = firstZone + slice;
+    }
+    const zone = zones[zoneMap[i]];
+    if (x < zone.bbox.left) zone.bbox.left = x;
+    if (x + 1 > zone.bbox.right) zone.bbox.right = x + 1;
+    if (y < zone.bbox.top) zone.bbox.top = y;
+    if (y + 1 > zone.bbox.bottom) zone.bbox.bottom = y + 1;
+  }
+  // a slice can end up with zero pixels when the wobble eats it entirely
+  for (const zone of zones) {
+    if (zone.bbox.left > zone.bbox.right) {
+      zone.bbox = { left: 0, top: 0, right: 0, bottom: 0 };
+    }
+  }
+
+  // assign themes left to right, never repeating the previous zone's theme
+  const rng = mulberry32(seed);
+  const order = zones
+    .map((_, idx) => idx)
+    .sort((a, b) => zones[a].bbox.left - zones[b].bbox.left);
+  let prev = "";
+  for (const idx of order) {
+    const candidates = THEME_IDS.filter((t) => t !== prev);
+    const pick = candidates[Math.floor(rng() * candidates.length)];
+    const override = themeOverrides[idx];
+    zones[idx].themeId = override && THEMES[override] ? override : pick;
+    prev = zones[idx].themeId;
+  }
+
+  return { zoneMap, landmassMap, zones };
+}

--- a/src/data/terrainPaint/zones.ts
+++ b/src/data/terrainPaint/zones.ts
@@ -17,6 +17,11 @@ export interface ZoneResult {
 }
 
 export const MAX_ZONE_WIDTH = 960; // ~12 WFC tiles
+
+/** True for slices whose pixels were all eaten by boundary wobble. */
+export function isEmptyZone(zone: ZoneInfo): boolean {
+  return zone.bbox.right <= zone.bbox.left;
+}
 const BOUNDARY_WOBBLE = 48;
 
 const DEFAULT_THEME = "grassland";
@@ -116,7 +121,7 @@ export function computeZones(
   }
   // a slice can end up with zero pixels when the wobble eats it entirely
   for (const zone of zones) {
-    if (zone.bbox.left > zone.bbox.right) {
+    if (isEmptyZone(zone)) {
       zone.bbox = { left: 0, top: 0, right: 0, bottom: 0 };
     }
   }


### PR DESCRIPTION
## Summary
- Adds a paint-bucket button to the Builder that procedurally textures a wallmask (WFC-generated, imported, or derived from terrain alpha) — no AI round-trip needed.
- New pure-logic module `src/data/terrainPaint/`: seeded RNG, four themes (Grassland, Cave, Snow, Urban with brick/plate/rebar patterns), chamfer depth + per-column sky fields, themed zone partitioning with dithered seams, and a per-pixel band painter (outline → surface lip → shallow → deep).
- Generates a destroyed-terrain background where each landmass collapses into a debris mound strictly inside its original silhouette; ladders are drawn into this layer.
- `TerrainPaintDialog.vue`: live preview, per-zone theme dropdowns, re-roll, background-only toggle. Deterministic — preview equals saved output.
- Maps from this flow carry **no stored wallmask**: terrain alpha is binary (0/255) and exactly matches the mask, so collision derives via `CollisionMask.fromAlpha`. No `Config` format changes.

## Hard invariants (unit-tested at typed-array level)
- Terrain alpha equals input mask alpha exactly
- All output pixels are alpha 0 or 255 (no translucency)
- Debris pixels are a strict subset of the original solid pixels
- Same input + seed → byte-identical output (no `Math.random`/canvas filters)

## Test Plan
- [x] `yarn test --run` — 736 tests pass (48 new in `src/data/terrainPaint/__spec__/`)
- [x] `yarn check-types` — clean
- [x] Manual: WFC generate → paint → themed preview with dithered zone seams, grass lip, depth darkening
- [x] Manual: background-only view shows collapsed debris mounds + ladder rails/rungs
- [x] Manual: confirm sets terrain + background, clears the stored mask (customMask off)
- [x] Manual: Test-play — character collides exactly with painted terrain; Babylon blast reveals the debris layer (incl. Urban rebar streaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)