### PR TITLE
Themed back-wall backgrounds behind terrain

### DIFF
--- a/src/data/terrainPaint/__spec__/backwall.spec.ts
+++ b/src/data/terrainPaint/__spec__/backwall.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "vitest";
+import { buildBackwall } from "../backwall";
+import { computeZones } from "../zones";
+import { THEMES } from "../palettes";
+import { createImageData, hexToRgb } from "../pixel";
+import { bitmap } from "./helpers";
+
+// Blocks are wide (>= 2*EDGE_WOBBLE+1) so the ragged-edge wobble never reaches
+// the interior columns the tests assert on.
+// left block cols0-9 (ceiling row1, floor row4). col10: open sky.
+// right block cols11-19 (ceiling row1, no floor -> floorless to the bottom).
+const W = 20;
+const ROOF = [
+  "....................",
+  "##########.#########",
+  "....................",
+  "....................",
+  "##########..........",
+  "....................",
+];
+
+function backwallFor(
+  rows: string[],
+  themeByCeil: Record<number, string> = {},
+  seed = 1
+) {
+  const { alpha, width, height } = bitmap(rows);
+  const { zoneMap, zones } = computeZones(alpha, width, height, seed);
+  // themeByCeil maps a "solid pixel index" to a themeId for that pixel's zone
+  for (const key of Object.keys(themeByCeil)) {
+    const zi = zoneMap[Number(key)];
+    if (zi >= 0) zones[zi].themeId = themeByCeil[Number(key)];
+  }
+  const background = createImageData(width, height);
+  buildBackwall({ background, width, height, zoneMap, zones, seed });
+  return { background, alpha, zoneMap, zones, width, height };
+}
+
+const alphaAt = (data: Uint8ClampedArray, i: number) => data[i * 4 + 3];
+
+// Shading multiplies every channel of a ramp color by one factor f in (0, 1].
+// A painted pixel belongs to a theme if it is such a uniform scaling of any of
+// that theme's ramp colors.
+const isScaledRampColor = (
+  data: Uint8ClampedArray,
+  i: number,
+  themeId: string
+): boolean => {
+  const px = [data[i * 4], data[i * 4 + 1], data[i * 4 + 2]];
+  return THEMES[themeId].backwall!.ramp.some((hex) => {
+    const c = hexToRgb(hex);
+    const factors: number[] = [];
+    for (let k = 0; k < 3; k++) {
+      if (c[k] === 0) {
+        if (px[k] > 2) return false;
+        continue;
+      }
+      const f = px[k] / c[k];
+      if (f < 0.3 || f > 1.05) return false;
+      factors.push(f);
+    }
+    return Math.max(...factors) - Math.min(...factors) < 0.06;
+  });
+};
+
+describe("buildBackwall", () => {
+  test("open-sky pixels (no solid above) stay transparent", () => {
+    const { background, width } = backwallFor(ROOF);
+    // col 10, row 2: the gap column has nothing solid above it
+    expect(alphaAt(background.data, 2 * width + 10)).toBe(0);
+  });
+
+  test("a roofed empty pixel is filled opaque", () => {
+    const { background, width } = backwallFor(ROOF);
+    // col 4, row 2: solid ceiling at row 1 above it
+    expect(alphaAt(background.data, 2 * width + 4)).toBe(255);
+  });
+
+  test("a roofed pixel takes the ceiling theme, not the floor's", () => {
+    const { background, width } = backwallFor(ROOF, {
+      [1 * W + 4]: "cave", // left ceiling (row1 col4)
+      [4 * W + 4]: "grassland", // left floor (row4 col4)
+    });
+    // row2 col4: under the cave ceiling
+    expect(isScaledRampColor(background.data, 2 * width + 4, "cave")).toBe(true);
+    // row5 col4: under the grassland floor acting as the nearest ceiling
+    expect(
+      isScaledRampColor(background.data, 5 * width + 4, "grassland")
+    ).toBe(true);
+  });
+
+  test("a floorless roofed column fills down to the bottom row", () => {
+    const { background, width, height } = backwallFor(ROOF);
+    // col 15: ceiling at row1, no floor below -> bottom row filled
+    expect(alphaAt(background.data, (height - 1) * width + 15)).toBe(255);
+  });
+
+  test("a theme without a back-wall (toon) leaves its pockets transparent", () => {
+    const { background, width } = backwallFor(ROOF, {
+      [1 * W + 15]: "toon", // right ceiling (row1 col15)
+    });
+    expect(alphaAt(background.data, 2 * width + 15)).toBe(0);
+  });
+
+  test("fills behind solid terrain so erosion reveals the wall", () => {
+    const { background, width } = backwallFor(ROOF);
+    // row1 col4 is solid ceiling: its backing must be painted, not transparent
+    expect(alphaAt(background.data, 1 * width + 4)).toBe(255);
+  });
+
+  test("never paints open sky above the first solid pixel", () => {
+    const { background, alpha, width, height } = backwallFor(ROOF);
+    const data = background.data;
+    for (let x = 0; x < width; x++) {
+      let seenSolid = false;
+      for (let y = 0; y < height; y++) {
+        const i = y * width + x;
+        if (alpha[i]) seenSolid = true;
+        // a painted pixel must have solid terrain at or above it in its column
+        if (alphaAt(data, i) !== 0) expect(seenSolid).toBe(true);
+      }
+    }
+  });
+
+  test("is deterministic for the same seed", () => {
+    const a = backwallFor(ROOF, {}, 5);
+    const b = backwallFor(ROOF, {}, 5);
+    expect(Array.from(a.background.data)).toEqual(
+      Array.from(b.background.data)
+    );
+  });
+});

--- a/src/data/terrainPaint/__spec__/debris.spec.ts
+++ b/src/data/terrainPaint/__spec__/debris.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { buildDebris } from "../debris";
+import { createImageData } from "../pixel";
 import { computeZones } from "../zones";
 import { bitmap } from "./helpers";
 
@@ -15,7 +16,9 @@ function debrisFor(
     height,
     seed
   );
-  const background = buildDebris({
+  const background = createImageData(width, height);
+  buildDebris({
+    background,
     width,
     height,
     zoneMap,
@@ -144,5 +147,21 @@ describe("buildDebris", () => {
     const data = background.data;
     // top-left corner: empty in the input, far from any ladder
     expect(data[(0 * width + 0) * 4 + 3]).toBe(0);
+  });
+
+  test("a ladder shadows the wall behind it along its full length", () => {
+    const width = 40;
+    const height = 40;
+    const rows = Array.from({ length: height }, () => "#".repeat(width));
+    const ladder = { left: 16, top: 4, right: 28, bottom: 30 };
+    const withLadder = debrisFor(rows, [ladder]);
+    const without = debrisFor(rows, []);
+    // a debris pixel beside the ladder, mid-length (not on a rail or rung)
+    const i = 20 * width + 30;
+    const sum = (d: Uint8ClampedArray) => d[i * 4] + d[i * 4 + 1] + d[i * 4 + 2];
+    expect(withLadder.background.data[i * 4 + 3]).toBe(255);
+    expect(sum(withLadder.background.data)).toBeLessThan(
+      sum(without.background.data)
+    );
   });
 });

--- a/src/data/terrainPaint/__spec__/index.spec.ts
+++ b/src/data/terrainPaint/__spec__/index.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { paintTerrain } from "../index";
-import { THEME_IDS } from "../palettes";
+import { THEMES, THEME_IDS } from "../palettes";
+import { hexToRgb } from "../pixel";
 import { bitmap } from "./helpers";
 
 const MAP = [
@@ -106,5 +107,89 @@ describe("paintTerrain", () => {
     for (let i = 3; i < result.terrain.data.length; i += 4) {
       expect(result.terrain.data[i]).toBe(0);
     }
+  });
+
+  test("paints a themed back-wall into roofed pockets", () => {
+    // a wide roof over open empty space, no floor: pockets must fill
+    const roof = [
+      "....................",
+      "####################",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+    ];
+    const { alpha, width, height } = bitmap(roof);
+    const result = paintTerrain({
+      alpha,
+      width,
+      height,
+      ladders: [],
+      seed: 1,
+    });
+    const data = result.background.data;
+    let filled = 0;
+    for (let x = 0; x < width; x++) {
+      // row 3 sits under the solid roof at row 1
+      if (data[(3 * width + x) * 4 + 3] === 255) filled++;
+    }
+    expect(filled).toBe(width);
+  });
+
+  test("a zone theme override drives its roofed pocket's back-wall", () => {
+    // one landmass -> zone 0; overriding it must reach the back-wall colors
+    const roof = [
+      "....................",
+      "####################",
+      "....................",
+      "....................",
+      "....................",
+      "....................",
+    ];
+    const { alpha, width, height } = bitmap(roof);
+    const result = paintTerrain({
+      alpha,
+      width,
+      height,
+      ladders: [],
+      seed: 1,
+      themeOverrides: { 0: "urban" },
+    });
+    expect(result.zones[0].themeId).toBe("urban");
+    // shading scales every channel of a ramp color by one factor; the painted
+    // pixel must be a uniform scaling of some urban back-wall color.
+    const data = result.background.data;
+    const o = (3 * width + 5) * 4;
+    const px = [data[o], data[o + 1], data[o + 2]];
+    const matches = THEMES.urban.backwall!.ramp.some((hex) => {
+      const c = hexToRgb(hex);
+      const factors: number[] = [];
+      for (let k = 0; k < 3; k++) {
+        if (c[k] === 0) return px[k] <= 2;
+        const f = px[k] / c[k];
+        if (f < 0.3 || f > 1.05) return false;
+        factors.push(f);
+      }
+      return Math.max(...factors) - Math.min(...factors) < 0.06;
+    });
+    expect(matches).toBe(true);
+  });
+
+  test("a ladder casts a contact shadow onto the terrain at its base", () => {
+    const width = 40;
+    const height = 40;
+    const rows = Array.from({ length: height }, () => "#".repeat(width));
+    const { alpha } = bitmap(rows);
+    const ladder = { left: 16, top: 4, right: 28, bottom: 30 };
+    const shade = (ladders: typeof ladder[]) =>
+      paintTerrain({ alpha, width, height, ladders, seed: 1 }).terrain.data;
+    const withLadder = shade([ladder]);
+    const without = shade([]);
+    // a solid-terrain pixel near the ladder's base center (22, 30)
+    const i = 30 * width + 30;
+    const sum = (d: Uint8ClampedArray) => d[i * 4] + d[i * 4 + 1] + d[i * 4 + 2];
+    // still opaque terrain, just darkened by the contact shadow
+    expect(withLadder[i * 4 + 3]).toBe(255);
+    expect(sum(withLadder)).toBeLessThan(sum(without));
   });
 });

--- a/src/data/terrainPaint/__spec__/palettes.spec.ts
+++ b/src/data/terrainPaint/__spec__/palettes.spec.ts
@@ -98,4 +98,45 @@ describe("THEMES", () => {
       }
     }
   });
+
+  test("every theme except toon defines a valid back-wall band", () => {
+    for (const id of THEME_IDS) {
+      const band = THEMES[id].backwall;
+      if (id === "toon") {
+        expect(band).toBeUndefined();
+        continue;
+      }
+      expect(band).toBeDefined();
+      expect(band!.ramp.length).toBeGreaterThanOrEqual(band!.pattern ? 2 : 1);
+      for (const color of band!.ramp) {
+        expect(color).toMatch(HEX);
+      }
+    }
+  });
+
+  test("back-wall patterns are pure functions of position", () => {
+    for (const id of THEME_IDS) {
+      const band = THEMES[id].backwall;
+      if (!band?.pattern) continue;
+      const len = band.ramp.length;
+      const first = band.pattern(13, 9, 0, len);
+      band.pattern(99, 99, 0, len);
+      expect(band.pattern(13, 9, 0, len)).toBe(first);
+    }
+  });
+
+  test("back-wall patterns stay within ramp bounds", () => {
+    for (const id of THEME_IDS) {
+      const band = THEMES[id].backwall;
+      if (!band?.pattern) continue;
+      const len = band.ramp.length;
+      for (let y = 0; y < 60; y++) {
+        for (let x = 0; x < 60; x++) {
+          const idx = band.pattern(x, y, 0, len);
+          expect(idx).toBeGreaterThanOrEqual(0);
+          expect(idx).toBeLessThan(len);
+        }
+      }
+    }
+  });
 });

--- a/src/data/terrainPaint/__spec__/pixel.spec.ts
+++ b/src/data/terrainPaint/__spec__/pixel.spec.ts
@@ -106,4 +106,34 @@ describe("pickZone", () => {
       );
     }
   });
+
+  test("clamps jitter to the pixel's own landmass when a map is given", () => {
+    // two adjacent landmasses meeting at x=16, each one solid zone. Within
+    // SEAM_JITTER (8px) a left-side pixel's jitter can reach the right zone.
+    const width = 32;
+    const height = 32;
+    const zoneMap = new Int32Array(width * height);
+    const landmassMap = new Int32Array(width * height);
+    for (let i = 0; i < zoneMap.length; i++) {
+      const right = i % width >= 16;
+      zoneMap[i] = right ? 1 : 0;
+      landmassMap[i] = right ? 1 : 0;
+    }
+
+    // baseline: without the landmass map, jitter bleeds the right zone across
+    let bledWithoutMap = false;
+    for (let x = 10; x < 16; x++) {
+      for (let y = 0; y < height; y++) {
+        if (pickZone(zoneMap, width, height, x, y, 7) === 1) bledWithoutMap = true;
+      }
+    }
+    expect(bledWithoutMap).toBe(true);
+
+    // with the map, a left-landmass pixel never adopts the right zone
+    for (let x = 10; x < 16; x++) {
+      for (let y = 0; y < height; y++) {
+        expect(pickZone(zoneMap, width, height, x, y, 7, landmassMap)).toBe(0);
+      }
+    }
+  });
 });

--- a/src/data/terrainPaint/backwall.ts
+++ b/src/data/terrainPaint/backwall.ts
@@ -16,7 +16,9 @@ export interface BackwallInput {
 // empty pixels within this distance below their ceiling are progressively
 // darkened — a downward contact shadow cast by the surface above them
 const AO_RADIUS = 18;
-const AO_MIN = 0.5;
+// darkest ambient-occlusion multiplier; debris reuses it so eroded terrain
+// reads as the same deep-shadow tone as a fully occluded pocket
+export const AO_MIN = 0.5;
 // how far the back-wall's edge against open sky is allowed to wander
 const EDGE_WOBBLE = 4;
 

--- a/src/data/terrainPaint/backwall.ts
+++ b/src/data/terrainPaint/backwall.ts
@@ -1,0 +1,115 @@
+import { THEMES } from "./palettes";
+import { hexToRgb, rampIndex } from "./pixel";
+import { noise2d } from "./rng";
+import type { ZoneInfo } from "./zones";
+
+export interface BackwallInput {
+  /** Shared background buffer; back-wall is painted before debris/ladders. */
+  background: ImageData;
+  width: number;
+  height: number;
+  zoneMap: Int32Array;
+  zones: ZoneInfo[];
+  seed: number;
+}
+
+// empty pixels within this distance below their ceiling are progressively
+// darkened — a downward contact shadow cast by the surface above them
+const AO_RADIUS = 18;
+const AO_MIN = 0.5;
+// how far the back-wall's edge against open sky is allowed to wander
+const EDGE_WOBBLE = 4;
+
+/**
+ * Paint the back-wall behind the terrain. Every solid pixel gets the back-wall
+ * of its own zone (so erosion reveals the wall rather than empty sky), and every
+ * empty pixel that has solid terrain above it gets the back-wall of the nearest
+ * solid pixel above (its "ceiling"). Debris is drawn on top afterwards, so the
+ * wall effectively runs down to the eroded edge of each span. Open sky (nothing
+ * solid above) and themes without a back-wall (e.g. toon) stay transparent.
+ *
+ * Shading: ambient occlusion darkens each pocket pixel toward the surface above
+ * it (never toward a floor below), and low-frequency noise mottles the rest, so
+ * the wall reads as a lit surface rather than a flat fill. The wall's edge
+ * against open sky is roughened with a wobbled lookup so it isn't dead straight.
+ */
+export function buildBackwall(input: BackwallInput): void {
+  const { background, width, height, zoneMap, zones, seed } = input;
+  const data = background.data;
+  const n = width * height;
+
+  // Pass 1: per column, resolve each pixel's back-wall zone and ambient factor.
+  // zoneOf is -1 for open sky (nothing solid above). aoOf folds in the
+  // below-the-ceiling occlusion so the paint pass only samples and mottles.
+  const zoneOf = new Int32Array(n).fill(-1);
+  const aoOf = new Float32Array(n);
+  for (let x = 0; x < width; x++) {
+    let ceilingZone = -1;
+    let ceilingY = -1;
+    for (let y = 0; y < height; y++) {
+      const i = y * width + x;
+      const zi = zoneMap[i];
+      if (zi !== -1) {
+        zoneOf[i] = zi;
+        aoOf[i] = 1; // behind terrain: no open recess to occlude
+        ceilingZone = zi;
+        ceilingY = y;
+      } else if (ceilingZone !== -1) {
+        zoneOf[i] = ceilingZone;
+        const d = y - ceilingY;
+        aoOf[i] = AO_MIN + (1 - AO_MIN) * Math.min(1, d / AO_RADIUS);
+      }
+    }
+  }
+
+  const colorCache = new Map<string, [number, number, number][]>();
+  const colorsFor = (themeId: string) => {
+    let c = colorCache.get(themeId);
+    if (!c) {
+      c = THEMES[themeId].backwall!.ramp.map(hexToRgb);
+      colorCache.set(themeId, c);
+    }
+    return c;
+  };
+
+  // Pass 2: paint. A wobbled horizontal lookup raggedizes two boundaries at once:
+  // the wall's edge against open sky (an empty pixel whose neighbour is sky is
+  // eroded) and the seam between two adjacent zones (a pixel adopts the
+  // neighbour zone's theme). Solid backing is never eroded, and the interior
+  // shading still comes from each pixel's own column.
+  for (let x = 0; x < width; x++) {
+    for (let y = 0; y < height; y++) {
+      const i = y * width + x;
+      const zoneIdx = zoneOf[i];
+      if (zoneIdx === -1) continue; // open sky
+
+      const off = Math.round(
+        (noise2d(seed ^ 0x2c1f51ed, x >> 3, y >> 2) - 0.5) * 2 * EDGE_WOBBLE
+      );
+      const xs = Math.min(width - 1, Math.max(0, x + off));
+      const sampled = zoneOf[y * width + xs];
+      let zone = zoneIdx;
+      if (sampled === -1) {
+        if (zoneMap[i] === -1) continue; // empty pocket: ragged edge against sky
+        // solid backing stays filled with its own zone
+      } else {
+        zone = sampled; // ragged seam between adjacent zones
+      }
+
+      const themeId = zones[zone].themeId;
+      const band = THEMES[themeId].backwall;
+      if (!band) continue; // theme opts out (toon)
+      const colors = colorsFor(themeId);
+      const [r, g, b] = colors[rampIndex(band, 0, x, y, seed)];
+
+      const mottle = 0.88 + 0.12 * noise2d(seed ^ 0x5bd1e995, x >> 2, y >> 2);
+      const f = aoOf[i] * mottle;
+
+      const o = i * 4;
+      data[o] = r * f;
+      data[o + 1] = g * f;
+      data[o + 2] = b * f;
+      data[o + 3] = 255;
+    }
+  }
+}

--- a/src/data/terrainPaint/debris.ts
+++ b/src/data/terrainPaint/debris.ts
@@ -1,10 +1,11 @@
 import type { PlainBBox } from "../map/bbox";
 import { THEMES } from "./palettes";
-import { createImageData, hexToRgb, pickZone, rampIndex } from "./pixel";
+import { hexToRgb, pickZone, rampIndex } from "./pixel";
 import { noise2d } from "./rng";
 import { isEmptyZone, type ZoneInfo } from "./zones";
 
 export interface DebrisInput {
+  background: ImageData;
   width: number;
   height: number;
   zoneMap: Int32Array;
@@ -17,24 +18,44 @@ export interface DebrisInput {
 const KEEP_BASE = 0.4;
 const KEEP_VARIATION = 0.2;
 const ROUGHEN_PX = 3;
+// eroded terrain reads as deep shadow: darken the wall to the back-wall's
+// darkest ambient-occlusion level (AO_MIN) so debris matches those shadows
+const DEBRIS_SHADE = 0.5;
 // deep terrain shouldn't crater: never erode more than this from a span's top
 const MAX_EROSION_PX = 10;
 const RUBBLE_BAND_PX = 22;
 const RAIL_WIDTH = 2;
 const RUNG_SPACING = 8;
 const RUNG_HEIGHT = 2;
+// darkest multiplier of the contact shadow pooled at a ladder's base
+const LADDER_AO_MIN = 0.72;
+// darkest multiplier of the shadow a ladder casts on the wall along its length
+const LADDER_SHADOW_MIN = 0.74;
 
 /**
  * Build the destroyed-terrain background: every landmass collapses into a
  * debris mound that is a strict subset of its original silhouette, plus
  * ladders drawn in empty space. Everything else stays fully transparent.
  */
-export function buildDebris(input: DebrisInput): ImageData {
-  const { width, height, zoneMap, landmassMap, zones, ladders, seed } = input;
-  const rubbleColors = zones.map((zone) =>
-    THEMES[zone.themeId].rubble.ramp.map(hexToRgb)
+export function buildDebris(input: DebrisInput): void {
+  const { background, width, height, zoneMap, landmassMap, zones, ladders, seed } =
+    input;
+  // shade the back-wall ramp (the same material seen behind terrain) down to the
+  // occlusion-shadow level; fall back to rubble for themes without a back-wall
+  const debrisBands = zones.map((zone) => {
+    const theme = THEMES[zone.themeId];
+    return { ramp: (theme.backwall ?? theme.rubble).ramp };
+  });
+  const debrisColors = debrisBands.map((band) =>
+    band.ramp.map((hex) => {
+      const [r, g, b] = hexToRgb(hex);
+      return [r * DEBRIS_SHADE, g * DEBRIS_SHADE, b * DEBRIS_SHADE] as [
+        number,
+        number,
+        number
+      ];
+    })
   );
-  const background = createImageData(width, height);
   const data = background.data;
 
   // per column, per landmass span: keep only the bottom portion
@@ -63,9 +84,9 @@ export function buildDebris(input: DebrisInput): ImageData {
       const newTop = y + erosion;
       for (let yy = newTop; yy < end; yy++) {
         const zi = pickZone(zoneMap, width, height, x, yy, seed);
-        const colors = rubbleColors[zi];
+        const colors = debrisColors[zi];
         const t = Math.min(0.999, (yy - newTop) / (RUBBLE_BAND_PX * colors.length));
-        const idx = rampIndex(THEMES[zones[zi].themeId].rubble, t, x, yy, seed);
+        const idx = rampIndex(debrisBands[zi], t, x, yy, seed);
         const [r, g, b] = colors[idx];
         const o = (yy * width + x) * 4;
         data[o] = r;
@@ -103,6 +124,25 @@ export function buildDebris(input: DebrisInput): ImageData {
       const right = Math.min(width, Math.round(ladder.right));
       const top = Math.max(0, Math.round(ladder.top));
       const bottom = Math.min(height, Math.round(ladder.bottom));
+
+      // soft shadow the ladder casts on the wall behind it, the full length,
+      // fading out sideways; only darkens existing opaque wall/debris
+      const sHalf = (right - left) * 0.9 + 3;
+      const ssLo = Math.max(0, Math.floor(cx - sHalf));
+      const ssHi = Math.min(width, Math.ceil(cx + sHalf));
+      for (let yy = top; yy < bottom; yy++) {
+        for (let xx = ssLo; xx < ssHi; xx++) {
+          const o = (yy * width + xx) * 4;
+          if (data[o + 3] !== 255) continue;
+          const dx = Math.abs(xx - cx) / sHalf;
+          if (dx >= 1) continue;
+          const k = LADDER_SHADOW_MIN + (1 - LADDER_SHADOW_MIN) * dx;
+          data[o] *= k;
+          data[o + 1] *= k;
+          data[o + 2] *= k;
+        }
+      }
+
       for (let yy = top; yy < bottom; yy++) {
         for (let xx = left; xx < right; xx++) {
           const isRail = xx < left + RAIL_WIDTH || xx >= right - RAIL_WIDTH;
@@ -118,6 +158,43 @@ export function buildDebris(input: DebrisInput): ImageData {
       }
     }
   }
+}
 
-  return background;
+/**
+ * Pool a soft radial contact shadow on the given layer around each ladder's
+ * base, fading up and outward. Applied to the terrain layer so the shadow lands
+ * on the ledge the ladder rests on; only darkens existing opaque pixels.
+ */
+export function shadeLadderBases(
+  image: ImageData,
+  ladders: PlainBBox[],
+  width: number,
+  height: number
+): void {
+  const data = image.data;
+  for (const ladder of ladders) {
+    const baseX = Math.round((ladder.left + ladder.right) / 2);
+    const bottom = Math.min(height, Math.round(ladder.bottom));
+    // wide, shallow ellipse so the shadow spreads sideways more than it sinks
+    const rx = Math.max(16, Math.round((ladder.right - ladder.left) * 1.6));
+    const ry = Math.round(rx * 0.6);
+    const syLo = Math.max(0, bottom - ry);
+    const syHi = Math.min(height, bottom + (ry >> 1));
+    const sxLo = Math.max(0, baseX - rx);
+    const sxHi = Math.min(width, baseX + rx);
+    for (let yy = syLo; yy < syHi; yy++) {
+      for (let xx = sxLo; xx < sxHi; xx++) {
+        const o = (yy * width + xx) * 4;
+        if (data[o + 3] !== 255) continue;
+        const dx = (xx - baseX) / rx;
+        const dy = (yy - bottom) / ry;
+        const d = Math.sqrt(dx * dx + dy * dy);
+        if (d >= 1) continue;
+        const k = LADDER_AO_MIN + (1 - LADDER_AO_MIN) * d;
+        data[o] *= k;
+        data[o + 1] *= k;
+        data[o + 2] *= k;
+      }
+    }
+  }
 }

--- a/src/data/terrainPaint/debris.ts
+++ b/src/data/terrainPaint/debris.ts
@@ -1,4 +1,5 @@
 import type { PlainBBox } from "../map/bbox";
+import { AO_MIN } from "./backwall";
 import { THEMES } from "./palettes";
 import { hexToRgb, pickZone, rampIndex } from "./pixel";
 import { noise2d } from "./rng";
@@ -19,8 +20,8 @@ const KEEP_BASE = 0.4;
 const KEEP_VARIATION = 0.2;
 const ROUGHEN_PX = 3;
 // eroded terrain reads as deep shadow: darken the wall to the back-wall's
-// darkest ambient-occlusion level (AO_MIN) so debris matches those shadows
-const DEBRIS_SHADE = 0.5;
+// darkest ambient-occlusion level so debris matches those shadows
+const DEBRIS_SHADE = AO_MIN;
 // deep terrain shouldn't crater: never erode more than this from a span's top
 const MAX_EROSION_PX = 10;
 const RUBBLE_BAND_PX = 22;
@@ -83,7 +84,7 @@ export function buildDebris(input: DebrisInput): void {
       const erosion = Math.min(fractional, Math.max(0, capped));
       const newTop = y + erosion;
       for (let yy = newTop; yy < end; yy++) {
-        const zi = pickZone(zoneMap, width, height, x, yy, seed);
+        const zi = pickZone(zoneMap, width, height, x, yy, seed, landmassMap);
         const colors = debrisColors[zi];
         const t = Math.min(0.999, (yy - newTop) / (RUBBLE_BAND_PX * colors.length));
         const idx = rampIndex(debrisBands[zi], t, x, yy, seed);

--- a/src/data/terrainPaint/index.ts
+++ b/src/data/terrainPaint/index.ts
@@ -63,7 +63,7 @@ export function paintTerrain(input: PaintInput): PaintResult {
     for (let x = 0; x < width; x++) {
       const i = y * width + x;
       if (!alpha[i]) continue;
-      const zi = pickZone(zoneMap, width, height, x, y, seed);
+      const zi = pickZone(zoneMap, width, height, x, y, seed, landmassMap);
       const theme = THEMES[zones[zi].themeId];
 
       // wobble the depth/sky fields so band boundaries and the color steps

--- a/src/data/terrainPaint/index.ts
+++ b/src/data/terrainPaint/index.ts
@@ -1,8 +1,10 @@
 import type { PlainBBox } from "../map/bbox";
-import { buildDebris } from "./debris";
+import { buildDebris, shadeLadderBases } from "./debris";
+import { buildBackwall } from "./backwall";
 import { computeField } from "./field";
 import { THEMES } from "./palettes";
 import { createImageData, hexToRgb, pickZone, rampIndex } from "./pixel";
+import { noise2d } from "./rng";
 import { computeZones, type ZoneInfo } from "./zones";
 
 export interface PaintInput {
@@ -18,7 +20,7 @@ export interface PaintInput {
 export interface PaintResult {
   /** Opaque exactly where the input alpha is solid. */
   terrain: ImageData;
-  /** Debris + ladders, transparent elsewhere. */
+  /** Themed back-wall + debris + ladders, transparent in open sky. */
   background: ImageData;
   zones: ZoneInfo[];
   /** Zone index per pixel, -1 for empty — lets the UI map clicks to zones. */
@@ -28,6 +30,11 @@ export interface PaintResult {
 const OUTLINE_DEPTH = 2.5;
 // each deep-ramp color covers this many px of depth before the next, darker one
 const DEEP_PX_PER_RAMP_STEP = 28;
+// px of low-frequency wobble added to the sky/depth fields so every depth-based
+// transition — band boundaries AND the color steps within a band — undulates
+// instead of tracing straight contours
+const SKY_JITTER = 4;
+const DEPTH_JITTER = 7;
 
 export function paintTerrain(input: PaintInput): PaintResult {
   const { alpha, width, height, ladders, seed } = input;
@@ -59,22 +66,32 @@ export function paintTerrain(input: PaintInput): PaintResult {
       const zi = pickZone(zoneMap, width, height, x, y, seed);
       const theme = THEMES[zones[zi].themeId];
 
+      // wobble the depth/sky fields so band boundaries and the color steps
+      // within each band undulate; coarse noise keeps the wobble smooth, and
+      // the raw depth still drives the crisp silhouette outline
+      const skyV =
+        sky[i] +
+        (noise2d(seed ^ 0x2f1d35b, x >> 2, y >> 2) - 0.5) * 2 * SKY_JITTER;
+      const depthV =
+        depth[i] +
+        (noise2d(seed ^ 0x77a3c19, x >> 2, y >> 2) - 0.5) * 2 * DEPTH_JITTER;
+
       let hex: string;
       if (theme.outline && depth[i] <= OUTLINE_DEPTH) {
         hex = theme.outline;
-      } else if (sky[i] < theme.surface.thickness) {
+      } else if (skyV < theme.surface.thickness) {
         const idx = rampIndex(
           theme.surface,
-          sky[i] / theme.surface.thickness,
+          skyV / theme.surface.thickness,
           x,
           y,
           seed
         );
         hex = theme.surface.ramp[idx];
-      } else if (depth[i] < theme.shallow.depth) {
+      } else if (depthV < theme.shallow.depth) {
         const idx = rampIndex(
           theme.shallow,
-          depth[i] / theme.shallow.depth,
+          depthV / theme.shallow.depth,
           x,
           y,
           seed
@@ -83,7 +100,7 @@ export function paintTerrain(input: PaintInput): PaintResult {
       } else {
         const t = Math.min(
           0.999,
-          (depth[i] - theme.shallow.depth) /
+          (depthV - theme.shallow.depth) /
             (DEEP_PX_PER_RAMP_STEP * theme.deep.ramp.length)
         );
         hex = theme.deep.ramp[rampIndex(theme.deep, t, x, y, seed)];
@@ -98,7 +115,10 @@ export function paintTerrain(input: PaintInput): PaintResult {
     }
   }
 
-  const background = buildDebris({
+  const background = createImageData(width, height);
+  buildBackwall({ background, width, height, zoneMap, zones, seed });
+  buildDebris({
+    background,
     width,
     height,
     zoneMap,
@@ -107,6 +127,7 @@ export function paintTerrain(input: PaintInput): PaintResult {
     ladders,
     seed,
   });
+  shadeLadderBases(terrain, ladders, width, height);
 
   return { terrain, background, zones, zoneMap };
 }

--- a/src/data/terrainPaint/palettes.ts
+++ b/src/data/terrainPaint/palettes.ts
@@ -1,3 +1,5 @@
+import { noise2d } from "./rng";
+
 export type PatternFn = (
   x: number,
   y: number,
@@ -20,6 +22,8 @@ export interface Theme {
   ladder: { rail: string; rung: string };
   /** Pillow-shading silhouette outline; omit to disable for the theme. */
   outline?: string;
+  /** Lightened background painted into roofed empty pockets; omit to opt out. */
+  backwall?: MaterialBand;
 }
 
 /** Brick coursing: 8×4 bricks offset every other row; last ramp color = mortar. */
@@ -65,6 +69,89 @@ const plankPattern: PatternFn = (x, y, rampIndex, rampLength) => {
   return Math.min(rampLength - 2, rampIndex + (plankId % 2));
 };
 
+// Fixed seed for the position-stable texture noise the back-wall patterns use.
+const PNOISE = 0x51ed2c1f;
+// small ±n integer offset, stable per (x, y), for roughening pattern edges
+const edgeJitter = (x: number, y: number, salt: number, n: number): number =>
+  Math.round((noise2d(PNOISE ^ salt, x, y) - 0.5) * 2 * n);
+
+/** Mineshaft: light rock with crisp vertical timber posts + cross-beams. */
+const minePattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const px = ((x % 40) + 40) % 40;
+  const py = ((y % 56) + 56) % 56;
+  if (px < 7 || py < 6) {
+    if (px === 0 || py === 0) return Math.max(0, rampLength - 3); // lit edge
+    return rampLength - 1; // timber
+  }
+  const mottle = noise2d(PNOISE ^ 9, x >> 1, y >> 1) < 0.4 ? 1 : 0;
+  return Math.min(rampLength - 2, rampIndex + mottle);
+};
+
+/** Dirt: mottled soil with scattered, varied embedded stones. */
+const dirtPattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const cx = Math.floor(x / 17);
+  const cy = Math.floor(y / 15);
+  if (noise2d(PNOISE ^ 21, cx, cy) > 0.74) {
+    const ox = 4 + Math.floor(noise2d(PNOISE ^ 22, cx, cy) * 9);
+    const oy = 4 + Math.floor(noise2d(PNOISE ^ 23, cx, cy) * 7);
+    const rr = 3 + Math.floor(noise2d(PNOISE ^ 24, cx, cy) * 8);
+    const dx = (((x % 17) + 17) % 17) - ox;
+    const dy = (((y % 15) + 15) % 15) - oy;
+    if (dx * dx + dy * dy < rr) {
+      return dy < 0 ? rampLength - 2 : rampLength - 1; // lit top edge / stone
+    }
+  }
+  const clump = noise2d(PNOISE ^ 25, x >> 2, y >> 2);
+  return Math.min(rampLength - 2, clump > 0.6 ? 1 : 0);
+};
+
+/** Girders: light steel with a beveled, riveted I-beam lattice; fuzzy edges. */
+const girderPattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const gx = (((x + edgeJitter(x, y, 1, 2)) % 44) + 44) % 44;
+  const gy = (((y + edgeJitter(x, y, 2, 2)) % 48) + 48) % 48;
+  const onV = gx >= 16 && gx < 28;
+  const onH = gy >= 20 && gy < 29;
+  if ((onV && gy % 12 === 6) || (onH && gx % 12 === 6)) return rampLength - 1; // rivet
+  if (onV || onH) {
+    if ((onV && gx === 16) || (onH && gy === 20)) return 0; // lit edge
+    if ((onV && gx === 27) || (onH && gy === 28)) return rampLength - 2; // shadow edge
+    return rampLength - 3; // beam body
+  }
+  const mottle = noise2d(PNOISE ^ 33, x >> 2, y >> 2) > 0.6 ? 1 : 0;
+  return Math.min(rampLength - 3, rampIndex + mottle);
+};
+
+/** Packed ice: lit strata bands with fuzzy crack seams and embedded stones. */
+const icePattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const yj = y + edgeJitter(x, y, 3, 2);
+  const into = ((yj % 11) + 11) % 11;
+  if (into === 0) return rampLength - 1; // crack seam
+  const cx = Math.floor(x / 24);
+  const cy = Math.floor(y / 19);
+  if (noise2d(PNOISE ^ 31, cx, cy) > 0.8) {
+    const dx = (((x % 24) + 24) % 24) - 6;
+    const dy = (((y % 19) + 19) % 19) - 6;
+    if (dx * dx + dy * dy < 7) return rampLength - 1; // stone
+  }
+  if (into <= 1) return 0; // sheen just below the seam
+  const band = ((Math.floor(yj / 11) % 2) + 2) % 2;
+  return Math.min(rampLength - 2, rampIndex + band);
+};
+
+/** Timber frame: light backing with crisp vertical studs and a diagonal brace. */
+const framePattern: PatternFn = (x, y, rampIndex, rampLength) => {
+  const bx = ((x % 34) + 34) % 34;
+  const by = ((y % 34) + 34) % 34;
+  const onStud = bx < 5;
+  const onBrace = Math.abs(bx - by) < 3;
+  if (onStud || onBrace) {
+    if (bx === 0 || bx - by === -2) return Math.max(0, rampLength - 3); // lit edge
+    return rampLength - 1; // timber
+  }
+  const grain = noise2d(PNOISE ^ 41, x >> 2, y) < 0.5 ? 0 : 1;
+  return Math.min(rampLength - 2, rampIndex + grain);
+};
+
 export const THEMES: Record<string, Theme> = {
   grassland: {
     id: "grassland",
@@ -74,6 +161,12 @@ export const THEMES: Record<string, Theme> = {
     deep: { ramp: ["#8a8478", "#6e695f", "#544f47"] },
     rubble: { ramp: ["#cbb59b", "#bca68b", "#ad967b"] },
     ladder: { rail: "#6f4730", rung: "#a9714b" },
+    backwall: {
+      // lightened tints of the foreground dirt (shallow ramp) so the wall reads
+      // as the same earth seen behind the play surface
+      ramp: ["#c89070", "#b27a58", "#996343", "#6f4730"],
+      pattern: dirtPattern,
+    },
   },
   cave: {
     id: "cave",
@@ -92,6 +185,10 @@ export const THEMES: Record<string, Theme> = {
     },
     rubble: { ramp: ["#a8a69f", "#97958e", "#86847d"] },
     ladder: { rail: "#5a4634", rung: "#6f5640" },
+    backwall: {
+      ramp: ["#9a8f82", "#857a6d", "#6b6053", "#43361f"],
+      pattern: minePattern,
+    },
   },
   snow: {
     id: "snow",
@@ -101,6 +198,10 @@ export const THEMES: Record<string, Theme> = {
     deep: { ramp: ["#5d6a78", "#4a5563", "#3a4350"] },
     rubble: { ramp: ["#e2e8ee", "#d2dae2", "#c1cbd5"] },
     ladder: { rail: "#5a4634", rung: "#8a5a3b" },
+    backwall: {
+      ramp: ["#e7eff5", "#d2dde6", "#b9c6d1", "#92a2b0"],
+      pattern: icePattern,
+    },
   },
   urban: {
     id: "urban",
@@ -123,6 +224,10 @@ export const THEMES: Record<string, Theme> = {
       pattern: rebarPattern,
     },
     ladder: { rail: "#4a4d52", rung: "#6e6e68" },
+    backwall: {
+      ramp: ["#bcc1c7", "#a9aeb4", "#969ca3", "#7c848c", "#55606a"],
+      pattern: girderPattern,
+    },
   },
   planks: {
     id: "planks",
@@ -137,6 +242,10 @@ export const THEMES: Record<string, Theme> = {
     deep: { ramp: ["#6e5233", "#5d4429", "#4c3720"] },
     rubble: { ramp: ["#dcc39c", "#cdb189", "#bd9f76"] },
     ladder: { rail: "#5a4226", rung: "#967040" },
+    backwall: {
+      ramp: ["#cba877", "#b1905f", "#8a6c44", "#4f3c24"],
+      pattern: framePattern,
+    },
   },
   toon: {
     id: "toon",

--- a/src/data/terrainPaint/pixel.ts
+++ b/src/data/terrainPaint/pixel.ts
@@ -46,6 +46,10 @@ export function rampIndex(
 /**
  * Sample the zone at a jittered position. Near zone seams this dithers
  * pixels between the two zones, producing ragged organic transitions.
+ *
+ * When a landmassMap is given the jittered sample is only adopted if it lands
+ * on the same landmass, so the dither never leaks one island's theme onto a
+ * different island that happens to sit within SEAM_JITTER of it.
  */
 export function pickZone(
   zoneMap: Int32Array,
@@ -53,8 +57,10 @@ export function pickZone(
   height: number,
   x: number,
   y: number,
-  seed: number
+  seed: number,
+  landmassMap?: Int32Array
 ): number {
+  const i = y * width + x;
   const jx = Math.min(
     width - 1,
     Math.max(
@@ -69,6 +75,9 @@ export function pickZone(
       y + Math.round((noise2d(seed ^ 0x85ebca6b, x, y) - 0.5) * 2 * SEAM_JITTER)
     )
   );
-  const zone = zoneMap[jy * width + jx];
-  return zone >= 0 ? zone : zoneMap[y * width + x];
+  const j = jy * width + jx;
+  const zone = zoneMap[j];
+  if (zone < 0) return zoneMap[i];
+  if (landmassMap && landmassMap[j] !== landmassMap[i]) return zoneMap[i];
+  return zone;
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This PR targets `terrain-paint` — do not merge until #42 is merged.

### Description

Fills the space behind terrain and in roofed pockets with a themed, lightened "back-wall" that connects zones of the same type and meets the eroded debris below. Each theme gets its own material — mineshaft (cave), dirt & rocks (grassland), girders (urban), packed ice (snow), timber frame (planks); toon opts out. Includes downward-only ambient occlusion below surfaces, ragged outer edges and dithered seams between adjacent zones, eroded debris darkened to the occlusion-shadow tone, ladder contact/length shadows, and wobbled grass/dirt/deep band transitions on the terrain itself.

### Manual check

- Run `yarn dev` and open the Builder
- Generate or import a terrain, then open "Paint terrain procedurally"
- Set a mix of zone themes (cave, grassland, urban, snow, planks, toon)
- [ ] Roofed pockets and the area behind terrain show the themed back-wall, clearly lighter than the terrain
- [ ] Toon zones leave their pockets transparent (parallax shows through)
- [ ] Destroying terrain reveals dark debris matching the occlusion-shadow tone
- [ ] Ladders cast a soft contact shadow on the terrain at their base and a shadow on the wall along their length
- [ ] Grass/dirt/deep band transitions and seams between adjacent zones read ragged, not straight