### PR TITLE
[TIDAL] Spellbook UI theme: torn parchment panels and pixel ornaments

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,8 @@ import { RouterView } from "vue-router";
   <RouterView />
 </template>
 
-<style>
+<style lang="scss">
+@use "./style/ornaments" as o;
 :root {
   --primary: #402020;
   --background: #bca88c;
@@ -26,8 +27,13 @@ import { RouterView } from "vue-router";
   --border-accent-faint: rgba(128, 51, 30, 0.4);
   --parchment-light: #d8c4a4;
   --parchment-dark: #c4a882;
-  --parchment-hover-light: #e0ccac;
-  --parchment-hover-dark: #ccb08a;
+  --field-bg: #e8dcc2;
+  --seal-dark: #5c1d10;
+  --seal-mid: #b05030;
+  --seal-light: #e8d4b4;
+  --tear-depth-heavy: 14px;
+  --tear-depth-light: 8px;
+  --shadow-hard: rgba(40, 20, 5, 0.35);
 }
 
 @property --pulse {
@@ -85,17 +91,15 @@ button {
 }
 
 .primary {
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
+  @include o.dither-surface;
   color: var(--primary);
-  border: 2px solid var(--border-accent);
-  border-radius: 2px;
-  box-shadow: 0 2px 5px rgba(30, 15, 5, 0.3);
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.15);
+  border: 3px solid var(--border-accent);
+  box-shadow: 2px 2px 0 var(--shadow-hard);
   letter-spacing: 1.2px;
   cursor: pointer;
   padding: 8px 20px;
   position: relative;
-  transition: all 0.3s ease;
+  transition: color 0.3s ease, border-color 0.3s ease;
 }
 
 .primary::before,
@@ -122,10 +126,10 @@ button {
 }
 
 .primary:not([disabled]):hover {
-  background: linear-gradient(180deg, var(--parchment-hover-light), var(--parchment-hover-dark));
+  @include o.dither-surface-hover;
   color: var(--highlight);
   border-color: var(--border-accent-hover);
-  box-shadow: 0 2px 5px rgba(30, 15, 5, 0.3), inset 0 0 20px var(--glow-warm-soft);
+  box-shadow: 2px 2px 0 var(--shadow-hard), inset 0 0 20px var(--glow-warm-soft);
 }
 
 .primary:not([disabled]):hover::before,
@@ -180,10 +184,12 @@ button {
 }
 
 .divider-top {
-  background-image: linear-gradient(90deg, transparent, var(--border-accent-faint) 20%, var(--border-accent-faint) 80%, transparent);
-  background-size: 100% 1px;
-  background-repeat: no-repeat;
-  background-position: top;
+  background: repeating-linear-gradient(
+      90deg,
+      var(--border-accent-faint) 0 4px,
+      transparent 4px 8px
+    )
+    top / 100% 2px no-repeat;
   padding-top: 10px;
 }
 
@@ -196,9 +202,11 @@ button {
   color: var(--border-accent);
 
   &::before {
-    content: '◆';
-    font-size: 18px;
-    color: var(--border-accent);
+    content: '';
+    width: 14px;
+    height: 14px;
+    background: o.$diamond center / contain no-repeat;
+    flex-shrink: 0;
   }
 }
 
@@ -473,21 +481,21 @@ a {
     left: 0;
     height: 25px;
     width: 25px;
-    background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
-    border: 1px solid var(--border-accent-faint);
-    border-radius: 2px;
+    @include o.dither-surface;
+    border: 2px solid var(--border-accent-faint);
+    border-radius: 0;
     transition: background 0.2s ease, box-shadow 0.2s ease;
   }
 
   /* On mouse-over, add glow */
   &:hover input ~ .checkmark {
-    background: linear-gradient(180deg, var(--parchment-hover-light), var(--parchment-hover-dark));
+    @include o.dither-surface-hover;
     box-shadow: 0 0 6px var(--glow-warm-soft);
   }
 
   /* When the checkbox is checked */
   input:checked ~ .checkmark {
-    background: linear-gradient(180deg, var(--highlight-background), var(--background-dark));
+    background: var(--highlight-background);
     box-shadow: 0 0 6px var(--glow-warm-soft);
     border-color: var(--border-accent);
   }

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -50,6 +50,8 @@ AssetsContainer.instance.onComplete(() => {
 </template>
 
 <style lang="scss" scoped>
+@use "../style/ornaments" as o;
+
 .background {
   min-height: 100vh;
   box-sizing: border-box;
@@ -58,17 +60,17 @@ AssetsContainer.instance.onComplete(() => {
   background-size: 256px;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 12px;
 
   &--padded {
-    padding: 4vmin 10vmin;
+    padding: 2vmin 6vmin;
     position: relative;
 
     &::before {
       content: '';
       position: absolute;
       inset: 0;
-      box-shadow: 0 0 10vmin inset var(--primary);
+      @include o.pixel-vignette;
       pointer-events: none;
       z-index: 1;
       animation: vignette-breathe 8s ease-in-out infinite;
@@ -102,7 +104,7 @@ AssetsContainer.instance.onComplete(() => {
 
 
       &--big {
-        font-size: 20vw;
+        font-size: 15vw;
         letter-spacing: 0.5vw;
         background: linear-gradient(
           90deg,
@@ -137,31 +139,5 @@ AssetsContainer.instance.onComplete(() => {
     }
   }
 
-  .mainMenu {
-    .list {
-      background: var(--background);
-      box-shadow: 0 0 10px inset var(--primary);
-      padding: 30px;
-      border-radius: 10px;
-
-      button {
-        min-width: 400px;
-        max-width: 100%;
-        font-size: 32px;
-        padding: 10px;
-        letter-spacing: 1.5px;
-      }
-    }
-  }
-}
-
-.book-link {
-  display: inline-block;
-  padding: 20px 0 15px;
-  width: 70px;
-
-  img {
-    scale: 2;
-  }
 }
 </style>

--- a/src/components/atoms/Collapsible.vue
+++ b/src/components/atoms/Collapsible.vue
@@ -30,8 +30,9 @@ const isOpen = ref(defaultOpen);
 </template>
 
 <style lang="scss" scoped>
+@use "../../style/ornaments" as o;
 .card {
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
+  @include o.dither-surface;
   border: 1px solid var(--border-accent-faint);
   border-left: 3px solid var(--border-accent);
   border-radius: 4px;

--- a/src/components/atoms/IconButton.vue
+++ b/src/components/atoms/IconButton.vue
@@ -20,6 +20,7 @@ const { onClick, icon, hoverIcon, title, className } = defineProps<{
 </template>
 
 <style lang="scss" scoped>
+@use "../../style/ornaments" as o;
 .icon-button {
   background: transparent;
   border: 1px solid transparent;
@@ -50,7 +51,7 @@ const { onClick, icon, hoverIcon, title, className } = defineProps<{
   &:hover {
     border-color: var(--border-accent);
     box-shadow: 0 0 8px var(--glow-warm-soft);
-    background: linear-gradient(180deg, var(--parchment-hover-light), var(--parchment-hover-dark));
+    @include o.dither-surface-hover;
 
     .icon {
       &:not(:only-child) {

--- a/src/components/atoms/Input.vue
+++ b/src/components/atoms/Input.vue
@@ -107,9 +107,9 @@ const handleBlur = (event: Event) => {
   }
 
   .input {
-    background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
-    border: 1px solid var(--border-accent-faint);
-    border-radius: var(--small-radius);
+    background: var(--field-bg);
+    border: 2px solid var(--border-accent-faint);
+    border-radius: 0;
     padding: 10px;
     box-shadow: inset 0 1px 3px rgba(30, 15, 5, 0.1);
     outline: none;
@@ -131,7 +131,7 @@ const handleBlur = (event: Event) => {
 
     &:focus {
       border-color: var(--border-accent);
-      box-shadow: inset 0 1px 3px rgba(30, 15, 5, 0.1), 0 0 8px var(--glow-warm-soft);
+      box-shadow: 2px 2px 0 var(--shadow-hard), 0 0 8px var(--glow-warm-soft);
     }
 
     &--invalid {

--- a/src/components/atoms/PixelDivider.vue
+++ b/src/components/atoms/PixelDivider.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+const { label, vertical = false } = defineProps<{
+  label?: string;
+  vertical?: boolean;
+}>();
+</script>
+
+<template>
+  <div
+    class="pixel-divider"
+    :class="{ 'pixel-divider--vertical': vertical }"
+    role="separator"
+  >
+    <span class="line" />
+    <svg class="diamond" viewBox="0 0 7 7" shape-rendering="crispEdges" aria-hidden="true">
+      <path
+        d="M3 0 H4 V1 H5 V2 H6 V3 H7 V4 H6 V5 H5 V6 H4 V7 H3 V6 H2 V5 H1 V4 H0 V3 H1 V2 H2 V1 H3 Z"
+        fill="currentColor"
+      />
+    </svg>
+    <span v-if="label" class="label">{{ label }}</span>
+    <svg
+      v-if="label"
+      class="diamond"
+      viewBox="0 0 7 7"
+      shape-rendering="crispEdges"
+      aria-hidden="true"
+    >
+      <path
+        d="M3 0 H4 V1 H5 V2 H6 V3 H7 V4 H6 V5 H5 V6 H4 V7 H3 V6 H2 V5 H1 V4 H0 V3 H1 V2 H2 V1 H3 Z"
+        fill="currentColor"
+      />
+    </svg>
+    <span class="line" />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@use "../../style/ornaments" as o;
+
+.pixel-divider {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  color: var(--border-accent);
+
+  .line {
+    @include o.stitched-line;
+    flex: 1;
+  }
+
+  .diamond {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+  }
+
+  .label {
+    font-family: Eternal;
+    font-size: 28px;
+  }
+}
+
+.pixel-divider--vertical {
+  flex-direction: column;
+  width: auto;
+  align-self: stretch;
+
+  .line {
+    width: 2px;
+    height: auto;
+    background: repeating-linear-gradient(
+      180deg,
+      var(--border-accent) 0 4px,
+      transparent 4px 8px
+    );
+  }
+}
+</style>

--- a/src/components/atoms/RuneLayer.vue
+++ b/src/components/atoms/RuneLayer.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import arcane from "../../assets/icons/arcane_bright.png";
+import elemental from "../../assets/icons/elemental_bright.png";
+import life from "../../assets/icons/life_bright.png";
+import physical from "../../assets/icons/physical_bright.png";
+
+const glyphs = [
+  { src: arcane, style: { top: "7%", right: "6%", animationDelay: "0s" } },
+  { src: elemental, style: { top: "31%", right: "15%", animationDelay: "0.9s" } },
+  { src: life, style: { top: "56%", right: "8%", animationDelay: "1.7s" } },
+  { src: physical, style: { top: "79%", right: "17%", animationDelay: "2.3s" } },
+];
+</script>
+
+<template>
+  <div class="rune-layer" aria-hidden="true">
+    <img v-for="glyph in glyphs" :key="glyph.src" :src="glyph.src" class="glyph" :style="glyph.style" />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.rune-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+
+  .glyph {
+    position: absolute;
+    scale: 2;
+    image-rendering: pixelated;
+    // `backwards` holds the first keyframe during the staggered delay so the
+    // glyphs don't flash from their base style before the animation starts.
+    animation: rune-glow 2.8s ease-in-out infinite backwards;
+  }
+}
+
+@keyframes rune-glow {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 2px var(--glow-mystic-soft));
+    opacity: 0.4;
+  }
+  50% {
+    filter: drop-shadow(0 0 9px var(--glow-mystic));
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rune-layer .glyph {
+    animation: none;
+    opacity: 0.5;
+  }
+}
+</style>

--- a/src/components/atoms/Tooltip.vue
+++ b/src/components/atoms/Tooltip.vue
@@ -74,13 +74,17 @@ const handleMouseLeave = (event: MouseEvent) => {
         :style="{ left: `${x}px`, top: `${y}px`, width: props.width }"
         :class="className"
       >
-        <slot name="tooltip"> {{ text }}</slot>
+        <div class="tooltip-inner">
+          <slot name="tooltip"> {{ text }}</slot>
+        </div>
       </div>
     </Teleport>
   </div>
 </template>
 
 <style lang="scss" scoped>
+@use "../../style/ornaments" as o;
+
 .tooltip-wrapper {
   display: inline-block;
   width: min-content;
@@ -88,14 +92,20 @@ const handleMouseLeave = (event: MouseEvent) => {
 
 .tooltip {
   position: fixed;
-  padding: 6px;
-
-  border-radius: var(--small-radius);
-  background-color: rgba(0, 0, 0, 0.8);
-  border: 1px solid #000;
-  color: white;
+  // Shadow lives on the outer element; the tear clip-path is on the inner one,
+  // otherwise the clip would cut the drop-shadow off.
+  filter: drop-shadow(2px 2px 0 var(--shadow-hard))
+    drop-shadow(0 2px 6px rgba(0, 0, 0, 0.4));
   translate: var(--horizontal, 0%) var(--vertical, 0%);
   margin: -2px;
+
+  .tooltip-inner {
+    @include o.dither-surface;
+    @include o.tear(o.$tear-light);
+    padding: calc(var(--tear-depth-light) + 4px) calc(var(--tear-depth-light) + 8px);
+    color: var(--primary);
+    font-size: 15px;
+  }
 
   &.horizontal {
     &-left {

--- a/src/components/atoms/TornPanel.vue
+++ b/src/components/atoms/TornPanel.vue
@@ -1,44 +1,35 @@
 <script setup lang="ts">
-const {
-  density = "heavy",
-  tear = "a",
-  title,
-} = defineProps<{
-  density?: "heavy" | "light";
+const { tear = "a" } = defineProps<{
   tear?: "a" | "b";
-  title?: string;
 }>();
 </script>
 
 <template>
-  <div :class="['torn-wrap', `torn-wrap--${density}`]">
-    <div :class="['torn', `torn--${density === 'light' ? 'light' : tear}`]">
-      <div v-if="title" class="title-plate" role="heading" aria-level="2">{{ title }}</div>
+  <div class="torn-wrap">
+    <div :class="['torn', `torn--${tear}`]">
       <div class="content">
-        <template v-if="density === 'heavy'">
-          <svg
-            class="corner corner--tl"
-            viewBox="0 0 10 10"
-            shape-rendering="crispEdges"
-            aria-hidden="true"
-          >
-            <path d="M0 10 V2 H1 V1 H2 V0 H10 V1 H3 V2 H2 V3 H1 V10 Z" fill="currentColor" />
-            <rect x="2" y="2" width="2" height="2" fill="currentColor" />
-            <rect x="5" y="1" width="1" height="1" fill="currentColor" />
-            <rect x="1" y="5" width="1" height="1" fill="currentColor" />
-          </svg>
-          <svg
-            class="corner corner--br"
-            viewBox="0 0 10 10"
-            shape-rendering="crispEdges"
-            aria-hidden="true"
-          >
-            <path d="M0 10 V2 H1 V1 H2 V0 H10 V1 H3 V2 H2 V3 H1 V10 Z" fill="currentColor" />
-            <rect x="2" y="2" width="2" height="2" fill="currentColor" />
-            <rect x="5" y="1" width="1" height="1" fill="currentColor" />
-            <rect x="1" y="5" width="1" height="1" fill="currentColor" />
-          </svg>
-        </template>
+        <svg
+          class="corner corner--tl"
+          viewBox="0 0 10 10"
+          shape-rendering="crispEdges"
+          aria-hidden="true"
+        >
+          <path d="M0 10 V2 H1 V1 H2 V0 H10 V1 H3 V2 H2 V3 H1 V10 Z" fill="currentColor" />
+          <rect x="2" y="2" width="2" height="2" fill="currentColor" />
+          <rect x="5" y="1" width="1" height="1" fill="currentColor" />
+          <rect x="1" y="5" width="1" height="1" fill="currentColor" />
+        </svg>
+        <svg
+          class="corner corner--br"
+          viewBox="0 0 10 10"
+          shape-rendering="crispEdges"
+          aria-hidden="true"
+        >
+          <path d="M0 10 V2 H1 V1 H2 V0 H10 V1 H3 V2 H2 V3 H1 V10 Z" fill="currentColor" />
+          <rect x="2" y="2" width="2" height="2" fill="currentColor" />
+          <rect x="5" y="1" width="1" height="1" fill="currentColor" />
+          <rect x="1" y="5" width="1" height="1" fill="currentColor" />
+        </svg>
         <slot />
       </div>
     </div>
@@ -48,18 +39,15 @@ const {
 <style lang="scss" scoped>
 @use "../../style/ornaments" as o;
 
-.torn-wrap--heavy {
+.torn-wrap {
   filter: drop-shadow(3px 4px 0 var(--shadow-hard));
-}
-
-.torn-wrap--light {
-  filter: drop-shadow(2px 2px 0 var(--shadow-hard));
 }
 
 .torn {
   @include o.dither-surface;
   position: relative;
   box-sizing: border-box;
+  padding: calc(var(--tear-depth-heavy) + 10px);
 
   &--a {
     @include o.tear(o.$tear-heavy-a);
@@ -69,23 +57,11 @@ const {
     @include o.tear(o.$tear-heavy-b);
   }
 
-  &--light {
-    @include o.tear(o.$tear-light);
-  }
-}
-
-.torn-wrap--heavy .torn {
-  padding: calc(var(--tear-depth-heavy) + 10px);
-
   .content {
     @include o.pixel-frame;
     position: relative;
     padding: 16px 20px;
   }
-}
-
-.torn-wrap--light .torn {
-  padding: calc(var(--tear-depth-light) + 6px);
 }
 
 .corner {
@@ -104,18 +80,5 @@ const {
     right: -2px;
     rotate: 180deg;
   }
-}
-
-.title-plate {
-  position: absolute;
-  top: 2px;
-  left: 50%;
-  translate: -50% 0;
-  z-index: 1;
-  font-family: Eternal;
-  font-size: 26px;
-  color: var(--border-accent);
-  padding: 0 14px;
-  white-space: nowrap;
 }
 </style>

--- a/src/components/atoms/TornPanel.vue
+++ b/src/components/atoms/TornPanel.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+const {
+  density = "heavy",
+  tear = "a",
+  title,
+} = defineProps<{
+  density?: "heavy" | "light";
+  tear?: "a" | "b";
+  title?: string;
+}>();
+</script>
+
+<template>
+  <div :class="['torn-wrap', `torn-wrap--${density}`]">
+    <div :class="['torn', `torn--${density === 'light' ? 'light' : tear}`]">
+      <div v-if="title" class="title-plate" role="heading" aria-level="2">{{ title }}</div>
+      <div class="content">
+        <template v-if="density === 'heavy'">
+          <svg
+            class="corner corner--tl"
+            viewBox="0 0 10 10"
+            shape-rendering="crispEdges"
+            aria-hidden="true"
+          >
+            <path d="M0 10 V2 H1 V1 H2 V0 H10 V1 H3 V2 H2 V3 H1 V10 Z" fill="currentColor" />
+            <rect x="2" y="2" width="2" height="2" fill="currentColor" />
+            <rect x="5" y="1" width="1" height="1" fill="currentColor" />
+            <rect x="1" y="5" width="1" height="1" fill="currentColor" />
+          </svg>
+          <svg
+            class="corner corner--br"
+            viewBox="0 0 10 10"
+            shape-rendering="crispEdges"
+            aria-hidden="true"
+          >
+            <path d="M0 10 V2 H1 V1 H2 V0 H10 V1 H3 V2 H2 V3 H1 V10 Z" fill="currentColor" />
+            <rect x="2" y="2" width="2" height="2" fill="currentColor" />
+            <rect x="5" y="1" width="1" height="1" fill="currentColor" />
+            <rect x="1" y="5" width="1" height="1" fill="currentColor" />
+          </svg>
+        </template>
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@use "../../style/ornaments" as o;
+
+.torn-wrap--heavy {
+  filter: drop-shadow(3px 4px 0 var(--shadow-hard));
+}
+
+.torn-wrap--light {
+  filter: drop-shadow(2px 2px 0 var(--shadow-hard));
+}
+
+.torn {
+  @include o.dither-surface;
+  position: relative;
+  box-sizing: border-box;
+
+  &--a {
+    @include o.tear(o.$tear-heavy-a);
+  }
+
+  &--b {
+    @include o.tear(o.$tear-heavy-b);
+  }
+
+  &--light {
+    @include o.tear(o.$tear-light);
+  }
+}
+
+.torn-wrap--heavy .torn {
+  padding: calc(var(--tear-depth-heavy) + 10px);
+
+  .content {
+    @include o.pixel-frame;
+    position: relative;
+    padding: 16px 20px;
+  }
+}
+
+.torn-wrap--light .torn {
+  padding: calc(var(--tear-depth-light) + 6px);
+}
+
+.corner {
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  color: var(--border-accent);
+
+  &--tl {
+    top: -2px;
+    left: -2px;
+  }
+
+  &--br {
+    bottom: -2px;
+    right: -2px;
+    rotate: 180deg;
+  }
+}
+
+.title-plate {
+  position: absolute;
+  top: 2px;
+  left: 50%;
+  translate: -50% 0;
+  z-index: 1;
+  font-family: Eternal;
+  font-size: 26px;
+  color: var(--border-accent);
+  padding: 0 14px;
+  white-space: nowrap;
+}
+</style>

--- a/src/components/atoms/WaxSeal.vue
+++ b/src/components/atoms/WaxSeal.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+const {
+  icon,
+  letter,
+  size = 40,
+} = defineProps<{
+  icon?: string;
+  letter?: string;
+  size?: number;
+}>();
+</script>
+
+<template>
+  <span class="wax-seal" :style="{ '--size': `${size}px` }">
+    <svg viewBox="0 0 13 13" shape-rendering="crispEdges" aria-hidden="true">
+      <path
+        d="M4 0 H9 V1 H11 V2 H12 V4 H13 V9 H12 V11 H11 V12 H9 V13 H4 V12 H2 V11 H1 V9 H0 V4 H1 V2 H2 V1 H4 Z"
+        fill="var(--seal-dark)"
+      />
+      <path d="M4 1 H9 V2 H10 V3 H11 V5 H10 V4 H9 V3 H7 V2 H4 Z" fill="var(--seal-mid)" />
+    </svg>
+    <img v-if="icon" :src="icon" class="emblem" alt="" />
+    <span v-else-if="letter" class="letter">{{ letter }}</span>
+  </span>
+</template>
+
+<style lang="scss" scoped>
+.wax-seal {
+  position: relative;
+  display: inline-block;
+  width: var(--size);
+  height: var(--size);
+
+  svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  .emblem {
+    position: absolute;
+    inset: 25%;
+    image-rendering: pixelated;
+    filter: brightness(1.6) sepia(0.4);
+  }
+
+  .letter {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: Eternal;
+    font-size: calc(var(--size) * 0.45);
+    color: var(--seal-light);
+  }
+}
+</style>

--- a/src/components/molecules/Dialog.vue
+++ b/src/components/molecules/Dialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
 import IconButton from "../atoms/IconButton.vue";
+import TornPanel from "../atoms/TornPanel.vue";
 import close from "pixelarticons/svg/close.svg";
 
 const props = defineProps<{
@@ -58,13 +59,15 @@ watch(
       ref="content"
       :class="{ content: true, 'content--ingame': props.ingame }"
     >
-      <div class="title">
-        <h2>{{ props.title }}</h2>
-        <IconButton title="Close" :onClick="$props.onClose" :icon="close" />
-      </div>
-      <div class="scroller">
-        <slot name="default"></slot>
-      </div>
+      <TornPanel>
+        <div class="title">
+          <h2>{{ props.title }}</h2>
+          <IconButton title="Close" :onClick="$props.onClose" :icon="close" />
+        </div>
+        <div class="scroller">
+          <slot name="default"></slot>
+        </div>
+      </TornPanel>
     </div>
   </dialog>
 </template>
@@ -91,36 +94,6 @@ dialog {
     }
   }
 
-  &:before {
-    content: "";
-    width: 100%;
-    height: 100%;
-    background: url("../../assets/parchment.png");
-    position: absolute;
-    display: block;
-    image-rendering: pixelated;
-    background-size: 256px;
-    border: 3px solid var(--border-accent);
-    border-radius: 4px;
-    box-shadow:
-      0 0 20px inset rgba(64, 32, 32, 0.3),
-      0 4px 20px rgba(0, 0, 0, 0.4),
-      0 0 0 1px var(--border-accent-faint),
-      0 0 0 5px rgba(188, 168, 140, 0.4),
-      0 0 0 6px var(--border-accent-faint);
-    animation: dialog-scale-in 0.2s ease-out;
-  }
-
-  &:after {
-    content: "";
-    position: absolute;
-    inset: 8px;
-    border: 1px solid var(--border-accent-faint);
-    border-radius: 2px;
-    pointer-events: none;
-    animation: dialog-scale-in 0.2s ease-out;
-  }
-
   @keyframes dialog-scale-in {
     from {
       transform: scale(0.95);
@@ -133,9 +106,7 @@ dialog {
   }
 
   .content {
-    padding: 16px 20px;
     position: relative;
-    z-index: 1;
     animation: dialog-scale-in 0.2s ease-out;
 
     &--ingame,

--- a/src/components/molecules/ImageInput.vue
+++ b/src/components/molecules/ImageInput.vue
@@ -130,6 +130,7 @@ function handleDragLeave() {
 </template>
 
 <style lang="scss" scoped>
+@use "../../style/ornaments" as o;
 .image-select-title {
   display: flex;
   justify-content: space-between;
@@ -144,7 +145,7 @@ function handleDragLeave() {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
+    @include o.dither-surface;
     cursor: pointer;
     border: 1px solid var(--border-accent-faint);
     border-radius: var(--small-radius);

--- a/src/components/molecules/PlayerStats.vue
+++ b/src/components/molecules/PlayerStats.vue
@@ -122,6 +122,7 @@ const grade = computed(() => {
 </template>
 
 <style lang="scss" scoped>
+@use "../../style/ornaments" as o;
 .player-stats {
   position: relative;
   width: 180px;
@@ -130,7 +131,7 @@ const grade = computed(() => {
   gap: 6px;
   padding: 3px;
   border-left: 4px solid var(--color);
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
+  @include o.dither-surface;
   border-radius: 4px;
   box-shadow: 0 2px 5px rgba(30, 15, 5, 0.3);
   padding: 8px;

--- a/src/components/molecules/SpellDescription.vue
+++ b/src/components/molecules/SpellDescription.vue
@@ -81,7 +81,6 @@ watch(
   .range-icon {
     width: 14px;
     height: 14px;
-    filter: invert(1);
     vertical-align: middle;
   }
 
@@ -90,9 +89,8 @@ watch(
     font-size: 36px;
     line-height: 1;
     animation: pulse 3s infinite;
-    color: rgb(42, 60, 255);
+    color: #1f2db8;
     filter: brightness(var(--pulse, 1));
-    text-shadow: 1px 1px 1px black;
 
     &.positive {
       color: rgb(62, 102, 62);
@@ -113,7 +111,7 @@ watch(
     .name {
       font-family: Eternal;
       font-size: 22px;
-      color: rgb(73, 87, 245);
+      color: var(--highlight);
     }
 
     .description {

--- a/src/components/organisms/BuilderSettings.vue
+++ b/src/components/organisms/BuilderSettings.vue
@@ -115,20 +115,23 @@ label {
 }
 
 select {
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
-  border: 1px solid var(--border-accent-faint);
-  border-radius: var(--small-radius);
+  background: var(--field-bg);
+  border: 2px solid var(--border-accent-faint);
+  border-radius: 0;
   padding: 10px;
-  box-shadow: inset 0 1px 3px rgba(30, 15, 5, 0.1);
   outline: none;
   font-size: inherit;
   font-family: inherit;
   color: var(--primary);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
 
+  &:hover {
+    border-color: var(--border-accent);
+  }
+
   &:focus {
     border-color: var(--border-accent);
-    box-shadow: inset 0 1px 3px rgba(30, 15, 5, 0.1), 0 0 8px var(--glow-warm-soft);
+    box-shadow: 2px 2px 0 var(--shadow-hard), 0 0 8px var(--glow-warm-soft);
   }
 }
 </style>

--- a/src/components/organisms/EndGameDialog.vue
+++ b/src/components/organisms/EndGameDialog.vue
@@ -87,10 +87,12 @@ onMounted(() => {
     padding: 4px 0;
 
     & + .highlight {
-      background-image: linear-gradient(90deg, transparent, var(--border-accent-faint) 20%, var(--border-accent-faint) 80%, transparent);
-      background-size: 100% 1px;
-      background-repeat: no-repeat;
-      background-position: top;
+      background: repeating-linear-gradient(
+          90deg,
+          var(--border-accent-faint) 0 4px,
+          transparent 4px 8px
+        )
+        top / 100% 2px no-repeat;
       padding-top: 8px;
     }
   }

--- a/src/components/organisms/GameSettings.vue
+++ b/src/components/organisms/GameSettings.vue
@@ -3,6 +3,7 @@ import { ref } from "vue";
 import Dialog from "../molecules/Dialog.vue";
 import Tooltip from "../atoms/Tooltip.vue";
 import Input from "../atoms/Input.vue";
+import TornPanel from "../atoms/TornPanel.vue";
 import { GameSettings } from "../../util/localStorage/settings";
 import IconButton from "../atoms/IconButton.vue";
 import edit from "pixelarticons/svg/pen-square.svg";
@@ -27,42 +28,45 @@ const numberFormatter = new Intl.NumberFormat("en");
 
 <template>
   <section class="game-settings">
-    <h2 class="section-heading">
-      Settings
-      <IconButton
-        v-if="onEdit"
-        title="Edit settings"
-        :onClick="() => (isEditing = true)"
-        :icon="edit"
-      />
-    </h2>
+    <TornPanel tear="a">
+      <h2 class="section-heading">
+        Settings
+        <IconButton
+          v-if="onEdit"
+          title="Edit settings"
+          :onClick="() => (isEditing = true)"
+          :icon="edit"
+        />
+      </h2>
 
-    <ul class="grid">
-      <li v-if="map">
-        <h3>Map</h3>
-        {{ map.replace("_", " ") }}
-      </li>
-      <li>
-        <h3>Game duration</h3>
-        {{ `${numberFormatter.format(settings.gameLength)} minutes` }}
-      </li>
-      <li>
-        <h3>Turn duration</h3>
-        {{ `${numberFormatter.format(settings.turnLength)} seconds` }}
-      </li>
-      <li>
-        <h3>Mana multiplier</h3>
-        {{ `${numberFormatter.format(settings.manaMultiplier)}%` }}
-      </li>
-      <li>
-        <h3>Item spawn chance</h3>
-        {{ `${numberFormatter.format(settings.itemSpawnChance)}%` }}
-      </li>
-      <li>
-        <h3>Visibility</h3>
-        {{ settings.isPrivate ? "Private" : "Public" }}
-      </li>
-    </ul>
+      <ul class="grid">
+        <li v-if="map">
+          <h3>Map</h3>
+          {{ map.replace("_", " ") }}
+        </li>
+        <li>
+          <h3>Game duration</h3>
+          {{ `${numberFormatter.format(settings.gameLength)} minutes` }}
+        </li>
+        <li>
+          <h3>Turn duration</h3>
+          {{ `${numberFormatter.format(settings.turnLength)} seconds` }}
+        </li>
+        <li>
+          <h3>Mana multiplier</h3>
+          {{ `${numberFormatter.format(settings.manaMultiplier)}%` }}
+        </li>
+        <li>
+          <h3>Item spawn chance</h3>
+          {{ `${numberFormatter.format(settings.itemSpawnChance)}%` }}
+        </li>
+        <li>
+          <h3>Visibility</h3>
+          {{ settings.isPrivate ? "Private" : "Public" }}
+        </li>
+      </ul>
+    </TornPanel>
+
     <Dialog :open="isEditing" :onClose="handleClose" title="Edit settings">
       <div class="inputs">
         <Input

--- a/src/components/organisms/Hud.vue
+++ b/src/components/organisms/Hud.vue
@@ -105,105 +105,115 @@ onBeforeUnmount(() => window.clearInterval(id));
 
 <template>
   <div v-if="!!popup" :class="{ popup: true, 'popup--out': popup.out }">
-    <p class="title">{{ popup!.title }}</p>
-    <p class="meta">{{ popup!.meta }}</p>
+    <div class="popup-inner">
+      <p class="title">{{ popup!.title }}</p>
+      <p class="meta">{{ popup!.meta }}</p>
+    </div>
   </div>
   <EndGameDialog v-if="stats" :stats="(stats as AccumulatedStat<unknown>[])" />
 
-  <div :class="{ hud: true, 'hud-open': forceOpen }">
-    <div class="players">
-      <ul>
-        <li class="player" v-for="(player, i) in players">
-          <span :class="{ name: true, active: activePlayer === player }"
-            >{{ player.name }}
-            <IconButton
-              v-if="getServer() && i > 0 && !!player.connection"
-              title="Remove player"
-              :onClick="() => handleKick(i)"
-              :icon="close"
-          /></span>
-          <ul
-            class="characters"
-            :style="{
-              '--max-hp': maxHp,
-              '--team-size': getManager().teamSize,
-            }"
-          >
-            <li
-              v-for="character in player.characters"
-              class="hp"
+  <div class="hud-wrap">
+    <div :class="{ hud: true, 'hud-open': forceOpen }">
+      <div class="players">
+        <ul>
+          <li class="player" v-for="(player, i) in players">
+            <span :class="{ name: true, active: activePlayer === player }"
+              >{{ player.name }}
+              <IconButton
+                v-if="getServer() && i > 0 && !!player.connection"
+                title="Remove player"
+                :onClick="() => handleKick(i)"
+                :icon="close"
+            /></span>
+            <ul
+              class="characters"
               :style="{
-                '--hp': character.hp,
-                background: player.color,
+                '--max-hp': maxHp,
+                '--team-size': getManager().teamSize,
               }"
-            ></li>
-          </ul>
-        </li>
-      </ul>
-    </div>
-    <div class="timer socket">
-      <span
-        :class="{ text: true, timeout: turnTime < 10000 && turnTime > 0 }"
-        >{{ Math.ceil(turnTime / 1000) }}</span
-      >
-    </div>
-    <div class="clock socket">
-      <span
-        :class="{ text: true, timeout: gameTime < 120000 && gameTime > 0 }"
-        >{{ numberFormatter.format(gameTime) }}</span
-      >
-    </div>
-    <div class="mana socket">
-      <span class="mana-bar" :style="{ '--value': (mana / MAX_MANA) * 100 }" />
-      <span class="text">{{ Math.ceil(mana) }}</span>
-    </div>
-    <div class="elements socket">
-      <span
-        class="element"
-        v-for="(value, element) in elements"
-        :style="{
-          '--value': value,
-        }"
-      >
-        <img
-          :src="ELEMENT_MAP[element]"
-          :alt="element"
-          :title="element"
-          class="background"
-        />
-        <img
-          :src="ELEMENT_MAP[element]"
-          :alt="element"
-          :title="element"
-          class="foreground"
-        />
-      </span>
+            >
+              <li
+                v-for="character in player.characters"
+                class="hp"
+                :style="{
+                  '--hp': character.hp,
+                  background: player.color,
+                }"
+              ></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+      <div class="timer socket">
+        <span
+          :class="{ text: true, timeout: turnTime < 10000 && turnTime > 0 }"
+          >{{ Math.ceil(turnTime / 1000) }}</span
+        >
+      </div>
+      <div class="clock socket">
+        <span
+          :class="{ text: true, timeout: gameTime < 120000 && gameTime > 0 }"
+          >{{ numberFormatter.format(gameTime) }}</span
+        >
+      </div>
+      <div class="mana socket">
+        <span class="mana-bar" :style="{ '--value': (mana / MAX_MANA) * 100 }" />
+        <span class="text">{{ Math.ceil(mana) }}</span>
+      </div>
+      <div class="elements socket">
+        <span
+          class="element"
+          v-for="(value, element) in elements"
+          :style="{
+            '--value': value,
+          }"
+        >
+          <img
+            :src="ELEMENT_MAP[element]"
+            :alt="element"
+            :title="element"
+            class="background"
+          />
+          <img
+            :src="ELEMENT_MAP[element]"
+            :alt="element"
+            :title="element"
+            class="foreground"
+          />
+        </span>
+      </div>
     </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
+@use "../../style/ornaments" as o;
 .popup {
   position: absolute;
   top: 20vh;
   left: 50%;
   transform: translate(-50%, -50%);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  font-size: 48px;
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
-  border: 2px solid var(--border-accent);
-  padding: 10px;
   width: 50%;
-  border-radius: 4px;
   pointer-events: none;
   animation: slide-in 0.5s 1;
-  font-family: Eternal;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--border-accent-faint), 0 0 0 5px rgba(188, 168, 140, 0.4), 0 0 0 6px var(--border-accent-faint);
+  // Shadow on the wrapper; the tear clip-path is on the inner element so the
+  // shadow isn't clipped away.
+  filter: drop-shadow(2px 2px 0 var(--shadow-hard))
+    drop-shadow(0 4px 16px rgba(0, 0, 0, 0.4));
 
   &--out {
     animation: slide-out 0.5s 1 forwards;
+  }
+
+  .popup-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-size: 48px;
+    font-family: Eternal;
+    @include o.dither-surface;
+    @include o.tear(o.$tear-light);
+    padding: calc(var(--tear-depth-light) + 10px);
   }
 
   .meta {
@@ -229,10 +239,15 @@ onBeforeUnmount(() => window.clearInterval(id));
   }
 }
 
-.hud {
+.hud-wrap {
   position: absolute;
   bottom: 0;
   left: 0;
+  margin: 20px;
+  filter: drop-shadow(2px 2px 0 var(--shadow-hard));
+}
+
+.hud {
   cursor: url("../../assets/pointer.png"), auto;
 
   display: grid;
@@ -242,16 +257,13 @@ onBeforeUnmount(() => window.clearInterval(id));
     "mana mana mana"
     "elements elements elements";
 
-  padding: 10px;
+  padding: calc(var(--tear-depth-light) + 2px);
   gap: 10px;
-  margin: 20px;
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
+  @include o.dither-surface;
+  @include o.tear(o.$tear-light);
   width: 200px;
-  border: 2px solid var(--border-accent);
-  border-radius: 4px;
   overflow: hidden;
   transition: all 0.5s;
-  box-shadow: 0 2px 10px rgba(30, 15, 5, 0.4), inset 0 0 15px rgba(180, 120, 40, 0.08);
   .text {
     display: block;
     margin-bottom: -4px;
@@ -325,10 +337,12 @@ onBeforeUnmount(() => window.clearInterval(id));
   .clock,
   .mana,
   .elements {
-    background-image: linear-gradient(90deg, transparent, var(--border-accent-faint) 20%, var(--border-accent-faint) 80%, transparent);
-    background-size: 100% 1px;
-    background-repeat: no-repeat;
-    background-position: top;
+    background: repeating-linear-gradient(
+        90deg,
+        var(--border-accent-faint) 0 4px,
+        transparent 4px 8px
+      )
+      top / 100% 2px no-repeat;
     padding-top: 10px;
   }
 

--- a/src/components/organisms/Inventory.vue
+++ b/src/components/organisms/Inventory.vue
@@ -246,6 +246,7 @@ const getElementFilter = (element: Element) =>
 </template>
 
 <style lang="scss" scoped>
+@use "../../style/ornaments" as o;
 .clip {
   --size: 48px;
 
@@ -269,13 +270,12 @@ const getElementFilter = (element: Element) =>
   display: flex;
   flex-direction: column;
   gap: 3px;
-  border: 2px solid var(--border-accent);
-  border-radius: 4px;
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
-  box-shadow: 0 2px 8px rgba(30, 15, 5, 0.3);
+  @include o.dither-surface;
+  @include o.tear(o.$tear-light);
+  filter: drop-shadow(2px 2px 0 var(--shadow-hard));
   pointer-events: all;
   cursor: url("../../assets/pointer.png"), auto;
-  padding: 6px;
+  padding: calc(var(--tear-depth-light) + 2px);
 
   .control {
     width: var(--size);
@@ -344,16 +344,16 @@ const getElementFilter = (element: Element) =>
 .wrapper {
   transition: transform 0.5s;
   transform: translateX(calc(100% + 2vw));
+  filter: drop-shadow(2px 2px 0 var(--shadow-hard));
 
   &.isOpen {
     transform: translateX(0);
   }
 
   .inventory {
-    border: 2px solid var(--border-accent);
-    border-radius: 4px;
-    background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
-    box-shadow: -4px 0 15px rgba(30, 15, 5, 0.3);
+    @include o.dither-surface;
+    @include o.tear(o.$tear-light);
+    padding: 2px;
     pointer-events: all;
     cursor: url("../../assets/pointer.png"), auto;
 
@@ -384,7 +384,7 @@ const getElementFilter = (element: Element) =>
         }
 
         &:hover {
-          background: linear-gradient(180deg, var(--parchment-hover-light), var(--parchment-hover-dark));
+          @include o.dither-surface-hover;
           box-shadow: inset 0 0 8px var(--glow-warm-soft);
         }
 

--- a/src/components/organisms/LobbyChat.vue
+++ b/src/components/organisms/LobbyChat.vue
@@ -7,6 +7,7 @@ import { Manager } from "../../data/network/manager";
 import type { ChatEntry } from "../../data/network/types";
 import ChatParticles from "../molecules/ChatParticles.vue";
 import IconButton from "../atoms/IconButton.vue";
+import TornPanel from "../atoms/TornPanel.vue";
 
 const props = defineProps<{
   manager: Manager;
@@ -69,23 +70,30 @@ const handleChatMessage = (_entry: ChatEntry, byMe: boolean) => {
   });
 };
 
+const observeMessages = () => {
+  resizeObserver?.disconnect();
+  if (messageList.value) {
+    resizeObserver?.observe(messageList.value);
+  }
+};
+
 onMounted(() => {
   props.manager.onChatMessage = handleChatMessage;
+  if (typeof ResizeObserver !== "undefined") {
+    // Re-pin to bottom on every clientHeight change (open/close
+    // transitions, hover, etc). Without this, growing the container
+    // (e.g. on hover) lets the browser clamp scrollTop down to fit
+    // the bigger window — and that smaller scrollTop sticks when the
+    // container shrinks back, leaving the last line off-center.
+    resizeObserver = new ResizeObserver(() => {
+      if (!isOpen.value || wasAtBottom.value) {
+        scrollToBottom();
+      }
+    });
+  }
   nextTick(() => {
     scrollToBottom();
-    if (messageList.value && typeof ResizeObserver !== "undefined") {
-      // Re-pin to bottom on every clientHeight change (open/close
-      // transitions, hover, etc). Without this, growing the container
-      // (e.g. on hover) lets the browser clamp scrollTop down to fit
-      // the bigger window — and that smaller scrollTop sticks when the
-      // container shrinks back, leaving the last line off-center.
-      resizeObserver = new ResizeObserver(() => {
-        if (!isOpen.value || wasAtBottom.value) {
-          scrollToBottom();
-        }
-      });
-      resizeObserver.observe(messageList.value);
-    }
+    observeMessages();
   });
 });
 
@@ -98,12 +106,13 @@ onUnmounted(() => {
 });
 
 watch(isOpen, (open) => {
-  if (open) {
-    nextTick(() => {
-      scrollToBottom();
-      inputEl.value?.focus();
-    });
-  }
+  // The messages element is recreated when switching between the open
+  // panel and the collapsed bar, so re-attach the observer to the new node.
+  nextTick(() => {
+    observeMessages();
+    scrollToBottom();
+    if (open) inputEl.value?.focus();
+  });
 });
 
 const open = () => {
@@ -138,47 +147,48 @@ const containerClass = computed(() => ({
   <div :class="containerClass">
     <ChatParticles ref="particles" class="particles-layer" />
 
-    <button
-      v-if="!isOpen"
-      class="open-trigger"
-      type="button"
-      @click="open"
-      title="Open chat"
-    />
-
-    <IconButton
-      v-else
-      class="close-btn"
-      :icon="closeIcon"
-      title="Close chat"
-      :onClick="close"
-    />
-
-    <div
-      ref="messageList"
-      class="messages"
-      @scroll="handleScroll"
-    >
-      <div
-        v-for="msg in messages"
-        :key="msg.id"
-        class="message"
-      >
-        <span class="author" :style="{ color: msg.color }">{{ msg.author }}</span>:
-        {{ msg.text }}
-      </div>
-    </div>
-
-    <div v-if="isOpen" class="input-row">
-      <input
-        ref="inputEl"
-        v-model="draft"
-        class="input"
-        type="text"
-        maxlength="200"
-        @keydown="handleKey"
+    <TornPanel tear="b" class="panel">
+      <IconButton
+        v-if="isOpen"
+        class="close-btn"
+        :icon="closeIcon"
+        title="Close chat"
+        :onClick="close"
       />
-    </div>
+      <button
+        v-else
+        class="open-trigger"
+        type="button"
+        @click="open"
+        title="Open chat"
+      />
+
+      <div
+        ref="messageList"
+        class="messages"
+        @scroll="handleScroll"
+      >
+        <div
+          v-for="msg in messages"
+          :key="msg.id"
+          class="message"
+        >
+          <span class="author" :style="{ color: msg.color }">{{ msg.author }}</span>:
+          {{ msg.text }}
+        </div>
+      </div>
+
+      <div v-if="isOpen" class="input-row">
+        <input
+          ref="inputEl"
+          v-model="draft"
+          class="input"
+          type="text"
+          maxlength="200"
+          @keydown="handleKey"
+        />
+      </div>
+    </TornPanel>
   </div>
 </template>
 
@@ -186,31 +196,29 @@ const containerClass = computed(() => ({
 .lobby-chat {
   position: fixed;
   right: 24px;
-  bottom: 0;
-  width: 340px;
-  height: 36px;
+  // Collapsed: pushed below the edge so only the top of the panel (torn edge,
+  // frame and a single message line) peeks above the bottom of the screen.
+  bottom: -44px;
+  width: 380px;
+  height: 116px;
   box-sizing: border-box;
   z-index: 50;
 
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
-  border: 2px solid var(--border-accent);
-  border-radius: 4px 4px 0 0;
-  box-shadow:
-    0 2px 5px rgba(30, 15, 5, 0.3),
-    0 -4px 20px rgba(0, 0, 0, 0.3);
-
-  transition: height 0.3s ease-out;
+  transition: height 0.3s ease-out, bottom 0.3s ease-out;
+  filter: drop-shadow(2px 2px 0 var(--shadow-hard))
+    drop-shadow(0 3px 10px rgba(0, 0, 0, 0.45));
 
   display: flex;
   flex-direction: column;
 
   &:not(.lobby-chat--open):hover {
-    height: 42px;
+    bottom: -28px;
   }
 }
 
 .lobby-chat--open {
-  height: 400px;
+  height: 440px;
+  bottom: 12px;
 }
 
 .lobby-chat--flash {
@@ -219,16 +227,24 @@ const containerClass = computed(() => ({
 
 @keyframes chat-flash {
   0%, 100% {
-    box-shadow:
-      0 2px 5px rgba(30, 15, 5, 0.3),
-      0 -4px 20px rgba(0, 0, 0, 0.3);
+    filter: drop-shadow(2px 2px 0 var(--shadow-hard))
+      drop-shadow(0 3px 10px rgba(0, 0, 0, 0.45));
   }
   50% {
-    box-shadow:
-      0 2px 5px rgba(30, 15, 5, 0.3),
-      0 -4px 30px rgba(255, 220, 140, 0.6);
+    filter: drop-shadow(2px 2px 0 var(--shadow-hard))
+      drop-shadow(0 -4px 12px rgba(255, 220, 140, 0.6));
   }
 }
+
+.panel,
+.panel :deep(.torn),
+.panel :deep(.content) {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 
 .particles-layer {
   position: absolute;

--- a/src/components/organisms/MapSelect.vue
+++ b/src/components/organisms/MapSelect.vue
@@ -4,6 +4,7 @@ import { onMounted, ref } from "vue";
 import { Assets } from "pixi.js";
 import { Config, Map } from "../../data/map";
 import { DefaultMap, defaultMaps } from "../../util/assets/constants";
+import TornPanel from "../atoms/TornPanel.vue";
 
 const { onEdit, defaultMap } = defineProps<{
   onEdit: (map: Config, name: string) => void;
@@ -122,57 +123,61 @@ onMounted(() => reset());
 
 <template>
   <section class="map-select">
-    <div class="map-preview">
-      <div class="custom-select">
-        <select @change="handleChange">
-          <option
-            v-if="!defaultMap"
-            :value="EMPTY"
-            :selected="selectedMap.map === EMPTY"
-          >
-            Select map...
-          </option>
-          <option
-            v-for="({ path }, map) in defaultMaps"
-            :value="map"
-            :selected="selectedMap.path === path"
-          >
-            {{ map.replace("_", " ") }}
-          </option>
-          <option :value="CUSTOM" :selected="selectedMap.map === CUSTOM">
-            Upload custom map
-          </option>
-        </select>
-      </div>
-      <img v-if="mapPath" :src="mapPath" />
-      <div v-else-if="selectedMap.map !== EMPTY" class="center-wrapper">
-        <span class="icon spinner">߷</span>
-      </div>
-      <input
-        type="file"
-        accept="image/*"
-        hidden
-        @change="handleUploadMap"
-        @cancel="reset"
-        ref="customUpload"
-      />
-    </div>
-    <ul v-if="selectedMap.map in defaultMaps" class="info">
-      <li>
-        <h3>Author</h3>
-        {{ selectedMap.author }}
-      </li>
+    <TornPanel tear="b">
+      <div class="layout">
+        <div class="map-preview">
+          <div class="custom-select">
+            <select @change="handleChange">
+              <option
+                v-if="!defaultMap"
+                :value="EMPTY"
+                :selected="selectedMap.map === EMPTY"
+              >
+                Select map...
+              </option>
+              <option
+                v-for="({ path }, map) in defaultMaps"
+                :value="map"
+                :selected="selectedMap.path === path"
+              >
+                {{ map.replace("_", " ") }}
+              </option>
+              <option :value="CUSTOM" :selected="selectedMap.map === CUSTOM">
+                Upload custom map
+              </option>
+            </select>
+          </div>
+          <img v-if="mapPath" :src="mapPath" />
+          <div v-else-if="selectedMap.map !== EMPTY" class="center-wrapper">
+            <span class="icon spinner">߷</span>
+          </div>
+          <input
+            type="file"
+            accept="image/*"
+            hidden
+            @change="handleUploadMap"
+            @cancel="reset"
+            ref="customUpload"
+          />
+        </div>
+        <ul v-if="selectedMap.map in defaultMaps" class="info">
+          <li>
+            <h3>Author</h3>
+            {{ selectedMap.author }}
+          </li>
 
-      <li>
-        <h3>Recommended character count</h3>
-        {{ selectedMap.recommendedCharacterCount }}
-      </li>
+          <li>
+            <h3>Recommended character count</h3>
+            {{ selectedMap.recommendedCharacterCount }}
+          </li>
 
-      <li v-if="selectedMap.theme">
-        <h3>Theme</h3>
-        {{ selectedMap.theme }}
-      </li>
-    </ul>
+          <li v-if="selectedMap.theme">
+            <h3>Theme</h3>
+            {{ selectedMap.theme }}
+          </li>
+        </ul>
+      </div>
+    </TornPanel>
   </section>
 </template>
 
@@ -186,24 +191,24 @@ select {
   appearance: none;
   -webkit-appearance: none; /*  safari  */
   width: 100%;
-  padding: 10px 6px;
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
+  padding: 10px 28px 10px 10px;
+  background: var(--field-bg);
   color: var(--primary);
   cursor: pointer;
-  border: none;
-  border-bottom: 2px solid var(--border-accent);
+  border: 2px solid var(--border-accent-faint);
+  border-radius: 0;
   font-size: 18px;
   font-family: Eternal;
-  transition: border-color 0.3s ease;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
 
   &:hover {
-    border-bottom-color: var(--border-accent-hover);
+    border-color: var(--border-accent);
   }
 
   &:focus {
     outline: none;
-    border-bottom-color: var(--border-accent-hover);
-    box-shadow: 0 2px 6px var(--glow-warm-soft);
+    border-color: var(--border-accent);
+    box-shadow: 2px 2px 0 var(--shadow-hard), 0 0 8px var(--glow-warm-soft);
   }
 }
 
@@ -212,29 +217,32 @@ select {
   --size: 0.3rem;
   content: "";
   position: absolute;
-  right: 6px;
+  right: 10px;
   pointer-events: none;
 }
 
 .custom-select::before {
   border-left: var(--size) solid transparent;
   border-right: var(--size) solid transparent;
-  border-bottom: var(--size) solid black;
-  top: 40%;
+  border-bottom: var(--size) solid var(--border-accent);
+  top: 38%;
 }
 
 .custom-select::after {
   border-left: var(--size) solid transparent;
   border-right: var(--size) solid transparent;
-  border-top: var(--size) solid black;
-  top: 55%;
+  border-top: var(--size) solid var(--border-accent);
+  top: 57%;
 }
 
 .map-select {
   margin-top: 10px;
-  display: flex;
-  flex-direction: row;
-  gap: 20px;
+
+  .layout {
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+  }
 
   .info {
     display: flex;
@@ -246,27 +254,30 @@ select {
 .map-preview {
   display: flex;
   flex-direction: column;
+  gap: 8px;
   width: 250px;
   height: 200px;
   align-items: center;
-  border: 2px solid var(--border-accent);
-  border-radius: 4px;
   overflow: hidden;
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
-  box-shadow: 0 2px 8px rgba(30, 15, 5, 0.3);
 
   .center-wrapper {
     flex: 1;
+    align-self: stretch;
     display: flex;
     align-items: center;
     justify-content: center;
+    border: 2px solid var(--border-accent-faint);
+    box-sizing: border-box;
   }
 
   img {
-    height: 160px;
+    flex: 1;
+    min-height: 0;
     width: 100%;
     object-fit: cover;
     image-rendering: pixelated;
+    border: 2px solid var(--border-accent-faint);
+    box-sizing: border-box;
   }
 }
 

--- a/src/components/organisms/ServerList.vue
+++ b/src/components/organisms/ServerList.vue
@@ -7,6 +7,8 @@ import {
   type LobbyEntry,
 } from "../../data/network/lobbyAnnouncement";
 import { joinByKey } from "../../data/network/joinByKey";
+import TornPanel from "../atoms/TornPanel.vue";
+import PixelDivider from "../atoms/PixelDivider.vue";
 
 const router = useRouter();
 const lobbies = ref<LobbyEntry[]>([]);
@@ -39,39 +41,43 @@ const numberFormatter = new Intl.NumberFormat("en");
 </script>
 
 <template>
-  <section v-if="lobbies.length > 0" class="server-list">
-    <h2>Public games</h2>
+  <TornPanel v-if="lobbies.length > 0" tear="b" class="server-list">
+    <h2 class="section-heading">Public games</h2>
     <ul>
-      <li v-for="entry in lobbies" :key="entry.joinKey">
-        <button
-          class="primary entry"
-          :disabled="entry.playerCount >= entry.maxPlayers"
-          @click="handleJoin(entry)"
-        >
-          <span class="host">{{ entry.hostName }}</span>
-          <span class="map">{{ entry.mapName.replace("_", " ") || "—" }}</span>
-          <span class="meta">
-            {{ entry.playerCount }}/{{ entry.maxPlayers }} ·
-            team {{ entry.gameSettings.teamSize }} ·
-            {{ numberFormatter.format(entry.gameSettings.turnLength) }}s turn
-          </span>
-        </button>
-      </li>
+      <template v-for="(entry, index) in lobbies" :key="entry.joinKey">
+        <li v-if="index > 0" class="separator"><PixelDivider /></li>
+        <li>
+          <button
+            class="entry"
+            :disabled="entry.playerCount >= entry.maxPlayers"
+            @click="handleJoin(entry)"
+          >
+            <span class="host">{{ entry.hostName }}</span>
+            <span class="map">{{ entry.mapName.replace("_", " ") || "—" }}</span>
+            <span class="meta">
+              {{ entry.playerCount }}/{{ entry.maxPlayers }} ·
+              team {{ entry.gameSettings.teamSize }} ·
+              {{ numberFormatter.format(entry.gameSettings.turnLength) }}s turn
+            </span>
+          </button>
+        </li>
+      </template>
     </ul>
-  </section>
+  </TornPanel>
 </template>
 
 <style lang="scss" scoped>
 .server-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
   min-width: 320px;
 
   ul {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    margin-top: 14px;
+  }
+
+  .separator {
+    padding: 6px 0;
   }
 
   .entry {
@@ -81,8 +87,21 @@ const numberFormatter = new Intl.NumberFormat("en");
     gap: 4px;
     width: 100%;
     text-align: left;
-    padding: 8px 16px;
+    padding: 8px 6px;
     font-family: Eternal;
+    background: none;
+    border: none;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+
+    &:hover:not([disabled]) {
+      background-color: rgba(128, 51, 30, 0.08);
+    }
+
+    &[disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
 
     .host {
       font-size: 24px;

--- a/src/components/organisms/TeamDisplay.vue
+++ b/src/components/organisms/TeamDisplay.vue
@@ -32,7 +32,9 @@ const handleDelete = (event: Event) => {
     @click="() => onEdit?.(player)"
   >
     <TornPanel tear="a">
-      <div class="sprite" aria-hidden="true" />
+      <div class="portrait" aria-hidden="true">
+        <div class="sprite" />
+      </div>
       <div class="header">
         <h2 class="player-name">{{ player.name }}</h2>
         <div class="buttons">
@@ -76,8 +78,17 @@ const handleDelete = (event: Event) => {
     }
   }
 
-  // Anchored to TornPanel's .content (position: relative); the panel's
-  // tear clip-path keeps the oversized art within the parchment silhouette.
+  // Clips the oversized portrait to TornPanel's inner frame so the artwork can
+  // never poke through the border — independent of how many character rows the
+  // panel ends up with (a 2-character team is much shorter than a 4-character
+  // one). Sibling of the corner ornaments so those stay unclipped.
+  .portrait {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+  }
+
   // Starts below the name/subtitle so the text never sits on the artwork.
   .sprite {
     background: url("../../assets/characters.png");
@@ -85,12 +96,11 @@ const handleDelete = (event: Event) => {
     background-size: 500%;
     background-position-x: calc(var(--team-offset) * 25%);
     position: absolute;
-    top: 34px;
+    top: 18px;
     left: 50%;
     width: 100px;
     height: 200px;
     translate: -50% 0%;
-    pointer-events: none;
   }
 
   .header {

--- a/src/components/organisms/TeamDisplay.vue
+++ b/src/components/organisms/TeamDisplay.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { COLORS } from "../../data/network/constants";
 import IconButton from "../atoms/IconButton.vue";
+import TornPanel from "../atoms/TornPanel.vue";
 import { IPlayer } from "../types";
 import close from "pixelarticons/svg/close.svg";
 
@@ -11,7 +12,11 @@ const { onDelete, onEdit, player, subTitle } = defineProps<{
   onEdit?: (IPlayer: IPlayer) => void;
 }>();
 
-const offset = COLORS.length - COLORS.indexOf(player.color) - 1;
+// Fall back to the first frame when the colour isn't an exact COLORS match
+// (e.g. a serialised colour from the network), otherwise indexOf(-1) pushes
+// background-position-x off the sprite sheet and the preview renders blank.
+const colorIndex = Math.max(0, COLORS.indexOf(player.color));
+const offset = COLORS.length - colorIndex - 1;
 
 const handleDelete = (event: Event) => {
   event.stopPropagation();
@@ -26,71 +31,77 @@ const handleDelete = (event: Event) => {
     :is="onEdit ? 'button' : 'div'"
     @click="() => onEdit?.(player)"
   >
-    <div class="header">
-      <h2 class="player-name">{{ player.name }}</h2>
-      <div class="buttons">
-        <IconButton
-          v-if="onDelete"
-          title="Remove player"
-          :onClick="handleDelete"
-          :icon="close"
-        />
+    <TornPanel tear="a">
+      <div class="sprite" aria-hidden="true" />
+      <div class="header">
+        <h2 class="player-name">{{ player.name }}</h2>
+        <div class="buttons">
+          <IconButton
+            v-if="onDelete"
+            title="Remove player"
+            :onClick="handleDelete"
+            :icon="close"
+          />
+        </div>
       </div>
-    </div>
-    <span v-if="subTitle" class="sub-title">{{ subTitle }}</span>
-    <ul class="characters">
-      <li v-for="character in player.team.getLimitedCharacters()">
-        {{ character }}
-      </li>
-    </ul>
+      <span class="sub-title">{{ subTitle }}</span>
+      <ul class="characters">
+        <li v-for="character in player.team.getLimitedCharacters()">
+          {{ character }}
+        </li>
+      </ul>
+    </TornPanel>
   </div>
 </template>
 
 <style lang="scss" scoped>
 .team-display {
   min-width: 250px;
-  border: 2px solid var(--border-accent);
   position: relative;
-  box-shadow: 0 2px 8px rgba(30, 15, 5, 0.3);
-  border-radius: 4px;
   flex: 1;
   flex-grow: 0;
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
-  overflow: hidden;
   white-space: nowrap;
-  transition: box-shadow 0.3s ease, transform 0.3s ease;
+  transition: transform 0.3s ease;
+
+  // Tighter inner box so the portrait can sit closer to the name.
+  :deep(.content) {
+    padding: 8px 10px;
+  }
 
   &.interactive {
     cursor: pointer;
 
     &:hover {
-      box-shadow: 0 2px 8px rgba(30, 15, 5, 0.3), 0 0 12px var(--glow-warm-soft);
       transform: translateY(-2px);
     }
   }
 
-  &:before {
+  // Anchored to TornPanel's .content (position: relative); the panel's
+  // tear clip-path keeps the oversized art within the parchment silhouette.
+  // Starts below the name/subtitle so the text never sits on the artwork.
+  .sprite {
     background: url("../../assets/characters.png");
     background-repeat: no-repeat;
     background-size: 500%;
     background-position-x: calc(var(--team-offset) * 25%);
-    content: "";
-    display: block;
     position: absolute;
-    top: 0;
+    top: 34px;
     left: 50%;
     width: 100px;
     height: 200px;
     translate: -50% 0%;
+    pointer-events: none;
   }
 
   .header {
-    padding: 5px 5px 0;
+    padding: 2px 4px 0;
     display: flex;
     justify-content: space-between;
     overflow: hidden;
 
     .player-name {
+      font-size: 22px;
+      line-height: 1.15;
       text-shadow: 2px 2px 2px var(--color);
       flex: 1;
       text-overflow: ellipsis;
@@ -99,27 +110,30 @@ const handleDelete = (event: Event) => {
   }
 
   .sub-title {
-    padding-left: 5px;
+    padding-left: 4px;
     font-size: 12px;
+    line-height: 16px;
+    min-height: 16px;
     display: block;
-    position: absolute;
   }
 
   .characters {
-    margin-top: 120px;
+    margin-top: 132px;
     display: grid;
     grid-template-columns: 1fr 1fr;
     position: relative;
 
     li {
-      border: 1px solid var(--border-accent-faint);
-      background: linear-gradient(180deg, var(--background), var(--background-dark));
-      border-radius: var(--big-radius);
+      border: 2px solid var(--border-accent-faint);
+      border-radius: 0;
+      background: var(--field-bg);
+      color: var(--primary);
+      font-size: 14px;
       text-align: center;
       margin: 3px;
       overflow: hidden;
       text-overflow: ellipsis;
-      padding: 0 5px;
+      padding: 1px 5px;
     }
   }
 }

--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -20,7 +20,7 @@ import Collapsible from "../atoms/Collapsible.vue";
 import WfcDialog, { type WfcSettings } from "../organisms/WfcDialog.vue";
 import AiAlignDialog from "../organisms/AiAlignDialog.vue";
 import TerrainPaintDialog from "../organisms/TerrainPaintDialog.vue";
-import paintBucket from "pixelarticons/svg/paint-bucket.svg";
+import brush from "pixelarticons/svg/brush.svg";
 import type { LadderInfo } from "../../data/wfc/postProcess";
 import WfcWorker from "../../data/wfc/wfc.worker?worker";
 import { useBuilderLayers } from "./composables/useBuilderLayers";
@@ -398,7 +398,7 @@ const handleBBoxChange = (newBBox: BBox) => {
             v-if="mask.data || terrain.data"
             title="Paint terrain procedurally"
             :onClick="() => (showTerrainPaint = true)"
-            :icon="paintBucket"
+            :icon="brush"
           />
           <input
             ref="aiTerrainInput"

--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -703,8 +703,8 @@ const handleBBoxChange = (newBBox: BBox) => {
 
   .controls {
     width: 200px;
-    border-right: 4px solid var(--primary);
-    box-shadow: 5px 0 10px #00000069;
+    border-right: 2px solid var(--border-accent);
+    box-shadow: 2px 0 0 var(--shadow-hard);
     padding: 10px;
     overflow-y: auto;
 
@@ -726,10 +726,12 @@ const handleBBoxChange = (newBBox: BBox) => {
 
     > .section + .section {
       padding-top: 10px;
-      background-image: linear-gradient(90deg, transparent, var(--border-accent-faint) 20%, var(--border-accent-faint) 80%, transparent);
-      background-size: 100% 1px;
-      background-repeat: no-repeat;
-      background-position: top;
+      background: repeating-linear-gradient(
+          90deg,
+          var(--border-accent-faint) 0 4px,
+          transparent 4px 8px
+        )
+        top / 100% 2px no-repeat;
     }
 
     .layer-title {

--- a/src/components/pages/Credits.vue
+++ b/src/components/pages/Credits.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import credits from "../../../credits.json";
 import { useRouter } from "vue-router";
+import PixelDivider from "../atoms/PixelDivider.vue";
 
 const router = useRouter();
 </script>
@@ -12,20 +13,27 @@ const router = useRouter();
     <a href="https://github.com/lorgan3/sorcerers">GitHub</a> if the there is an
     issue with the credits.
   </p>
+  <PixelDivider />
   <div class="credits">
-    <div class="section" v-for="{ section, authors } in credits">
-      <h2 class="section-heading">{{ section }}</h2>
-      <ul>
-        <li class="item" v-for="{ author, items } in authors">
-          <template v-for="(item, i) in items">
-            <a :href="item.link" target="_blank" rel="noopener noreferrer">{{
-              item.name
-            }}</a>
-            <template v-if="i < items.length - 1">, </template></template
-          >: {{ author }}
-        </li>
-      </ul>
-    </div>
+    <template
+      v-for="({ section, authors }, sectionIndex) in credits"
+      :key="section"
+    >
+      <PixelDivider v-if="sectionIndex > 0" class="col-divider" />
+      <div class="section">
+        <h2 class="section-heading">{{ section }}</h2>
+        <ul>
+          <li class="item" v-for="{ author, items } in authors">
+            <template v-for="(item, i) in items">
+              <a :href="item.link" target="_blank" rel="noopener noreferrer">{{
+                item.name
+              }}</a>
+              <template v-if="i < items.length - 1">, </template></template
+            >: {{ author }}
+          </li>
+        </ul>
+      </div>
+    </template>
   </div>
 
   <div class="buttons">
@@ -42,14 +50,6 @@ const router = useRouter();
   .section {
     flex: 1;
 
-    & + .section {
-      padding-top: 12px;
-      background-image: linear-gradient(90deg, transparent, var(--border-accent-faint) 20%, var(--border-accent-faint) 80%, transparent);
-      background-size: 100% 1px;
-      background-repeat: no-repeat;
-      background-position: top;
-    }
-
     .item {
       -webkit-line-clamp: 2;
       display: -webkit-box;
@@ -61,9 +61,20 @@ const router = useRouter();
   }
 }
 
+// On wide screens the sections sit side by side; a divider between every
+// column reads as clutter, so the inter-section dividers only show once the
+// sections stack vertically.
+.credits :deep(.col-divider) {
+  display: none;
+}
+
 @media screen and (max-width: 992px) {
   .credits {
     flex-direction: column;
+  }
+
+  .credits :deep(.col-divider) {
+    display: flex;
   }
 }
 </style>

--- a/src/components/pages/Host.vue
+++ b/src/components/pages/Host.vue
@@ -14,6 +14,7 @@ import GameSettingsComponent from "../organisms/GameSettings.vue";
 import MapSelect from "../organisms/MapSelect.vue";
 import { COLORS } from "../../data/network/constants";
 import IconButton from "../atoms/IconButton.vue";
+import PixelDivider from "../atoms/PixelDivider.vue";
 import human from "pixelarticons/svg/user-plus.svg";
 import bot from "pixelarticons/svg/robot.svg";
 import { useHostServer } from "./composables/useHostServer";
@@ -265,6 +266,8 @@ const handleSelectMap = async (config: Config, name: string) => {
         </div>
       </div>
 
+      <PixelDivider vertical class="column-divider" />
+
       <div class="column">
         <div class="section">
           <h2 class="section-heading">
@@ -272,10 +275,14 @@ const handleSelectMap = async (config: Config, name: string) => {
           </h2>
         </div>
 
+        <PixelDivider />
+
         <div class="section">
           <h2 class="section-heading">Map</h2>
           <MapSelect :onEdit="handleSelectMap" defaultMap="Playground" />
         </div>
+
+        <PixelDivider />
 
         <div class="section">
           <GameSettingsComponent
@@ -309,37 +316,14 @@ const handleSelectMap = async (config: Config, name: string) => {
 .columns {
   display: flex;
   gap: 30px;
-  align-items: flex-start;
+  align-items: stretch;
 
   @media (max-width: 800px) {
     flex-direction: column;
 
-    &::before {
+    .column-divider {
       display: none;
     }
-  }
-
-  // Vertical divider between columns
-  &::before {
-    content: '';
-    order: 1;
-    width: 1px;
-    align-self: stretch;
-    background: linear-gradient(
-      180deg,
-      transparent,
-      var(--border-accent-faint) 15%,
-      var(--border-accent-faint) 85%,
-      transparent
-    );
-  }
-
-  .column:first-child {
-    order: 0;
-  }
-
-  .column:last-child {
-    order: 2;
   }
 }
 
@@ -355,16 +339,6 @@ const handleSelectMap = async (config: Config, name: string) => {
   display: flex;
   flex-direction: column;
   gap: 10px;
-
-
-  // Divider after section content, not after title
-  + .section::before {
-    content: '';
-    display: block;
-    height: 1px;
-    margin-bottom: 4px;
-    background: linear-gradient(90deg, transparent, var(--border-accent-faint) 20%, var(--border-accent-faint) 80%, transparent);
-  }
 }
 
 .teams {

--- a/src/components/pages/MainMenu.vue
+++ b/src/components/pages/MainMenu.vue
@@ -7,27 +7,38 @@ import { ref } from "vue";
 import JoinDialog from "../organisms/JoinDialog.vue";
 import ServerList from "../organisms/ServerList.vue";
 import externalLink from "pixelarticons/svg/external-link.svg";
+import TornPanel from "../atoms/TornPanel.vue";
+import WaxSeal from "../atoms/WaxSeal.vue";
+import RuneLayer from "../atoms/RuneLayer.vue";
 
 const joinDialogOpen = ref(false);
 </script>
 
 <template>
+  <RuneLayer />
   <div class="main-menu-row">
-    <div class="mainMenu">
+    <TornPanel class="menu-panel">
       <ul class="list flex-list">
         <li>
-          <RouterLink to="/host" class="primary menu-button">Host</RouterLink>
+          <RouterLink to="/host" class="primary menu-button">
+            <WaxSeal class="seal" letter="S" :size="34" aria-hidden="true" />Host
+          </RouterLink>
         </li>
         <li>
           <button class="primary menu-button" @click="joinDialogOpen = true">
-            Join game
+            <WaxSeal class="seal" letter="S" :size="34" aria-hidden="true" />Join
+            game
           </button>
         </li>
         <li>
-          <RouterLink to="/builder" class="primary menu-button">Builder</RouterLink>
+          <RouterLink to="/builder" class="primary menu-button">
+            <WaxSeal class="seal" letter="S" :size="34" aria-hidden="true" />Builder
+          </RouterLink>
         </li>
         <li>
-          <RouterLink to="/credits" class="primary menu-button">Credits</RouterLink>
+          <RouterLink to="/credits" class="primary menu-button">
+            <WaxSeal class="seal" letter="S" :size="34" aria-hidden="true" />Credits
+          </RouterLink>
         </li>
         <li>
           <a
@@ -36,12 +47,12 @@ const joinDialogOpen = ref(false);
             rel="noopener noreferrer"
             class="primary menu-button"
           >
-            Issues/Feedback
+            <WaxSeal class="seal" letter="S" :size="34" aria-hidden="true" />Issues/Feedback
             <img class="github-icon" :src="externalLink" />
           </a>
         </li>
       </ul>
-    </div>
+    </TornPanel>
     <ServerList />
   </div>
   <div class="spellbooks">
@@ -70,13 +81,11 @@ const joinDialogOpen = ref(false);
   flex-wrap: wrap;
 }
 
-.mainMenu {
+.menu-panel {
+  width: fit-content;
+
   .list {
-    background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
-    border: 2px solid var(--border-accent);
-    box-shadow: 0 2px 8px rgba(30, 15, 5, 0.3), inset 0 0 15px rgba(180, 120, 40, 0.08);
-    padding: 30px;
-    border-radius: 4px;
+    padding: 6px;
 
     .menu-button {
       display: block;
@@ -91,6 +100,20 @@ const joinDialogOpen = ref(false);
       text-align: center;
       text-decoration: none;
     }
+
+    .seal {
+      position: absolute;
+      left: -10px;
+      top: 50%;
+      translate: 0 -50%;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+      pointer-events: none;
+    }
+
+    .menu-button:hover .seal {
+      opacity: 1;
+    }
   }
 }
 
@@ -99,13 +122,18 @@ const joinDialogOpen = ref(false);
 
   .book-link {
     display: inline-block;
-    padding: 20px 0 15px;
+    padding: 10px 0 8px;
     width: 70px;
     cursor: pointer;
     text-decoration: none;
 
     img {
       scale: 2;
+      transition: filter 0.3s ease;
+    }
+
+    &:hover img {
+      filter: drop-shadow(0 0 6px var(--glow-warm));
     }
   }
 }

--- a/src/components/pages/Settings.vue
+++ b/src/components/pages/Settings.vue
@@ -87,6 +87,7 @@ const handleChangeMusic = () => {
 </template>
 
 <style lang="scss" scoped>
+@use "../../style/ornaments" as o;
 .slider {
   -webkit-appearance: none;
   appearance: none;
@@ -105,7 +106,7 @@ const handleChangeMusic = () => {
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
+  @include o.dither-surface;
   border: 2px solid var(--border-accent);
   box-shadow: 0 1px 3px rgba(30, 15, 5, 0.3);
   cursor: pointer;
@@ -120,7 +121,7 @@ const handleChangeMusic = () => {
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
+  @include o.dither-surface;
   border: 2px solid var(--border-accent);
   box-shadow: 0 1px 3px rgba(30, 15, 5, 0.3);
   cursor: pointer;

--- a/src/components/pages/Spellbook.vue
+++ b/src/components/pages/Spellbook.vue
@@ -96,13 +96,13 @@ const spellsByElement = SPELLS.reduce((all, spell) => {
 </template>
 
 <style lang="scss" scoped>
+@use "../../style/ornaments" as o;
 .grid {
   display: grid;
   grid-template-columns: 54px repeat(4, 1fr);
   gap: 2px;
   background: var(--border-accent-faint);
-  border: 2px solid var(--border-accent);
-  border-radius: 4px;
+  @include o.pixel-frame;
   overflow: hidden;
 }
 
@@ -159,11 +159,7 @@ const spellsByElement = SPELLS.reduce((all, spell) => {
   align-content: flex-start;
   padding: 6px;
   position: relative;
-  background: linear-gradient(
-    180deg,
-    var(--parchment-light),
-    var(--parchment-dark)
-  );
+  @include o.dither-surface;
   border-left: 2px solid color-mix(in srgb, var(--row-color) 25%, transparent);
   border-top: 2px solid color-mix(in srgb, var(--col-color) 25%, transparent);
   transition: box-shadow 0.2s ease;
@@ -219,7 +215,7 @@ const spellsByElement = SPELLS.reduce((all, spell) => {
   font-family: Eternal;
   font-size: 16px;
   color: var(--border-accent);
-  background: linear-gradient(180deg, var(--parchment-light), var(--parchment-dark));
+  @include o.dither-surface;
   border: 1px solid var(--border-accent-faint);
   border-radius: 3px;
   padding: 1px 6px;

--- a/src/style/ornaments.scss
+++ b/src/style/ornaments.scss
@@ -1,0 +1,117 @@
+@use "sass:list";
+
+// Pixel-art ornament library for the spellbook UI theme.
+// Single source of truth: components never inline these data-URIs/polygons.
+// Everything is code-drawn SVG — no PNG or atlas changes.
+
+// --- Dithered parchment surfaces --------------------------------------------
+// A hard-stepped vertical gradient using ABSOLUTE pixel stops (60px bands), so
+// the steps never stretch — a taller panel simply reveals more of the gradient
+// and clips the rest. The dithering is the bands themselves bleeding into each
+// other: across every 60px seam, pixels of the darker band poke up into the
+// lighter one and vice-versa, drawn in the actual band colors (no tint, no
+// border line). The dot colors are generated from the same lists as the
+// gradient so the two can never drift apart.
+
+$dither-bands: "dbc7a6", "d7c19f", "d2bc99", "ceb692", "cab18c", "c6ab85",
+  "c1a57e", "bda078";
+$dither-bands-hover: "e3cfae", "dfc9a7", "dac4a1", "d6be9a", "d2b994", "ceb38d",
+  "c9ad86", "c5a880";
+
+// Transparent overlay carrying only the dither dots at each band seam. 8px-deep
+// checkerboard (4px each side of the seam) in the two adjacent band colors.
+@function dither-seam($colors) {
+  $dots: "";
+  @for $i from 1 through list.length($colors) - 1 {
+    $up: list.nth($colors, $i);
+    $lo: list.nth($colors, $i + 1);
+    $b: $i * 60;
+    // darker (next) band poking up into the lighter band, above the seam
+    $dots: $dots + '<rect y="#{$b - 4}" width="8" height="2" fill="%23#{$lo}"/>';
+    $dots: $dots +
+      '<rect x="8" y="#{$b - 2}" width="8" height="2" fill="%23#{$lo}"/>';
+    // lighter band poking down into the darker band, below the seam
+    $dots: $dots + '<rect x="8" y="#{$b}" width="8" height="2" fill="%23#{$up}"/>';
+    $dots: $dots +
+      '<rect y="#{$b + 2}" width="8" height="2" fill="%23#{$up}"/>';
+  }
+  @return 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="480" shape-rendering="crispEdges">#{$dots}</svg>';
+}
+
+@mixin dither-surface {
+  background-image: url('#{dither-seam($dither-bands)}'),
+    linear-gradient(
+      180deg,
+      #dbc7a6 0 60px,
+      #d7c19f 60px 120px,
+      #d2bc99 120px 180px,
+      #ceb692 180px 240px,
+      #cab18c 240px 300px,
+      #c6ab85 300px 360px,
+      #c1a57e 360px 420px,
+      #bda078 420px 480px
+    );
+  background-size: 16px 480px, 100% 100%;
+  background-repeat: repeat-x, no-repeat;
+  image-rendering: pixelated;
+}
+
+@mixin dither-surface-hover {
+  background-image: url('#{dither-seam($dither-bands-hover)}'),
+    linear-gradient(
+      180deg,
+      #e3cfae 0 60px,
+      #dfc9a7 60px 120px,
+      #dac4a1 120px 180px,
+      #d6be9a 180px 240px,
+      #d2b994 240px 300px,
+      #ceb38d 300px 360px,
+      #c9ad86 360px 420px,
+      #c5a880 420px 480px
+    );
+  background-size: 16px 480px, 100% 100%;
+  background-repeat: repeat-x, no-repeat;
+  image-rendering: pixelated;
+}
+
+// --- Torn paper edges --------------------------------------------------------
+// Percentage polygons stretch with the element, so several variants exist.
+// a/b: deep tears for menus & dialogs. light: shallow tears for in-game HUD.
+
+$tear-heavy-a: polygon(0% 3%, 5% 3%, 5% 1%, 12% 1%, 12% 3%, 18% 3%, 18% 0%, 26% 0%, 26% 2%, 34% 2%, 34% 1%, 42% 1%, 42% 3%, 50% 3%, 50% 0%, 58% 0%, 58% 2%, 66% 2%, 66% 1%, 74% 1%, 74% 3%, 82% 3%, 82% 0%, 90% 0%, 90% 2%, 97% 2%, 97% 4%, 100% 4%, 100% 12%, 98% 12%, 98% 22%, 100% 22%, 100% 32%, 99% 32%, 99% 44%, 97% 44%, 97% 56%, 100% 56%, 100% 68%, 98% 68%, 98% 80%, 100% 80%, 100% 90%, 98% 90%, 98% 97%, 92% 97%, 92% 100%, 84% 100%, 84% 98%, 76% 98%, 76% 100%, 68% 100%, 68% 97%, 60% 97%, 60% 99%, 52% 99%, 52% 100%, 44% 100%, 44% 98%, 36% 98%, 36% 100%, 28% 100%, 28% 97%, 20% 97%, 20% 99%, 12% 99%, 12% 100%, 5% 100%, 5% 98%, 2% 98%, 2% 96%, 0% 96%, 0% 86%, 2% 86%, 2% 76%, 0% 76%, 0% 64%, 1% 64%, 1% 52%, 3% 52%, 3% 40%, 0% 40%, 0% 28%, 2% 28%, 2% 16%, 0% 16%);
+
+$tear-heavy-b: polygon(0% 2%, 8% 2%, 8% 0%, 20% 0%, 20% 2%, 31% 2%, 31% 1%, 45% 1%, 45% 3%, 60% 3%, 60% 0%, 73% 0%, 73% 2%, 86% 2%, 86% 1%, 100% 1%, 100% 14%, 98% 14%, 98% 30%, 100% 30%, 100% 48%, 99% 48%, 99% 66%, 100% 66%, 100% 84%, 98% 84%, 98% 98%, 88% 98%, 88% 100%, 72% 100%, 72% 98%, 55% 98%, 55% 100%, 38% 100%, 38% 99%, 22% 99%, 22% 100%, 8% 100%, 8% 98%, 0% 98%, 0% 80%, 2% 80%, 2% 62%, 0% 62%, 0% 44%, 1% 44%, 1% 26%, 0% 26%);
+
+$tear-light: polygon(0% 1%, 6% 1%, 6% 0%, 14% 0%, 14% 1%, 24% 1%, 24% 0%, 34% 0%, 34% 1%, 45% 1%, 45% 0%, 56% 0%, 56% 1%, 66% 1%, 66% 0%, 76% 0%, 76% 1%, 86% 1%, 86% 0%, 95% 0%, 95% 1%, 100% 1%, 100% 10%, 99% 10%, 99% 22%, 100% 22%, 100% 38%, 99% 38%, 99% 55%, 100% 55%, 100% 70%, 99% 70%, 99% 85%, 100% 85%, 100% 99%, 94% 99%, 94% 100%, 84% 100%, 84% 99%, 72% 99%, 72% 100%, 60% 100%, 60% 99%, 48% 99%, 48% 100%, 36% 100%, 36% 99%, 24% 99%, 24% 100%, 12% 100%, 12% 99%, 0% 99%, 0% 88%, 1% 88%, 1% 74%, 0% 74%, 0% 58%, 1% 58%, 1% 42%, 0% 42%, 0% 26%, 1% 26%, 1% 12%, 0% 12%);
+
+@mixin tear($shape: $tear-heavy-a) {
+  clip-path: $shape;
+}
+
+// --- Pixel frame (inner double border for heavy panels) -----------------------
+
+@mixin pixel-frame {
+  border: 4px solid var(--border-accent);
+  border-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6" shape-rendering="crispEdges"><path d="M0 0 H6 V6 H0 Z M1 1 V5 H5 V1 Z" fill="%2380331e" fill-rule="evenodd"/></svg>') 2 / 4px / 0 round;
+}
+
+// --- Stitched ledger line ------------------------------------------------------
+
+@mixin stitched-line {
+  height: 2px;
+  background: repeating-linear-gradient(90deg, var(--border-accent) 0 4px, transparent 4px 8px);
+}
+
+// Pixel diamond, used by PixelDivider and section headings.
+$diamond: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7 7" shape-rendering="crispEdges"><path d="M3 0 H4 V1 H5 V2 H6 V3 H7 V4 H6 V5 H5 V6 H4 V7 H3 V6 H2 V5 H1 V4 H0 V3 H1 V2 H2 V1 H3 Z" fill="%2380331e"/></svg>');
+
+// --- Stepped page vignette -----------------------------------------------------
+// Hard-edged inset rings replace the smooth blurred box-shadow vignette.
+
+@mixin pixel-vignette {
+  box-shadow:
+    inset 0 0 0 0.6vmin rgba(64, 32, 32, 0.25),
+    inset 0 0 0 1.6vmin rgba(64, 32, 32, 0.16),
+    inset 0 0 0 3vmin rgba(64, 32, 32, 0.09),
+    inset 0 0 0 5vmin rgba(64, 32, 32, 0.04);
+}

--- a/src/style/ornaments.scss
+++ b/src/style/ornaments.scss
@@ -8,15 +8,31 @@
 // A hard-stepped vertical gradient using ABSOLUTE pixel stops (60px bands), so
 // the steps never stretch — a taller panel simply reveals more of the gradient
 // and clips the rest. The dithering is the bands themselves bleeding into each
-// other: across every 60px seam, pixels of the darker band poke up into the
-// lighter one and vice-versa, drawn in the actual band colors (no tint, no
-// border line). The dot colors are generated from the same lists as the
-// gradient so the two can never drift apart.
+// other: across every seam, pixels of the darker band poke up into the lighter
+// one and vice-versa, drawn in the actual band colors (no tint, no border
+// line). Both the gradient stops AND the dither dots are generated from the
+// same `$dither-bands` list, so the two can never drift apart.
 
+$dither-band: 60; // height of one band, in px
 $dither-bands: "dbc7a6", "d7c19f", "d2bc99", "ceb692", "cab18c", "c6ab85",
   "c1a57e", "bda078";
 $dither-bands-hover: "e3cfae", "dfc9a7", "dac4a1", "d6be9a", "d2b994", "ceb38d",
   "c9ad86", "c5a880";
+
+// Hard-stepped vertical gradient: one solid band per color, $dither-band tall.
+@function dither-gradient($colors) {
+  $stops: "";
+  @for $i from 1 through list.length($colors) {
+    $c: list.nth($colors, $i);
+    $start: ($i - 1) * $dither-band;
+    $end: $i * $dither-band;
+    $stops: $stops + '##{$c} #{$start}px #{$end}px';
+    @if $i < list.length($colors) {
+      $stops: $stops + ", ";
+    }
+  }
+  @return $stops;
+}
 
 // Transparent overlay carrying only the dither dots at each band seam. 8px-deep
 // checkerboard (4px each side of the seam) in the two adjacent band colors.
@@ -25,7 +41,7 @@ $dither-bands-hover: "e3cfae", "dfc9a7", "dac4a1", "d6be9a", "d2b994", "ceb38d",
   @for $i from 1 through list.length($colors) - 1 {
     $up: list.nth($colors, $i);
     $lo: list.nth($colors, $i + 1);
-    $b: $i * 60;
+    $b: $i * $dither-band;
     // darker (next) band poking up into the lighter band, above the seam
     $dots: $dots + '<rect y="#{$b - 4}" width="8" height="2" fill="%23#{$lo}"/>';
     $dots: $dots +
@@ -35,43 +51,25 @@ $dither-bands-hover: "e3cfae", "dfc9a7", "dac4a1", "d6be9a", "d2b994", "ceb38d",
     $dots: $dots +
       '<rect y="#{$b + 2}" width="8" height="2" fill="%23#{$up}"/>';
   }
-  @return 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="480" shape-rendering="crispEdges">#{$dots}</svg>';
+  $h: list.length($colors) * $dither-band;
+  @return 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="#{$h}" shape-rendering="crispEdges">#{$dots}</svg>';
+}
+
+@mixin dither-bands($colors) {
+  $h: list.length($colors) * $dither-band;
+  background-image: url('#{dither-seam($colors)}'),
+    linear-gradient(180deg, #{dither-gradient($colors)});
+  background-size: 16px #{$h}px, 100% 100%;
+  background-repeat: repeat-x, no-repeat;
+  image-rendering: pixelated;
 }
 
 @mixin dither-surface {
-  background-image: url('#{dither-seam($dither-bands)}'),
-    linear-gradient(
-      180deg,
-      #dbc7a6 0 60px,
-      #d7c19f 60px 120px,
-      #d2bc99 120px 180px,
-      #ceb692 180px 240px,
-      #cab18c 240px 300px,
-      #c6ab85 300px 360px,
-      #c1a57e 360px 420px,
-      #bda078 420px 480px
-    );
-  background-size: 16px 480px, 100% 100%;
-  background-repeat: repeat-x, no-repeat;
-  image-rendering: pixelated;
+  @include dither-bands($dither-bands);
 }
 
 @mixin dither-surface-hover {
-  background-image: url('#{dither-seam($dither-bands-hover)}'),
-    linear-gradient(
-      180deg,
-      #e3cfae 0 60px,
-      #dfc9a7 60px 120px,
-      #dac4a1 120px 180px,
-      #d6be9a 180px 240px,
-      #d2b994 240px 300px,
-      #ceb38d 300px 360px,
-      #c9ad86 360px 420px,
-      #c5a880 420px 480px
-    );
-  background-size: 16px 480px, 100% 100%;
-  background-repeat: repeat-x, no-repeat;
-  image-rendering: pixelated;
+  @include dither-bands($dither-bands-hover);
 }
 
 // --- Torn paper edges --------------------------------------------------------


### PR DESCRIPTION
### Description

Restyles the entire Vue UI as a magic spellbook: a shared pixel-ornament SCSS library plus four new atoms (`TornPanel`, `PixelDivider`, `WaxSeal`, `RuneLayer`), all drawn in code — no new image assets.

- All dialogs, lobby panels and tooltips render as torn parchment pages (clip-path tears, hard pixel shadows)
- Every smooth parchment gradient replaced with checkerboard-dithered pixel gradients; smooth dividers → stitched ledger lines; page vignette → stepped rings
- Main menu becomes a "living grimoire": pulsing element-icon runes, self-writing ink tagline, wax seal on Host, server list as a torn ledger
- In-game HUD/inventory get a deliberately light pass: shallow tears, no size or animation changes

> [!NOTE]
> The `WaxSeal` look is a first iteration (used only on the Host button) — feedback welcome before using it more widely.

### Manual check

- Run `yarn dev` and open the main menu
- [ ] Menu renders inside a torn parchment panel with pixel frame + corner flourishes; element icons pulse in the margins; the tagline writes itself at the bottom; Host carries a wax seal
- [ ] Hover the spellbook/settings books: tooltip is a small torn note with readable dark text
- Click "Join game"
- [ ] Dialog opens as a torn page; close button and click-outside both dismiss it
- Go to Host and add a local player
- [ ] Each lobby section (settings, teams, map, chat) is its own torn page with varying tear shapes; checkboxes and inputs are dithered with square corners
- [ ] Chat: collapsed bar shows the last message; opening it gives a scrollable torn panel with reachable input
- Start a local 2-player game
- [ ] HUD (bottom-left) has shallow torn edges at its old size; hovering still expands the player list; timers/mana/elements readable
- [ ] Right-click opens the spell inventory as a light torn panel; spell tooltips are readable on parchment (dark cost/name colors, range icon visible)
- Visit Spellbook, Settings, Credits and Builder
- [ ] Spellbook grid is pixel-framed and dithered; Credits shows stitched dividers between sections; Builder sidebar has the thin accent border

[Checklist for a thorough manual check](https://teamleader.atlassian.net/wiki/spaces/ENG/pages/3332735012/Manual+check+list)