### PR TITLE
Builder configuration wizard

### DIFF
--- a/src/components/molecules/BuilderDescription.vue
+++ b/src/components/molecules/BuilderDescription.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+export type DescriptionTopic =
+  | "terrain"
+  | "wallmask"
+  | "background"
+  | "overlays"
+  | "advanced"
+  | "publishing";
+
+defineProps<{ topic: DescriptionTopic }>();
+</script>
+
+<template>
+  <p v-if="topic === 'terrain'">
+    A map needs at least a terrain to be playable. The terrain is the layer that
+    can be blown up and by default this is what the sorcerers stand on. At the
+    default scale (6x6), a character is 6 pixels wide and 16 pixels high. They
+    can jump about 21 pixels high. You can use this template
+    <img src="../../assets/mask.png" alt="Mask" title="Mask" /> when making the
+    basic outline of your map to make sure the scale is correct. Generally the
+    height of an area should be a lot higher than 21 pixels to prevent it from
+    feeling cramped.
+  </p>
+
+  <p v-else-if="topic === 'wallmask'">
+    In the advanced settings you can enable the wallmask, this will overwrite the
+    default wallmask that gets generated from the terrain. You can use this
+    feature if you want to add things to your map that can be blown up but not
+    collide with the sorcerers. You can also use it for example for stairs that
+    have distinct steps but a smooth diagonal wallmask so it can be scaled
+    without jumping. The wallmask is always 6x6 so it will have to be scaled down
+    if you use a smaller scale (eg if you have a terrain that's 600 pixels wide
+    on scale 3, the wallmask should be scaled down 50% to 300 pixels to match).
+    Because the wallmask is not shown to the player this image can be black +
+    transparent to reduce the file size.
+  </p>
+
+  <p v-else-if="topic === 'background'">
+    The background is placed behind the sorcerers and can't be blown up. It can
+    be used to show where the terrain used to be after it has been blown up and
+    to add some more detail to the map. Typically the colors used for the
+    background are less saturated so it's clear what's part of the terrain and
+    what is not. The sky does not need to be part of the background, you can use
+    a built in parallax background for this in the advanced settings.
+  </p>
+
+  <p v-else-if="topic === 'overlays'">
+    Overlays are drawn on top of the sorcerers and become transparent for
+    sorcerers intersecting them. This means the image should fit the content
+    closely and generally be fairly rectangular. Overlays can be dragged in the
+    right position after adding. They can be used for sorcerers to hide behind
+    and can get blown up like the terrain.
+  </p>
+
+  <ul v-else-if="topic === 'advanced'">
+    <li>
+      <h4>Scale</h4>
+      <p>
+        The scale is the resolution of the map, a smaller scale can be used to
+        add more detail to the map. Keep in mind that collisions (the wallmask)
+        are always at the 6x6 scale. For this reason multiples of 6 (6, 3, 2, 1)
+        are preferred. It is recommended to first plan out the layout of your map
+        at the 6x6 scale and then scale it up if you want to work at a higher
+        resolution.
+      </p>
+    </li>
+    <li>
+      <h4>Spawn area</h4>
+      <p>
+        The spawn area can either be changed from the advanced settings or by
+        dragging the red box in the builder. The spawn area dictates where
+        sorcerers can spawn at the start of the game.
+      </p>
+    </li>
+    <li>
+      <h4>Parallax background & vertical offset</h4>
+      <p>
+        A parallax background adds some more depth to the game by making details
+        in the distance move slower than details closer by. The vertical offset
+        can be used to move the still layers up or down. If you wish to add your
+        own parallax background, pull requests are welcome! Take a look at
+        <code>src/data/map/background.ts</code> to see how they're configured.
+      </p>
+    </li>
+  </ul>
+
+  <p v-else-if="topic === 'publishing'">
+    If you made a cool map that you want to share, feel free to make a pull
+    request to add it to the game (See
+    <code>src/util/assets/constants.ts</code>). If you do not know how to use git
+    you can also
+    <a
+      href="https://github.com/lorgan3/sorcerers/issues"
+      target="_blank"
+      rel="noopener noreferrer"
+      >open an issue</a
+    >
+    so someone else can add it for you. All reasonable maps will be accepted, if
+    you have a crazy idea consider contacting me first if you want to ensure it
+    can get added to the game.<br />
+    Please optimize the images first (eg
+    <a
+      href="https://imageoptim.com/mac"
+      target="_blank"
+      rel="noopener noreferrer"
+      >imageOptim</a
+    >) before compiling the final version of your map, this can easily cut the
+    filesize in half.
+  </p>
+</template>
+
+<style lang="scss" scoped>
+ul {
+  margin-left: 10px;
+}
+
+h4 {
+  margin-top: 10px;
+}
+
+code {
+  font-family: monospace;
+  font-size: 14px;
+}
+</style>

--- a/src/components/molecules/Dialog.vue
+++ b/src/components/molecules/Dialog.vue
@@ -9,6 +9,9 @@ const props = defineProps<{
   title: string;
   onClose: () => void;
   ingame?: boolean;
+  // seamless: no own backdrop dim / scale-in, for when a parent already provides
+  // a constant backdrop (e.g. the builder wizard) so screens don't double-dim or pop
+  seamless?: boolean;
 }>();
 
 const slots = defineSlots<{
@@ -54,7 +57,7 @@ watch(
 </script>
 
 <template>
-  <dialog ref="dialog" id="dialog">
+  <dialog ref="dialog" id="dialog" :class="{ seamless: props.seamless }">
     <div
       ref="content"
       :class="{ content: true, 'content--ingame': props.ingame }"
@@ -83,6 +86,15 @@ dialog {
 
   &::backdrop {
     animation: fade-in 0.3s forwards;
+  }
+
+  &.seamless::backdrop {
+    animation: none;
+    background-color: transparent;
+  }
+
+  &.seamless .content {
+    animation: none;
   }
 
   @keyframes fade-in {

--- a/src/components/organisms/AiAlignDialog.vue
+++ b/src/components/organisms/AiAlignDialog.vue
@@ -214,7 +214,7 @@ function handleConfirm() {
 </script>
 
 <template>
-  <Dialog open :onClose="onClose" title="Align AI terrain">
+  <Dialog open seamless :onClose="onClose" title="Align AI terrain">
     <div class="align-dialog">
       <div class="preview-scroll">
         <canvas ref="previewCanvas" class="preview" />
@@ -260,8 +260,8 @@ function handleConfirm() {
       </label>
 
       <div class="actions">
-        <button class="primary" @click="handleConfirm">Confirm</button>
-        <button class="secondary" @click="onClose">Cancel</button>
+        <button class="secondary" @click="onClose">Back</button>
+        <button class="primary" @click="handleConfirm">Next</button>
       </div>
     </div>
   </Dialog>
@@ -339,7 +339,13 @@ function handleConfirm() {
 
 .actions {
   display: flex;
+  align-items: center;
   gap: 8px;
   margin-top: 4px;
+
+  // back button pinned left, primary action to the right
+  > :first-child {
+    margin-right: auto;
+  }
 }
 </style>

--- a/src/components/organisms/BuilderSettings.vue
+++ b/src/components/organisms/BuilderSettings.vue
@@ -1,18 +1,11 @@
 <script setup lang="ts">
 import Dialog from "../molecules/Dialog.vue";
 import Input from "../atoms/Input.vue";
-import { BBox } from "../../data/map/bbox";
 import { ref, watch } from "vue";
 import Tooltip from "../atoms/Tooltip.vue";
 import { CONFIGS } from "../../data/map/background";
-
-export interface AdvancedSettings {
-  bbox: BBox;
-  scale: number;
-  customMask: boolean;
-  parallaxName: string;
-  parallaxOffset: number;
-}
+import type { AdvancedSettings } from "../../data/builder/draft";
+export type { AdvancedSettings };
 
 const { settings, onClose } = defineProps<{
   settings: AdvancedSettings;

--- a/src/components/organisms/BuilderWizard.vue
+++ b/src/components/organisms/BuilderWizard.vue
@@ -1,0 +1,459 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { useRouter } from "vue-router";
+import { useBuilderWizard } from "../pages/composables/useBuilderWizard";
+import { useMapDraft } from "../../data/builder/draft";
+import WfcDialog, { type WfcSettings } from "./WfcDialog.vue";
+import TerrainPaintDialog from "./TerrainPaintDialog.vue";
+import AiAlignDialog from "./AiAlignDialog.vue";
+import MapSelect from "./MapSelect.vue";
+import ImageInput from "../molecules/ImageInput.vue";
+import BuilderDescription from "../molecules/BuilderDescription.vue";
+import Collapsible from "../atoms/Collapsible.vue";
+import TornPanel from "../atoms/TornPanel.vue";
+import IconButton from "../atoms/IconButton.vue";
+import close from "pixelarticons/svg/close.svg";
+import autoMapIcon from "pixelarticons/svg/shuffle.svg";
+import autoTerrainIcon from "pixelarticons/svg/magic-edit.svg";
+import manualIcon from "pixelarticons/svg/image-new.svg";
+import type { LadderInfo } from "../../data/wfc/postProcess";
+import type { Config } from "../../data/map";
+import WfcWorker from "../../data/wfc/wfc.worker?worker";
+
+const router = useRouter();
+const { screen, visible, selectPath, next, back, close: closeWizard } =
+  useBuilderWizard();
+const draft = useMapDraft();
+
+const TITLES: Partial<Record<string, string>> = {
+  choose: "Create a map",
+  "autoTerrain-preview": "Add terrain",
+  "manual-terrain": "Add your terrain",
+  "manual-background": "Add a background",
+  "manual-advanced": "Finalize map",
+};
+const title = computed(() => TITLES[screen.value] ?? "");
+
+const wfcSettings = ref<WfcSettings>({
+  width: 10, height: 4, density: 60,
+  edgeTop: 25, edgeBottom: 75, edgeLeft: 0, edgeRight: 0,
+  continuityBonus: 2, preventBlockages: true,
+  densityMode: "edges", densityMask: null, densityImageData: "",
+});
+const wfcLadders = ref<LadderInfo[]>([]);
+
+const goToBuilder = () => {
+  router.push("/builder");
+  closeWizard();
+};
+
+const goBack = () => {
+  if (!back()) closeWizard();
+};
+
+// Each "create" path starts a brand-new map, so clear any map left over from a
+// previously loaded/built session before entering the path. (The Load card
+// repopulates the draft via loadConfig, so it doesn't go through here.)
+const startPath = (p: "autoMap" | "autoTerrain" | "manual") => {
+  draft.reset();
+  selectPath(p);
+};
+
+const handleWfcGenerated = (maskData: string, ladders: LadderInfo[]) => {
+  wfcLadders.value = ladders;
+  draft.applyWfc(maskData, ladders);
+  next();
+};
+
+const wfcGenerating = ref(false);
+let activeWorker: Worker | null = null;
+
+const runWfc = () => {
+  if (wfcGenerating.value) return;
+  wfcGenerating.value = true;
+  const s = wfcSettings.value;
+  const worker = new WfcWorker();
+  activeWorker = worker;
+  worker.postMessage({
+    width: s.width, height: s.height, density: s.density / 100,
+    edges: { top: s.edgeTop / 100, bottom: s.edgeBottom / 100, left: s.edgeLeft / 100, right: s.edgeRight / 100 },
+    continuityBonus: s.continuityBonus, preventBlockages: s.preventBlockages,
+    ...(s.densityMode === "image" && s.densityMask ? { densityMask: s.densityMask } : {}),
+  });
+  worker.onmessage = (e: MessageEvent) => {
+    if (e.data.type === "progress") return;
+    wfcGenerating.value = false;
+    activeWorker = null;
+    worker.terminate();
+    if (e.data.success && e.data.mask) {
+      wfcLadders.value = e.data.ladders ?? [];
+      draft.applyWfc(e.data.mask, e.data.ladders ?? []);
+    }
+  };
+  worker.onerror = () => {
+    wfcGenerating.value = false;
+    activeWorker = null;
+    worker.terminate();
+  };
+};
+
+const aiFileInput = ref<HTMLInputElement>();
+const aiAlignSrc = ref("");
+const showAiAlign = ref(false);
+
+function buildAIPrompt(wpx: number, hpx: number): string {
+  return `Generate an image of a 2D side-view game terrain based on the attached black-and-white mask image. In the mask, black areas represent solid terrain and white areas represent empty sky or background.\n\nThe output image must be exactly ${wpx}x${hpx} pixels — the same dimensions as the input mask.\n\nCreate a textured terrain image that follows these rules:\n- The solid black areas should become detailed, textured <theme> terrain. Add surface detail, shading, and depth to make it look like a painted game environment.\n- The white empty areas should become a distinct, clearly different background — use a lighter sky or atmospheric background that is obviously not terrain. The background must have no transparency.\n- The boundary between terrain and background must be clearly visible with good contrast.\n- Keep the exact same dimensions and shape as the input mask. Do not add, remove, or reshape any terrain. Every black pixel must remain solid, every white pixel must remain background.\n- If there are brown rectangular areas in the image, these indicate ladder positions. Draw wooden ladders on these brown areas. The ladders should look like climbable wooden game ladders with rungs.\n- The output must be a fully opaque image with no transparency anywhere.\n- Use a pixel art or hand-painted 2D game art style.\n- This is a side-scrolling game map, so add appropriate environmental details like grass on top edges, rocky textures on sides, and darker shading underneath overhangs.`;
+}
+
+const handleExportMaskForAI = () => {
+  if (!draft.mask.value.data) return;
+  const image = new Image();
+  image.src = draft.mask.value.data;
+  image.onload = () => {
+    const src = new OffscreenCanvas(image.width, image.height);
+    const srcCtx = src.getContext("2d")!;
+    srcCtx.drawImage(image, 0, 0);
+    const dst = new OffscreenCanvas(image.width, image.height);
+    const dstCtx = dst.getContext("2d")!;
+    dstCtx.fillStyle = "#ffffff";
+    dstCtx.fillRect(0, 0, image.width, image.height);
+    if (wfcLadders.value.length > 0) {
+      dstCtx.fillStyle = "#8B4513";
+      for (const ladder of wfcLadders.value) {
+        dstCtx.fillRect(ladder.x - ladder.width / 2, ladder.y, ladder.width, ladder.height);
+      }
+    }
+    const srcData = srcCtx.getImageData(0, 0, image.width, image.height);
+    const dstData = dstCtx.getImageData(0, 0, image.width, image.height);
+    for (let i = 0; i < srcData.data.length; i += 4) {
+      if (srcData.data[i + 3] > 128) {
+        dstData.data[i] = 0; dstData.data[i + 1] = 0; dstData.data[i + 2] = 0; dstData.data[i + 3] = 255;
+      }
+    }
+    dstCtx.putImageData(dstData, 0, 0);
+    navigator.clipboard.writeText(buildAIPrompt(image.width, image.height));
+    dst.convertToBlob({ type: "image/png" }).then((blob) => {
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.download = `${draft.name.value || "mask"}-ai.png`;
+      link.href = url;
+      link.click();
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+    });
+  };
+};
+
+const handleImportClick = () => aiFileInput.value?.click();
+const handleAiFile = (event: Event) => {
+  const file = (event.target as HTMLInputElement).files?.[0];
+  if (!file || !draft.mask.value.data) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    aiAlignSrc.value = reader.result as string;
+    showAiAlign.value = true;
+  };
+  reader.readAsDataURL(file);
+  (event.target as HTMLInputElement).value = "";
+};
+const handleAiAlignConfirm = (result: {
+  terrain: string; background: string; mask: string; width: number; height: number;
+}) => {
+  draft.applyAiAlign(result);
+  showAiAlign.value = false;
+  goToBuilder();
+};
+
+const handleAddTerrain = (_: File, data: string) => {
+  draft.setTerrainImage(data);
+  next();
+};
+const handleAddBackground = (_: File, data: string) => {
+  draft.setBackgroundImage(data);
+  next();
+};
+
+const handlePaintConfirm = (result: {
+  terrain: string; background: string; width: number; height: number;
+}) => {
+  draft.applyPaint(result);
+  goToBuilder();
+};
+
+const handleLoad = (config: Config, name: string) => {
+  draft.loadConfig(config, name);
+  goToBuilder();
+};
+
+const handleBuild = () => {
+  draft.build();
+  closeWizard();
+};
+
+const handleKeydown = (e: KeyboardEvent) => {
+  if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+  if (
+    visible.value &&
+    (screen.value === "autoMap-paint" || screen.value === "autoTerrain-preview") &&
+    (e.key === "g" || e.key === "G")
+  ) {
+    runWfc();
+  }
+};
+onMounted(() => window.addEventListener("keydown", handleKeydown));
+onUnmounted(() => {
+  window.removeEventListener("keydown", handleKeydown);
+  if (activeWorker) { activeWorker.terminate(); activeWorker = null; }
+});
+</script>
+
+<template>
+  <template v-if="visible">
+    <!-- persistent dim so transitioning between panel screens and the modal
+         dialogs never leaves an undimmed frame (no background flash) -->
+    <div class="wizard-dim" />
+    <WfcDialog
+      v-if="screen === 'autoMap-wfc' || screen === 'autoTerrain-wfc'"
+      :settings="wfcSettings"
+      :onGenerate="handleWfcGenerated"
+      :onClose="goBack"
+    />
+    <TerrainPaintDialog
+      v-else-if="screen === 'autoMap-paint'"
+      :alphaSrc="draft.mask.value.data || draft.terrain.value.data"
+      :ladders="draft.ladders.value.map((l) => l.toJS())"
+      :onConfirm="handlePaintConfirm"
+      :onClose="goBack"
+    />
+
+    <div v-else class="wizard-overlay">
+      <div class="wizard-panel">
+        <TornPanel>
+          <div class="wizard-head">
+            <h2>{{ title }}</h2>
+            <IconButton title="Close" :onClick="closeWizard" :icon="close" />
+          </div>
+          <div class="wizard-body">
+            <template v-if="screen === 'choose'">
+              <div class="cards">
+                <button class="card" @click="startPath('autoMap')">
+                  <h3>Autogenerate map</h3>
+                  <p class="sub">Generate a wallmask and paint terrain over it.</p>
+                  <img class="card-icon" :src="autoMapIcon" alt="" />
+                </button>
+                <button class="card" @click="startPath('autoTerrain')">
+                  <h3>Autogenerate terrain</h3>
+                  <p class="sub">Generate a wallmask, then build the terrain yourself.</p>
+                  <img class="card-icon" :src="autoTerrainIcon" alt="" />
+                </button>
+                <button class="card" @click="startPath('manual')">
+                  <h3>Create map manually</h3>
+                  <p class="sub">Upload your own terrain and background images.</p>
+                  <img class="card-icon" :src="manualIcon" alt="" />
+                </button>
+                <div class="card card--select">
+                  <h3>Load map</h3>
+                  <p class="sub">Open an existing map to edit.</p>
+                  <MapSelect compact :onEdit="handleLoad" class="load-select" />
+                </div>
+              </div>
+            </template>
+
+            <template v-else-if="screen === 'autoTerrain-preview'">
+              <div class="preview-frame">
+                <img v-if="draft.mask.value.data" :src="draft.mask.value.data" class="mask-preview" />
+              </div>
+              <p class="sub">
+                Export the mask to paint terrain in an external AI tool, then import
+                the result to finish your map.
+              </p>
+              <input ref="aiFileInput" hidden type="file" accept="image/*" @change="handleAiFile" />
+              <div class="actions">
+                <button class="secondary" @click="goBack">Back</button>
+                <button class="secondary" @click="handleExportMaskForAI">Export mask for AI</button>
+                <button class="primary" @click="handleImportClick">Import AI terrain</button>
+              </div>
+            </template>
+
+            <template v-else-if="screen === 'manual-terrain'">
+              <div class="description"><BuilderDescription topic="terrain" /></div>
+              <ImageInput name="Terrain" :modelValue="draft.terrain.value.data" :onAdd="handleAddTerrain" />
+              <div class="actions">
+                <button class="secondary" @click="goBack">Back</button>
+              </div>
+            </template>
+
+            <template v-else-if="screen === 'manual-background'">
+              <div class="description"><BuilderDescription topic="background" /></div>
+              <ImageInput name="Background" :modelValue="draft.background.value.data" :onAdd="handleAddBackground" />
+              <div class="actions">
+                <button class="secondary" @click="goBack">Back</button>
+                <button class="primary" @click="next">Skip</button>
+              </div>
+            </template>
+
+            <template v-else-if="screen === 'manual-advanced'">
+              <Collapsible title="Advanced settings">
+                <div class="advanced-scroll">
+                  <div class="description">
+                    <BuilderDescription topic="advanced" />
+                    <h4>Wallmask</h4>
+                    <BuilderDescription topic="wallmask" />
+                    <h4>Overlays</h4>
+                    <BuilderDescription topic="overlays" />
+                  </div>
+                </div>
+              </Collapsible>
+              <div class="actions">
+                <button class="secondary" @click="goBack">Back</button>
+                <button class="primary" @click="handleBuild">Build</button>
+                <button class="primary" @click="goToBuilder">Continue in builder</button>
+              </div>
+            </template>
+          </div>
+        </TornPanel>
+      </div>
+    </div>
+
+    <AiAlignDialog
+      v-if="showAiAlign"
+      :maskSrc="draft.mask.value.data"
+      :aiSrc="aiAlignSrc"
+      :onConfirm="handleAiAlignConfirm"
+      :onClose="() => (showAiAlign = false)"
+    />
+  </template>
+</template>
+
+<style lang="scss" scoped>
+.wizard-dim {
+  position: fixed;
+  inset: 0;
+  z-index: 99;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.wizard-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.wizard-panel {
+  width: 100%;
+  max-width: 640px;
+}
+
+.wizard-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  margin-right: -10px;
+  min-height: 40px;
+}
+
+/* fixed height so every wizard screen is the same size as the paint dialog */
+.wizard-body {
+  height: min(460px, 76vh);
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.cards {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-auto-rows: 1fr;
+  gap: 12px;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  padding: 14px;
+  background: var(--field-bg);
+  border: 2px solid var(--border-accent-faint);
+  border-radius: var(--small-radius);
+  cursor: pointer;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+
+  h3 { margin: 0 0 6px; }
+
+  &:not(.card--select):hover {
+    border-color: var(--border-accent);
+    box-shadow: 2px 2px 0 var(--shadow-hard), 0 0 8px var(--glow-warm-soft);
+  }
+}
+
+.card-icon {
+  // center in the leftover space below the text
+  margin: auto;
+  width: 72px;
+  height: 72px;
+  opacity: 0.22;
+  image-rendering: pixelated;
+}
+
+.card--select {
+  cursor: default;
+
+  // the load option is a single full-width select filling the card width; the
+  // compact MapSelect already strips its panel framing
+  :deep(.map-select--compact) {
+    margin-top: auto;
+    width: 100%;
+  }
+
+  :deep(.custom-select),
+  :deep(select) {
+    width: 100%;
+  }
+}
+
+.sub {
+  font-family: system-ui;
+  font-size: 14px;
+  line-height: 1.35;
+  opacity: 0.8;
+  letter-spacing: 0;
+}
+
+.preview-frame {
+  border: 1px solid var(--border-accent-faint);
+  border-radius: var(--small-radius);
+  overflow: auto;
+  max-height: 220px;
+
+  .mask-preview {
+    display: block;
+    image-rendering: pixelated;
+    width: 100%;
+  }
+}
+
+.description img { image-rendering: pixelated; vertical-align: middle; }
+
+.advanced-scroll {
+  max-height: 240px;
+  overflow: auto;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: auto;
+
+  // back button pinned left, primary actions to the right
+  > :first-child {
+    margin-right: auto;
+  }
+}
+</style>

--- a/src/components/organisms/BuilderWizard.vue
+++ b/src/components/organisms/BuilderWizard.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useRouter } from "vue-router";
 import { useBuilderWizard } from "../pages/composables/useBuilderWizard";
 import { useMapDraft } from "../../data/builder/draft";
-import WfcDialog, { type WfcSettings } from "./WfcDialog.vue";
+import WfcDialog from "./WfcDialog.vue";
 import TerrainPaintDialog from "./TerrainPaintDialog.vue";
 import AiAlignDialog from "./AiAlignDialog.vue";
 import MapSelect from "./MapSelect.vue";
@@ -18,7 +18,7 @@ import autoTerrainIcon from "pixelarticons/svg/magic-edit.svg";
 import manualIcon from "pixelarticons/svg/image-new.svg";
 import type { LadderInfo } from "../../data/wfc/postProcess";
 import type { Config } from "../../data/map";
-import WfcWorker from "../../data/wfc/wfc.worker?worker";
+import { runWfc, type WfcSettings } from "../../data/wfc/runWfc";
 
 const router = useRouter();
 const { screen, visible, selectPath, next, back, close: closeWizard } =
@@ -66,35 +66,27 @@ const handleWfcGenerated = (maskData: string, ladders: LadderInfo[]) => {
 };
 
 const wfcGenerating = ref(false);
+const wfcError = ref("");
 let activeWorker: Worker | null = null;
 
-const runWfc = () => {
+// Regenerate the wallmask in place (the `g` shortcut). Errors surface in the
+// status banner instead of being swallowed.
+const regenerateWfc = () => {
   if (wfcGenerating.value) return;
   wfcGenerating.value = true;
-  const s = wfcSettings.value;
-  const worker = new WfcWorker();
+  wfcError.value = "";
+  const { promise, worker } = runWfc(wfcSettings.value);
   activeWorker = worker;
-  worker.postMessage({
-    width: s.width, height: s.height, density: s.density / 100,
-    edges: { top: s.edgeTop / 100, bottom: s.edgeBottom / 100, left: s.edgeLeft / 100, right: s.edgeRight / 100 },
-    continuityBonus: s.continuityBonus, preventBlockages: s.preventBlockages,
-    ...(s.densityMode === "image" && s.densityMask ? { densityMask: s.densityMask } : {}),
-  });
-  worker.onmessage = (e: MessageEvent) => {
-    if (e.data.type === "progress") return;
-    wfcGenerating.value = false;
-    activeWorker = null;
-    worker.terminate();
-    if (e.data.success && e.data.mask) {
-      wfcLadders.value = e.data.ladders ?? [];
-      draft.applyWfc(e.data.mask, e.data.ladders ?? []);
-    }
-  };
-  worker.onerror = () => {
-    wfcGenerating.value = false;
-    activeWorker = null;
-    worker.terminate();
-  };
+  promise
+    .then(({ mask, ladders }) => {
+      wfcLadders.value = ladders;
+      draft.applyWfc(mask, ladders);
+    })
+    .catch((err: Error) => (wfcError.value = err.message))
+    .finally(() => {
+      wfcGenerating.value = false;
+      activeWorker = null;
+    });
 };
 
 const aiFileInput = ref<HTMLInputElement>();
@@ -196,7 +188,7 @@ const handleKeydown = (e: KeyboardEvent) => {
     (screen.value === "autoMap-paint" || screen.value === "autoTerrain-preview") &&
     (e.key === "g" || e.key === "G")
   ) {
-    runWfc();
+    regenerateWfc();
   }
 };
 onMounted(() => window.addEventListener("keydown", handleKeydown));
@@ -211,6 +203,22 @@ onUnmounted(() => {
     <!-- persistent dim so transitioning between panel screens and the modal
          dialogs never leaves an undimmed frame (no background flash) -->
     <div class="wizard-dim" />
+
+    <!-- pinned to the top so it stays visible above the centred paint/preview
+         screens while regenerating with `g` -->
+    <div
+      v-if="
+        (screen === 'autoMap-paint' || screen === 'autoTerrain-preview') &&
+        (wfcGenerating || wfcError)
+      "
+      :class="{ 'wfc-status': true, 'wfc-status--error': !!wfcError }"
+    >
+      <span v-if="wfcGenerating" class="spinner-row">
+        <span class="spinner">&#x07F7;</span> Regenerating wallmask...
+      </span>
+      <span v-else>{{ wfcError }}</span>
+    </div>
+
     <WfcDialog
       v-if="screen === 'autoMap-wfc' || screen === 'autoTerrain-wfc'"
       :settings="wfcSettings"
@@ -330,6 +338,30 @@ onUnmounted(() => {
   inset: 0;
   z-index: 99;
   background: rgba(0, 0, 0, 0.5);
+}
+
+.wfc-status {
+  position: fixed;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 101;
+  padding: 6px 14px;
+  border-radius: var(--small-radius);
+  background: var(--field-bg);
+  border: 2px solid var(--border-accent-faint);
+  font-size: 14px;
+
+  &--error {
+    color: var(--highlight);
+    border-color: var(--highlight);
+  }
+
+  .spinner-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
 }
 
 .wizard-overlay {

--- a/src/components/organisms/MapSelect.vue
+++ b/src/components/organisms/MapSelect.vue
@@ -6,9 +6,10 @@ import { Config, Map } from "../../data/map";
 import { DefaultMap, defaultMaps } from "../../util/assets/constants";
 import TornPanel from "../atoms/TornPanel.vue";
 
-const { onEdit, defaultMap } = defineProps<{
+const { onEdit, defaultMap, compact } = defineProps<{
   onEdit: (map: Config, name: string) => void;
   defaultMap?: keyof typeof defaultMaps;
+  compact?: boolean;
 }>();
 
 const CUSTOM = "custom";
@@ -122,7 +123,36 @@ onMounted(() => reset());
 </script>
 
 <template>
-  <section class="map-select">
+  <!-- compact: a single full-width select, no panel framing -->
+  <section v-if="compact" class="map-select map-select--compact">
+    <div class="custom-select">
+      <select @change="handleChange">
+        <option v-if="!defaultMap" :value="EMPTY" :selected="selectedMap.map === EMPTY">
+          Select map...
+        </option>
+        <option
+          v-for="({ path }, map) in defaultMaps"
+          :value="map"
+          :selected="selectedMap.path === path"
+        >
+          {{ map.replace("_", " ") }}
+        </option>
+        <option :value="CUSTOM" :selected="selectedMap.map === CUSTOM">
+          Upload custom map
+        </option>
+      </select>
+    </div>
+    <input
+      type="file"
+      accept="image/*"
+      hidden
+      @change="handleUploadMap"
+      @cancel="reset"
+      ref="customUpload"
+    />
+  </section>
+
+  <section v-else class="map-select">
     <TornPanel tear="b">
       <div class="layout">
         <div class="map-preview">

--- a/src/components/organisms/TerrainPaintDialog.vue
+++ b/src/components/organisms/TerrainPaintDialog.vue
@@ -201,7 +201,7 @@ function handleConfirm() {
 </script>
 
 <template>
-  <Dialog open :onClose="onClose" title="Paint terrain">
+  <Dialog open seamless :onClose="onClose" title="Paint terrain">
     <div class="paint-dialog">
       <div class="preview-scroll">
         <canvas ref="previewCanvas" class="preview" @click="handlePreviewClick" />
@@ -233,10 +233,10 @@ function handleConfirm() {
       <p v-if="error" class="error">{{ error }}</p>
 
       <div class="actions">
+        <button class="secondary" @click="onClose">Back</button>
         <button class="primary" :disabled="zones.length === 0" @click="handleConfirm">
-          Confirm
+          Next
         </button>
-        <button class="secondary" @click="onClose">Cancel</button>
       </div>
     </div>
   </Dialog>
@@ -330,7 +330,13 @@ function handleConfirm() {
 
 .actions {
   display: flex;
+  align-items: center;
   gap: 8px;
   margin-top: 4px;
+
+  // back button pinned left, primary action to the right
+  > :first-child {
+    margin-right: auto;
+  }
 }
 </style>

--- a/src/components/organisms/WfcDialog.vue
+++ b/src/components/organisms/WfcDialog.vue
@@ -6,22 +6,9 @@ import Input from "../atoms/Input.vue";
 import ImageInput from "../molecules/ImageInput.vue";
 import { TILE_SIZE_PX } from "../../data/wfc/tiles";
 import type { LadderInfo } from "../../data/wfc/postProcess";
-import WfcWorker from "../../data/wfc/wfc.worker?worker";
+import { runWfc, type WfcSettings } from "../../data/wfc/runWfc";
 
-export interface WfcSettings {
-  width: number;
-  height: number;
-  density: number;
-  edgeTop: number;
-  edgeBottom: number;
-  edgeLeft: number;
-  edgeRight: number;
-  continuityBonus: number;
-  preventBlockages: boolean;
-  densityMode: "edges" | "image";
-  densityMask: Uint8Array | null;
-  densityImageData: string;
-}
+export type { WfcSettings };
 
 const { onGenerate, onClose, settings, initialError } = defineProps<{
   onGenerate: (maskData: string, ladders: LadderInfo[]) => void;
@@ -76,42 +63,10 @@ const handleGenerate = () => {
   generating.value = true;
   error.value = "";
 
-  const worker = new WfcWorker();
-
-  const finish = (errMessage?: string) => {
-    generating.value = false;
-    worker.terminate();
-    if (errMessage) error.value = errMessage;
-  };
-
-  worker.postMessage({
-    width: settings.width,
-    height: settings.height,
-    density: settings.density / 100,
-    edges: {
-      top: settings.edgeTop / 100,
-      bottom: settings.edgeBottom / 100,
-      left: settings.edgeLeft / 100,
-      right: settings.edgeRight / 100,
-    },
-    continuityBonus: settings.continuityBonus,
-    preventBlockages: settings.preventBlockages,
-    ...(settings.densityMode === "image" && settings.densityMask
-      ? { densityMask: settings.densityMask }
-      : {}),
-  });
-
-  worker.onmessage = (e: MessageEvent) => {
-    if (e.data.type === "progress") return;
-    if (e.data.success && e.data.mask) {
-      finish();
-      onGenerate(e.data.mask, e.data.ladders ?? []);
-    } else {
-      finish(e.data.error ?? "Generation failed.");
-    }
-  };
-
-  worker.onerror = () => finish("An unexpected error occurred.");
+  runWfc(settings).promise
+    .then(({ mask, ladders }) => onGenerate(mask, ladders))
+    .catch((err: Error) => (error.value = err.message))
+    .finally(() => (generating.value = false));
 };
 </script>
 

--- a/src/components/organisms/WfcDialog.vue
+++ b/src/components/organisms/WfcDialog.vue
@@ -116,7 +116,7 @@ const handleGenerate = () => {
 </script>
 
 <template>
-  <Dialog open :onClose="onClose" title="Generate wallmask">
+  <Dialog open seamless :onClose="onClose" title="Generate wallmask">
     <div class="wfc-params">
       <div class="size-row">
         <Input label="Width (tiles)" v-model="settings.width" :max="60" />
@@ -236,14 +236,14 @@ const handleGenerate = () => {
       <p v-if="error" class="error">{{ error }}</p>
 
       <div class="actions">
+        <button class="secondary" @click="onClose">Back</button>
         <button class="primary" @click="handleGenerate" :disabled="generating || (settings.densityMode === 'image' && !settings.densityImageData)">
           <span v-if="generating" class="spinner-row">
             <span class="spinner">&#x07F7;</span>
             Generating...
           </span>
-          <span v-else>Generate</span>
+          <span v-else>Next</span>
         </button>
-        <button class="secondary" @click="onClose">Cancel</button>
       </div>
     </div>
   </Dialog>
@@ -332,8 +332,14 @@ const handleGenerate = () => {
 
 .actions {
   display: flex;
+  align-items: center;
   gap: 8px;
   margin-top: 4px;
+
+  // back button pinned left, primary action to the right
+  > :first-child {
+    margin-right: auto;
+  }
 }
 
 .spinner-row {

--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -40,10 +40,9 @@ const {
   handleAddMask, handleSetMaskVisibility,
   handleAddBackground, handleSetBackgroundVisibility,
   handleAddLayer, handleRemoveLayer, handleSetLayerVisibility,
-} = useBuilderLayers(advancedSettings, preview);
+} = useBuilderLayers(preview);
 
-const { creatingLadder, handleCreateLadder } =
-  useBuilderLadders(advancedSettings, preview);
+const { creatingLadder, handleCreateLadder } = useBuilderLadders(preview);
 
 const { handleBuild, handleTest, loadMap } = useBuilderMap();
 

--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -1,31 +1,24 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { onMounted, ref, watch } from "vue";
 import { Map, Config, Layer } from "../../data/map";
 import Input from "../atoms/Input.vue";
 import BoundingBox from "../molecules/BoundingBox.vue";
 import { BBox } from "../../data/map/bbox";
 import { useRouter } from "vue-router";
 import { GameSettings } from "../../util/localStorage/settings";
-import MapSelect from "../organisms/MapSelect.vue";
-import BuilderSettings, {
-  AdvancedSettings,
-} from "../organisms/BuilderSettings.vue";
+import BuilderWizard from "../organisms/BuilderWizard.vue";
+import BuilderSettings from "../organisms/BuilderSettings.vue";
 import ImageInput from "../molecules/ImageInput.vue";
 import IconButton from "../atoms/IconButton.vue";
 import plus from "pixelarticons/svg/plus.svg";
 import shuffle from "pixelarticons/svg/shuffle.svg";
-import download from "pixelarticons/svg/download.svg";
-import upload from "pixelarticons/svg/upload.svg";
 import Collapsible from "../atoms/Collapsible.vue";
-import WfcDialog, { type WfcSettings } from "../organisms/WfcDialog.vue";
-import AiAlignDialog from "../organisms/AiAlignDialog.vue";
-import TerrainPaintDialog from "../organisms/TerrainPaintDialog.vue";
-import brush from "pixelarticons/svg/brush.svg";
-import type { LadderInfo } from "../../data/wfc/postProcess";
-import WfcWorker from "../../data/wfc/wfc.worker?worker";
+import BuilderDescription from "../molecules/BuilderDescription.vue";
 import { useBuilderLayers } from "./composables/useBuilderLayers";
 import { useBuilderLadders } from "./composables/useBuilderLadders";
 import { useBuilderMap } from "./composables/useBuilderMap";
+import { useBuilderWizard } from "./composables/useBuilderWizard";
+import { useMapDraft } from "../../data/builder/draft";
 
 const { onPlay, config } = defineProps<{
   onPlay: (key: string, map: Map | Config, settings: GameSettings) => void;
@@ -34,33 +27,25 @@ const { onPlay, config } = defineProps<{
 const router = useRouter();
 const preview = ref<HTMLDivElement>();
 
-const name = ref("");
+const wizard = useBuilderWizard();
 
 const settingsOpen = ref(false);
-const advancedSettings = ref<AdvancedSettings>({
-  scale: 6,
-  bbox: BBox.create(0, 0),
-  customMask: false,
-  parallaxName: "",
-  parallaxOffset: 0,
-});
-
-const oldScale = ref(advancedSettings.value.scale);
 
 const {
-  terrain, mask, background, layers,
+  terrain, mask, background, layers, ladders, advancedSettings, name, oldScale,
+} = useMapDraft();
+
+const {
   handleAddTerrain, handleSetTerrainVisibility,
   handleAddMask, handleSetMaskVisibility,
   handleAddBackground, handleSetBackgroundVisibility,
   handleAddLayer, handleRemoveLayer, handleSetLayerVisibility,
 } = useBuilderLayers(advancedSettings, preview);
 
-const { ladders, creatingLadder, handleCreateLadder } =
+const { creatingLadder, handleCreateLadder } =
   useBuilderLadders(advancedSettings, preview);
 
-const { handleBuild, handleTest, loadMap } = useBuilderMap(
-  name, terrain, mask, background, layers, ladders, advancedSettings, oldScale
-);
+const { handleBuild, handleTest, loadMap } = useBuilderMap();
 
 onMounted(async () => {
   if (config) {
@@ -76,257 +61,6 @@ watch(
     }
   }
 );
-
-const showWfcDialog = ref(false);
-const wfcSettings = ref<WfcSettings>({
-  width: 10,
-  height: 4,
-  density: 60,
-  edgeTop: 25,
-  edgeBottom: 75,
-  edgeLeft: 0,
-  edgeRight: 0,
-  continuityBonus: 2,
-  preventBlockages: true,
-  densityMode: "edges",
-  densityMask: null,
-  densityImageData: "",
-});
-
-const wfcLadders = ref<LadderInfo[]>([]);
-
-const wfcGenerating = ref(false);
-const wfcInitialError = ref<string>("");
-let activeWorker: Worker | null = null;
-
-const generateWfc = () => {
-  if (wfcGenerating.value) return;
-  wfcGenerating.value = true;
-  const s = wfcSettings.value;
-  const worker = new WfcWorker();
-  activeWorker = worker;
-
-  const finish = (errMessage?: string) => {
-    wfcGenerating.value = false;
-    activeWorker = null;
-    worker.terminate();
-    if (errMessage) {
-      wfcInitialError.value = errMessage;
-      showWfcDialog.value = true;
-    }
-  };
-
-  worker.postMessage({
-    width: s.width,
-    height: s.height,
-    density: s.density / 100,
-    edges: {
-      top: s.edgeTop / 100,
-      bottom: s.edgeBottom / 100,
-      left: s.edgeLeft / 100,
-      right: s.edgeRight / 100,
-    },
-    continuityBonus: s.continuityBonus,
-    preventBlockages: s.preventBlockages,
-    ...(s.densityMode === "image" && s.densityMask
-      ? { densityMask: s.densityMask }
-      : {}),
-  });
-  worker.onmessage = (e: MessageEvent) => {
-    if (e.data.type === "progress") return;
-    if (e.data.success && e.data.mask) {
-      finish();
-      handleWfcGenerated(e.data.mask, e.data.ladders ?? []);
-    } else {
-      finish(e.data.error ?? "Generation failed.");
-    }
-  };
-  worker.onerror = () => finish("An unexpected error occurred.");
-};
-
-const handleKeydown = (e: KeyboardEvent) => {
-  if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-  if (showWfcDialog.value || showAiAlign.value || showTerrainPaint.value) return;
-  if (e.key === "g" || e.key === "G") {
-    generateWfc();
-  }
-};
-onMounted(() => window.addEventListener("keydown", handleKeydown));
-onUnmounted(() => {
-  window.removeEventListener("keydown", handleKeydown);
-  if (activeWorker) {
-    activeWorker.terminate();
-    activeWorker = null;
-  }
-});
-
-const handleWfcGenerated = (maskData: string, wfcLadderData: LadderInfo[]) => {
-  mask.value = { data: maskData, visible: true };
-  advancedSettings.value.customMask = true;
-  showWfcDialog.value = false;
-  wfcLadders.value = wfcLadderData;
-
-  // Clear existing ladders and overlays
-  ladders.value = [];
-  layers.value = [];
-
-  // Add WFC-generated ladders to the builder
-  for (const ladder of wfcLadderData) {
-    ladders.value.push(
-      new BBox(
-        ladder.x - ladder.width / 2,
-        ladder.y,
-        ladder.x + ladder.width / 2,
-        ladder.y + ladder.height,
-      ),
-    );
-  }
-
-  const image = new Image();
-  image.src = maskData;
-  image.onload = () => {
-    advancedSettings.value.bbox = BBox.create(image.width, image.height);
-  };
-};
-
-function buildAIPrompt(w: number, h: number): string {
-  return `Generate an image of a 2D side-view game terrain based on the attached black-and-white mask image. In the mask, black areas represent solid terrain and white areas represent empty sky or background.
-
-The output image must be exactly ${w}x${h} pixels — the same dimensions as the input mask.
-
-Create a textured terrain image that follows these rules:
-- The solid black areas should become detailed, textured <theme> terrain. Add surface detail, shading, and depth to make it look like a painted game environment.
-- The white empty areas should become a distinct, clearly different background — use a lighter sky or atmospheric background that is obviously not terrain. The background must have no transparency.
-- The boundary between terrain and background must be clearly visible with good contrast.
-- Keep the exact same dimensions and shape as the input mask. Do not add, remove, or reshape any terrain. Every black pixel must remain solid, every white pixel must remain background.
-- If there are brown rectangular areas in the image, these indicate ladder positions. Draw wooden ladders on these brown areas. The ladders should look like climbable wooden game ladders with rungs.
-- The output must be a fully opaque image with no transparency anywhere.
-- Use a pixel art or hand-painted 2D game art style.
-- This is a side-scrolling game map, so add appropriate environmental details like grass on top edges, rocky textures on sides, and darker shading underneath overhangs.`;
-}
-
-const handleExportMaskForAI = () => {
-  if (!mask.value.data) return;
-
-  const image = new Image();
-  image.src = mask.value.data;
-  image.onload = () => {
-    const src = new OffscreenCanvas(image.width, image.height);
-    const srcCtx = src.getContext("2d")!;
-    srcCtx.drawImage(image, 0, 0);
-
-    // Build export canvas: brown ladder rectangles behind the mask
-    const dst = new OffscreenCanvas(image.width, image.height);
-    const dstCtx = dst.getContext("2d")!;
-
-    // Start with white background
-    dstCtx.fillStyle = "#ffffff";
-    dstCtx.fillRect(0, 0, image.width, image.height);
-
-    // Draw brown rectangles at ladder positions
-    if (wfcLadders.value.length > 0) {
-      dstCtx.fillStyle = "#8B4513";
-      for (const ladder of wfcLadders.value) {
-        dstCtx.fillRect(
-          ladder.x - ladder.width / 2,
-          ladder.y,
-          ladder.width,
-          ladder.height,
-        );
-      }
-    }
-
-    // Draw mask on top: solid terrain = black, transparent areas show what's beneath
-    const srcData = srcCtx.getImageData(0, 0, image.width, image.height);
-    const dstData = dstCtx.getImageData(0, 0, image.width, image.height);
-    const srcPixels = srcData.data;
-    const dstPixels = dstData.data;
-
-    for (let i = 0; i < srcPixels.length; i += 4) {
-      const solid = srcPixels[i + 3] > 128;
-      if (solid) {
-        // Solid terrain = black, overwriting whatever was beneath
-        dstPixels[i] = 0;
-        dstPixels[i + 1] = 0;
-        dstPixels[i + 2] = 0;
-        dstPixels[i + 3] = 255;
-      }
-      // Non-solid areas keep whatever was drawn (white or brown)
-    }
-
-    dstCtx.putImageData(dstData, 0, 0);
-
-    // Copy prompt to clipboard with exact dimensions
-    navigator.clipboard.writeText(buildAIPrompt(image.width, image.height));
-
-    dst.convertToBlob({ type: "image/png" }).then((blob) => {
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.download = `${name.value || "mask"}-ai.png`;
-      link.href = url;
-      link.click();
-      setTimeout(() => URL.revokeObjectURL(url), 1000);
-    });
-  };
-};
-
-const aiTerrainInput = ref<HTMLInputElement>();
-
-const handleImportAITerrain = () => {
-  aiTerrainInput.value?.click();
-};
-
-const aiAlignSrc = ref("");
-const showAiAlign = ref(false);
-
-const handleAITerrainFile = (event: Event) => {
-  const file = (event.target as HTMLInputElement).files?.[0];
-  if (!file || !mask.value.data) return;
-
-  const reader = new FileReader();
-  reader.onload = () => {
-    aiAlignSrc.value = reader.result as string;
-    showAiAlign.value = true;
-  };
-  reader.readAsDataURL(file);
-  (event.target as HTMLInputElement).value = "";
-};
-
-const handleAiAlignConfirm = (result: {
-  terrain: string;
-  background: string;
-  mask: string;
-  width: number;
-  height: number;
-}) => {
-  terrain.value = { data: result.terrain, visible: true };
-  background.value = { data: result.background, visible: true };
-  mask.value = { data: result.mask, visible: false };
-  advancedSettings.value.bbox = BBox.create(result.width, result.height);
-  showAiAlign.value = false;
-};
-
-const showTerrainPaint = ref(false);
-
-const handleTerrainPaintConfirm = (result: {
-  terrain: string;
-  background: string;
-  width: number;
-  height: number;
-}) => {
-  terrain.value = { data: result.terrain, visible: true };
-  background.value = { data: result.background, visible: true };
-  // terrain alpha now IS the wallmask; the customMask watcher clears the
-  // stored mask so the built map derives collision from terrain alpha
-  advancedSettings.value.customMask = false;
-  advancedSettings.value.bbox = BBox.create(result.width, result.height);
-  // painted backgrounds are transparent outside the debris, so a parallax
-  // is expected to fill the sky
-  if (!advancedSettings.value.parallaxName) {
-    advancedSettings.value.parallaxName = "Ocean";
-  }
-  showTerrainPaint.value = false;
-};
 
 watch(
   () => advancedSettings.value.scale,
@@ -375,38 +109,7 @@ const handleBBoxChange = (newBBox: BBox) => {
       <div class="section">
         <h2>
           Terrain
-          <span v-if="wfcGenerating" class="spinner wfc-generating" title="Generating...">&#x07F7;</span>
-          <IconButton
-            v-else
-            title="Generate wallmask"
-            :onClick="() => { wfcInitialError = ''; showWfcDialog = true; }"
-            :icon="shuffle"
-          />
-          <IconButton
-            v-if="mask.data"
-            title="Export mask for AI (copies prompt to clipboard)"
-            :onClick="handleExportMaskForAI"
-            :icon="download"
-          />
-          <IconButton
-            v-if="mask.data"
-            title="Import AI-generated terrain"
-            :onClick="handleImportAITerrain"
-            :icon="upload"
-          />
-          <IconButton
-            v-if="mask.data || terrain.data"
-            title="Paint terrain procedurally"
-            :onClick="() => (showTerrainPaint = true)"
-            :icon="brush"
-          />
-          <input
-            ref="aiTerrainInput"
-            hidden
-            type="file"
-            accept="image/*"
-            @change="handleAITerrainFile"
-          />
+          <IconButton title="Open wizard" :onClick="() => wizard.openLast()" :icon="shuffle" />
         </h2>
         <ImageInput
           name="Terrain"
@@ -494,147 +197,9 @@ const handleBBoxChange = (newBBox: BBox) => {
       @mousedown="handleCreateLadder"
     >
       <div v-if="!terrain.data && !background.data && !mask.data" class="description">
-        <p>
-          Building your own maps is very easy thanks to the builder. Only a
-          terrain image is needed to start testing! All configuration options
-          are explained below. If something is not clear, consider making an
-          <a
-            href="https://github.com/lorgan3/sorcerers/issues"
-            target="_blank"
-            rel="noopener noreferrer"
-            >issue on GitHub</a
-          >. If you just want to quickly have a look at an existing map you can
-          do so here:
-        </p>
-        <MapSelect :onEdit="loadMap" />
-
-        <div class="section">
-          <Collapsible title="Terrain">
-            <p>
-              A map needs at least a terrain to be playable. The terrain is the
-              layer that can be blown up and by default this is what the
-              sorcerers stand on. At the default scale (6x6), a character is 6
-              pixels wide and 16 pixels high. They can jump about 21 pixels
-              high. You can use this template
-              <img src="../../assets/mask.png" alt="Mask" title="Mask" /> when
-              making the basic outline of your map to make sure the scale is
-              correct. Generally the height of an area should be a lot higher
-              than 21 pixels to prevent it from feeling cramped.
-            </p>
-          </Collapsible>
-        </div>
-
-        <div class="section">
-          <Collapsible title="Wallmask">
-            <p>
-              In the advanced settings you can enable the wallmask, this will
-              overwrite the default wallmask that gets generated from the
-              terrain. You can use this feature if you want to add things to
-              your map that can be blown up but not collide with the sorcerers.
-              You can also use it for example for stairs that have distinct
-              steps but a smooth diagonal wallmask so it can be scaled without
-              jumping. The wallmask is always 6x6 so it will have to be scaled
-              down if you use a smaller scale (eg if you have a terrain that's
-              600 pixels wide on scale 3, the wallmask should be scaled down 50%
-              to 300 pixels to match). Because the wallmask is not shown to the
-              player this image can be black + transparent to reduce the file
-              size.
-            </p>
-          </Collapsible>
-        </div>
-
-        <div class="section">
-          <Collapsible title="Background">
-            <p>
-              The background is placed behind the sorcerers and can't be blown
-              up. It can be used to show where the terrain used to be after it
-              has been blown up and to add some more detail to the map.
-              Typically the colors used for the background are less saturated so
-              it's clear what's part of the terrain and what is not. The sky
-              does not need to be part of the background, you can use a built in
-              parallax background for this in the advanced settings.
-            </p>
-          </Collapsible>
-        </div>
-
-        <div class="section">
-          <Collapsible title="Overlays">
-            <p>
-              Overlays are drawn on top of the sorcerers and become transparent
-              for sorcerers intersecting them. This means the image should fit
-              the content closely and generally be fairly rectangular. Overlays
-              can be dragged in the right position after adding. They can be
-              used for sorcerers to hide behind and can get blown up like the
-              terrain.
-            </p>
-          </Collapsible>
-        </div>
-
-        <div class="section">
-          <Collapsible title="Advanced settings">
-            <ul>
-              <li>
-                <h4>Scale</h4>
-                <p>
-                  The scale is the resolution of the map, a smaller scale can be
-                  used to add more detail to the map. Keep in mind that
-                  collisions (the wallmask) are always at the 6x6 scale. For
-                  this reason multiples of 6 (6, 3, 2, 1) are preferred. It is
-                  recommended to first plan out the layout of your map at the
-                  6x6 scale and then scale it up if you want to work at a higher
-                  resolution.
-                </p>
-              </li>
-              <li>
-                <h4>Spawn area</h4>
-                <p>
-                  The spawn area can either be changed from the advanced
-                  settings or by dragging the red box in the builder. The spawn
-                  area dictates where sorcerers can spawn at the start of the
-                  game.
-                </p>
-              </li>
-              <li>
-                <h4>Parallax background & vertical offset</h4>
-                <p>
-                  A parallax background adds some more depth to the game by
-                  making details in the distance move slower than details closer
-                  by. The vertical offset can be used to move the still layers
-                  up or down. If you wish to add your own parallax background,
-                  pull requests are welcome! Take a look at
-                  <code>src/data/map/background.ts</code> to see how they're
-                  configured.
-                </p>
-              </li>
-            </ul>
-          </Collapsible>
-        </div>
-
         <div class="section">
           <Collapsible title="Publishing" defaultOpen>
-            <p>
-              If you made a cool map that you want to share, feel free to make a
-              pull request to add it to the game (See
-              <code>src/util/assets/constants.ts</code>). If you do not know how
-              to use git you can also
-              <a
-                href="https://github.com/lorgan3/sorcerers/issues"
-                target="_blank"
-                rel="noopener noreferrer"
-                >open an issue</a
-              >
-              so someone else can add it for you. All reasonable maps will be
-              accepted, if you have a crazy idea consider contacting me first if
-              you want to ensure it can get added to the game.<br />
-              Please optimize the images first (eg
-              <a
-                href="https://imageoptim.com/mac"
-                target="_blank"
-                rel="noopener noreferrer"
-                >imageOptim</a
-              >) before compiling the final version of your map, this can easily
-              cut the filesize in half.
-            </p>
+            <BuilderDescription topic="publishing" />
           </Collapsible>
         </div>
       </div>
@@ -666,27 +231,7 @@ const handleBBoxChange = (newBBox: BBox) => {
         draggable
       />
     </section>
-    <WfcDialog
-      v-if="showWfcDialog"
-      :settings="wfcSettings"
-      :initialError="wfcInitialError"
-      :onGenerate="handleWfcGenerated"
-      :onClose="() => { showWfcDialog = false; wfcInitialError = ''; }"
-    />
-    <AiAlignDialog
-      v-if="showAiAlign"
-      :maskSrc="mask.data"
-      :aiSrc="aiAlignSrc"
-      :onConfirm="handleAiAlignConfirm"
-      :onClose="() => (showAiAlign = false)"
-    />
-    <TerrainPaintDialog
-      v-if="showTerrainPaint && (mask.data || terrain.data)"
-      :alphaSrc="mask.data || terrain.data"
-      :ladders="ladders.map((l) => l.toJS())"
-      :onConfirm="handleTerrainPaintConfirm"
-      :onClose="() => (showTerrainPaint = false)"
-    />
+    <BuilderWizard />
   </div>
 </template>
 
@@ -839,32 +384,11 @@ const handleBBoxChange = (newBBox: BBox) => {
         margin-top: 16px;
       }
 
-      ul {
-        margin-left: 10px;
-      }
-
-      h4 {
-        margin-top: 10px;
-      }
-
       code {
         font-family: monospace;
         font-size: 14px;
       }
     }
-  }
-
-  .wfc-generating {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    line-height: 16px;
-    text-align: center;
-    padding: 4px;
-    margin: -4px 0;
-    font-size: 16px;
-    vertical-align: middle;
-    box-sizing: content-box;
   }
 }
 </style>

--- a/src/components/pages/MainMenu.vue
+++ b/src/components/pages/MainMenu.vue
@@ -10,8 +10,11 @@ import externalLink from "pixelarticons/svg/external-link.svg";
 import TornPanel from "../atoms/TornPanel.vue";
 import WaxSeal from "../atoms/WaxSeal.vue";
 import RuneLayer from "../atoms/RuneLayer.vue";
+import { useBuilderWizard } from "./composables/useBuilderWizard";
+import BuilderWizard from "../organisms/BuilderWizard.vue";
 
 const joinDialogOpen = ref(false);
+const wizard = useBuilderWizard();
 </script>
 
 <template>
@@ -31,9 +34,9 @@ const joinDialogOpen = ref(false);
           </button>
         </li>
         <li>
-          <RouterLink to="/builder" class="primary menu-button">
+          <button class="primary menu-button" @click="wizard.open()">
             <WaxSeal class="seal" letter="S" :size="34" aria-hidden="true" />Builder
-          </RouterLink>
+          </button>
         </li>
         <li>
           <RouterLink to="/credits" class="primary menu-button">
@@ -71,6 +74,7 @@ const joinDialogOpen = ref(false);
     :open="joinDialogOpen"
     :onClose="() => (joinDialogOpen = false)"
   />
+  <BuilderWizard />
 </template>
 
 <style lang="scss" scoped>

--- a/src/components/pages/composables/__spec__/useBuilderWizard.spec.ts
+++ b/src/components/pages/composables/__spec__/useBuilderWizard.spec.ts
@@ -1,0 +1,68 @@
+import { useBuilderWizard } from "../useBuilderWizard";
+
+const w = useBuilderWizard();
+beforeEach(() => {
+  w.close();
+  w.reset();
+});
+
+describe("useBuilderWizard", () => {
+  it("starts on the chooser, hidden", () => {
+    expect(w.screen.value).toBe("choose");
+    expect(w.visible.value).toBe(false);
+  });
+
+  it("enters each path on the correct first screen", () => {
+    w.selectPath("autoMap");
+    expect(w.screen.value).toBe("autoMap-wfc");
+    w.selectPath("autoTerrain");
+    expect(w.screen.value).toBe("autoTerrain-wfc");
+    w.selectPath("manual");
+    expect(w.screen.value).toBe("manual-terrain");
+  });
+
+  it("autoTerrain advances wfc -> preview and caps there", () => {
+    w.selectPath("autoTerrain");
+    w.next();
+    expect(w.screen.value).toBe("autoTerrain-preview");
+    w.next();
+    expect(w.screen.value).toBe("autoTerrain-preview");
+  });
+
+  it("advances through the manual path", () => {
+    w.selectPath("manual");
+    w.next();
+    expect(w.screen.value).toBe("manual-background");
+    w.next();
+    expect(w.screen.value).toBe("manual-advanced");
+    w.next();
+    expect(w.screen.value).toBe("manual-advanced");
+  });
+
+  it("back steps within a path then to the chooser, returning false at the chooser", () => {
+    w.selectPath("autoMap");
+    w.next();
+    expect(w.back()).toBe(true);
+    expect(w.screen.value).toBe("autoMap-wfc");
+    expect(w.back()).toBe(true);
+    expect(w.screen.value).toBe("choose");
+    expect(w.back()).toBe(false);
+  });
+
+  it("open() resets to a visible chooser; openLast() keeps path/step", () => {
+    w.selectPath("manual");
+    w.next();
+    w.close();
+    w.openLast();
+    expect(w.visible.value).toBe(true);
+    expect(w.screen.value).toBe("manual-background");
+    w.open();
+    expect(w.visible.value).toBe(true);
+    expect(w.screen.value).toBe("choose");
+  });
+
+  it("is a singleton — state is shared across calls", () => {
+    useBuilderWizard().selectPath("autoMap");
+    expect(useBuilderWizard().screen.value).toBe("autoMap-wfc");
+  });
+});

--- a/src/components/pages/composables/useBuilderLadders.ts
+++ b/src/components/pages/composables/useBuilderLadders.ts
@@ -1,41 +1,30 @@
 import { Ref, ref } from "vue";
 import { BBox } from "../../../data/map/bbox";
-import type { AdvancedSettings } from "../../organisms/BuilderSettings.vue";
+import { useMapDraft } from "../../../data/builder/draft";
+import type { AdvancedSettings } from "../../../data/builder/draft";
 
 export function useBuilderLadders(
   advancedSettings: Ref<AdvancedSettings>,
   preview: Ref<HTMLDivElement | undefined>
 ) {
-  const ladders = ref<BBox[]>([]);
+  const { ladders } = useMapDraft();
   const creatingLadder = ref(false);
 
   const handleCreateLadder = (event: MouseEvent) => {
-    if (!creatingLadder.value) {
-      return;
-    }
-
+    if (!creatingLadder.value) return;
     event.preventDefault();
     const position = preview.value!.getBoundingClientRect();
     const x = Math.round(
-      (position.left - preview.value!.scrollLeft) /
-        advancedSettings.value.scale
+      (position.left - preview.value!.scrollLeft) / advancedSettings.value.scale
     );
     const y = Math.round(
-      (position.top - preview.value!.scrollTop) /
-        advancedSettings.value.scale
+      (position.top - preview.value!.scrollTop) / advancedSettings.value.scale
     );
-    const startX =
-      Math.round(event.pageX / advancedSettings.value.scale) - x;
-    const startY =
-      Math.round(event.pageY / advancedSettings.value.scale) - y;
+    const startX = Math.round(event.pageX / advancedSettings.value.scale) - x;
+    const startY = Math.round(event.pageY / advancedSettings.value.scale) - y;
 
     ladders.value.push(
-      BBox.fromJS({
-        left: startX,
-        top: startY,
-        right: startX,
-        bottom: startY,
-      })!
+      BBox.fromJS({ left: startX, top: startY, right: startX, bottom: startY })!
     );
 
     const handleMouseMove = (moveEvent: MouseEvent) => {
@@ -48,23 +37,16 @@ export function useBuilderLadders(
         Math.round(moveEvent.pageY / advancedSettings.value.scale) - y
       );
     };
-
     const handleMouseUp = () => {
       document.onselectstart = null;
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
       creatingLadder.value = false;
     };
-
-    event.preventDefault();
     document.onselectstart = () => false;
     document.addEventListener("mousemove", handleMouseMove);
     document.addEventListener("mouseup", handleMouseUp);
   };
 
-  return {
-    ladders,
-    creatingLadder,
-    handleCreateLadder,
-  };
+  return { ladders, creatingLadder, handleCreateLadder };
 }

--- a/src/components/pages/composables/useBuilderLadders.ts
+++ b/src/components/pages/composables/useBuilderLadders.ts
@@ -1,13 +1,9 @@
 import { Ref, ref } from "vue";
 import { BBox } from "../../../data/map/bbox";
 import { useMapDraft } from "../../../data/builder/draft";
-import type { AdvancedSettings } from "../../../data/builder/draft";
 
-export function useBuilderLadders(
-  advancedSettings: Ref<AdvancedSettings>,
-  preview: Ref<HTMLDivElement | undefined>
-) {
-  const { ladders } = useMapDraft();
+export function useBuilderLadders(preview: Ref<HTMLDivElement | undefined>) {
+  const { ladders, advancedSettings } = useMapDraft();
   const creatingLadder = ref(false);
 
   const handleCreateLadder = (event: MouseEvent) => {

--- a/src/components/pages/composables/useBuilderLayers.ts
+++ b/src/components/pages/composables/useBuilderLayers.ts
@@ -1,54 +1,43 @@
-import { Ref, ref } from "vue";
-import { Layer } from "../../../data/map";
+import { Ref } from "vue";
 import { BBox } from "../../../data/map/bbox";
-import type { AdvancedSettings } from "../../organisms/BuilderSettings.vue";
+import { useMapDraft } from "../../../data/builder/draft";
+import type { AdvancedSettings } from "../../../data/builder/draft";
 
 export function useBuilderLayers(
   advancedSettings: Ref<AdvancedSettings>,
   preview: Ref<HTMLDivElement | undefined>
 ) {
-  const terrain = ref({ data: "", visible: false });
-  const mask = ref({ data: "", visible: false });
-  const background = ref({ data: "", visible: false });
-  const layers = ref<Array<Layer & { visible: boolean }>>([]);
+  const {
+    terrain, mask, background, layers,
+    setTerrainImage, setBackgroundImage,
+  } = useMapDraft();
 
-  const addImageFactory =
-    (target: Ref<{ data: string; visible: boolean }>, visible = true) =>
-    (_: File, data: string) => {
-      target.value = { data, visible };
-
-      if (advancedSettings.value.bbox.isEmpty()) {
-        const image = new Image();
-        image.src = data;
-
-        image.onload = () => {
-          advancedSettings.value.bbox = BBox.create(
-            image.width,
-            image.height
-          );
-        };
-      }
-    };
-
-  const handleAddTerrain = addImageFactory(terrain);
+  const handleAddTerrain = (_: File, data: string) => setTerrainImage(data);
   const handleSetTerrainVisibility = (visible: boolean) =>
     (terrain.value.visible = visible);
-  const handleAddMask = addImageFactory(mask, false);
+
+  const handleAddMask = (_: File, data: string) => {
+    mask.value = { data, visible: false };
+    if (advancedSettings.value.bbox.isEmpty() && data) {
+      const image = new Image();
+      image.src = data;
+      image.onload = () => {
+        advancedSettings.value.bbox = BBox.create(image.width, image.height);
+      };
+    }
+  };
   const handleSetMaskVisibility = (visible: boolean) =>
     (mask.value.visible = visible);
-  const handleAddBackground = addImageFactory(background);
+
+  const handleAddBackground = (_: File, data: string) => setBackgroundImage(data);
   const handleSetBackgroundVisibility = (visible: boolean) =>
     (background.value.visible = visible);
 
   const handleAddLayer = () =>
     layers.value.push({
       data: "",
-      x: Math.round(
-        preview.value!.scrollLeft / advancedSettings.value.scale
-      ),
-      y: Math.round(
-        preview.value!.scrollTop / advancedSettings.value.scale
-      ),
+      x: Math.round(preview.value!.scrollLeft / advancedSettings.value.scale),
+      y: Math.round(preview.value!.scrollTop / advancedSettings.value.scale),
       visible: true,
     });
 
@@ -61,18 +50,10 @@ export function useBuilderLayers(
   };
 
   return {
-    terrain,
-    mask,
-    background,
-    layers,
-    handleAddTerrain,
-    handleSetTerrainVisibility,
-    handleAddMask,
-    handleSetMaskVisibility,
-    handleAddBackground,
-    handleSetBackgroundVisibility,
-    handleAddLayer,
-    handleRemoveLayer,
-    handleSetLayerVisibility,
+    terrain, mask, background, layers,
+    handleAddTerrain, handleSetTerrainVisibility,
+    handleAddMask, handleSetMaskVisibility,
+    handleAddBackground, handleSetBackgroundVisibility,
+    handleAddLayer, handleRemoveLayer, handleSetLayerVisibility,
   };
 }

--- a/src/components/pages/composables/useBuilderLayers.ts
+++ b/src/components/pages/composables/useBuilderLayers.ts
@@ -1,31 +1,17 @@
 import { Ref } from "vue";
-import { BBox } from "../../../data/map/bbox";
 import { useMapDraft } from "../../../data/builder/draft";
-import type { AdvancedSettings } from "../../../data/builder/draft";
 
-export function useBuilderLayers(
-  advancedSettings: Ref<AdvancedSettings>,
-  preview: Ref<HTMLDivElement | undefined>
-) {
+export function useBuilderLayers(preview: Ref<HTMLDivElement | undefined>) {
   const {
-    terrain, mask, background, layers,
-    setTerrainImage, setBackgroundImage,
+    terrain, mask, background, layers, advancedSettings,
+    setTerrainImage, setBackgroundImage, setMaskImage,
   } = useMapDraft();
 
   const handleAddTerrain = (_: File, data: string) => setTerrainImage(data);
   const handleSetTerrainVisibility = (visible: boolean) =>
     (terrain.value.visible = visible);
 
-  const handleAddMask = (_: File, data: string) => {
-    mask.value = { data, visible: false };
-    if (advancedSettings.value.bbox.isEmpty() && data) {
-      const image = new Image();
-      image.src = data;
-      image.onload = () => {
-        advancedSettings.value.bbox = BBox.create(image.width, image.height);
-      };
-    }
-  };
+  const handleAddMask = (_: File, data: string) => setMaskImage(data);
   const handleSetMaskVisibility = (visible: boolean) =>
     (mask.value.visible = visible);
 

--- a/src/components/pages/composables/useBuilderMap.ts
+++ b/src/components/pages/composables/useBuilderMap.ts
@@ -1,100 +1,24 @@
-import { Ref } from "vue";
-import { Config, Layer, Map } from "../../../data/map";
-import { BBox } from "../../../data/map/bbox";
+import { useMapDraft } from "../../../data/builder/draft";
+import { Config, Map } from "../../../data/map";
 import { Server } from "../../../data/network/server";
 import { Team } from "../../../data/team";
-import { logEvent } from "../../../util/firebase";
 import { defaults, GameSettings } from "../../../util/localStorage/settings";
-import type { AdvancedSettings } from "../../organisms/BuilderSettings.vue";
 
-export function useBuilderMap(
-  name: Ref<string>,
-  terrain: Ref<{ data: string; visible: boolean }>,
-  mask: Ref<{ data: string; visible: boolean }>,
-  background: Ref<{ data: string; visible: boolean }>,
-  layers: Ref<Array<Layer & { visible: boolean }>>,
-  ladders: Ref<BBox[]>,
-  advancedSettings: Ref<AdvancedSettings>,
-  oldScale: Ref<number>
-) {
-  const buildConfig = (): Config => ({
-    terrain: {
-      data: terrain.value.data || mask.value.data,
-      mask: mask.value.data,
-    },
-    background: background.value.data
-      ? { data: background.value.data }
-      : undefined,
-    layers: layers.value
-      .filter((layer) => !!layer.data)
-      .map((layer) => ({ ...layer })),
-    bbox: advancedSettings.value.bbox,
-    parallax: {
-      name: advancedSettings.value.parallaxName,
-      offset: advancedSettings.value.parallaxOffset,
-    },
-    scale: advancedSettings.value.scale,
-    ladders: ladders.value,
-  });
+export function useBuilderMap() {
+  const { toConfig, build, loadConfig } = useMapDraft();
 
-  const handleBuild = async () => {
-    const map = await Map.fromConfig(buildConfig());
-
-    const url = URL.createObjectURL(await map.toBlob());
-    setTimeout(() => window.URL.revokeObjectURL(url), 1000);
-
-    const link = document.createElement("a");
-    link.download = `${name.value || "map"}.png`;
-    link.href = url;
-    link.click();
-
-    logEvent("build_map");
-  };
+  const handleBuild = () => build();
 
   const handleTest = async (
     onPlay: (key: string, map: Map | Config, settings: GameSettings) => void
   ) => {
-    const config = buildConfig();
-
+    const config = toConfig();
     const server = new Server();
     server.addPlayer("Test player", Team.random());
     onPlay("0000", config, { ...defaults().gameSettings, teamSize: 1 });
   };
 
-  const loadMap = (config: Config, mapName: string) => {
-    oldScale.value = config.scale;
-    terrain.value = { data: config.terrain.data as string, visible: true };
-    background.value = {
-      data: (config.background?.data as string) || "",
-      visible: true,
-    };
-    layers.value = config.layers.map((layer) => ({
-      ...layer,
-      visible: true,
-    }));
-    advancedSettings.value = {
-      bbox: BBox.fromJS(config.bbox) || BBox.create(0, 0),
-      scale: config.scale,
-      customMask: !!config.terrain.mask,
-      parallaxName: config.parallax.name,
-      parallaxOffset: config.parallax.offset,
-    };
-    name.value = mapName;
-    ladders.value =
-      (config.ladders
-        ?.map((bbox) => BBox.fromJS(bbox))
-        .filter(Boolean) as BBox[]) || [];
+  const loadMap = (config: Config, mapName: string) => loadConfig(config, mapName);
 
-    if (config.terrain.mask) {
-      mask.value = { data: config.terrain.mask as string, visible: false };
-    } else {
-      mask.value = { data: "", visible: false };
-    }
-  };
-
-  return {
-    handleBuild,
-    handleTest,
-    loadMap,
-  };
+  return { handleBuild, handleTest, loadMap };
 }

--- a/src/components/pages/composables/useBuilderWizard.ts
+++ b/src/components/pages/composables/useBuilderWizard.ts
@@ -1,0 +1,67 @@
+import { computed, ref } from "vue";
+
+export type WizardPath = "choose" | "autoMap" | "autoTerrain" | "manual";
+
+export type WizardScreen =
+  | "choose"
+  | "autoMap-wfc"
+  | "autoMap-paint"
+  | "autoTerrain-wfc"
+  | "autoTerrain-preview"
+  | "manual-terrain"
+  | "manual-background"
+  | "manual-advanced";
+
+const SCREENS: Record<WizardPath, WizardScreen[]> = {
+  choose: ["choose"],
+  autoMap: ["autoMap-wfc", "autoMap-paint"],
+  autoTerrain: ["autoTerrain-wfc", "autoTerrain-preview"],
+  manual: ["manual-terrain", "manual-background", "manual-advanced"],
+};
+
+const path = ref<WizardPath>("choose");
+const step = ref(0);
+const visible = ref(false);
+
+const screen = computed<WizardScreen>(() => SCREENS[path.value][step.value]);
+
+const selectPath = (next: WizardPath) => {
+  path.value = next;
+  step.value = 0;
+};
+
+const next = () => {
+  if (step.value < SCREENS[path.value].length - 1) step.value++;
+};
+
+const back = (): boolean => {
+  if (path.value === "choose") return false;
+  if (step.value > 0) step.value--;
+  else {
+    path.value = "choose";
+    step.value = 0;
+  }
+  return true;
+};
+
+const reset = () => {
+  path.value = "choose";
+  step.value = 0;
+};
+
+const open = () => {
+  reset();
+  visible.value = true;
+};
+
+const openLast = () => {
+  visible.value = true;
+};
+
+const close = () => {
+  visible.value = false;
+};
+
+export function useBuilderWizard() {
+  return { path, step, visible, screen, selectPath, next, back, reset, open, openLast, close };
+}

--- a/src/data/builder/__spec__/draft.spec.ts
+++ b/src/data/builder/__spec__/draft.spec.ts
@@ -1,0 +1,91 @@
+import { useMapDraft } from "../draft";
+import { BBox } from "../../map/bbox";
+import type { Config } from "../../map";
+
+const draft = useMapDraft();
+
+beforeEach(() => draft.reset());
+
+describe("useMapDraft", () => {
+  it("starts empty", () => {
+    expect(draft.terrain.value.data).toBe("");
+    expect(draft.mask.value.data).toBe("");
+    expect(draft.background.value.data).toBe("");
+    expect(draft.ladders.value).toEqual([]);
+    expect(draft.layers.value).toEqual([]);
+  });
+
+  it("loadConfig then toConfig round-trips the core fields", () => {
+    const config: Config = {
+      terrain: { data: "T", mask: "M" },
+      background: { data: "B" },
+      layers: [{ data: "L", x: 1, y: 2 }],
+      bbox: { left: 0, top: 0, right: 100, bottom: 50 },
+      parallax: { name: "Ocean", offset: 5 },
+      scale: 3,
+      ladders: [{ left: 1, top: 1, right: 2, bottom: 9 }],
+    };
+    draft.loadConfig(config, "My map");
+
+    expect(draft.name.value).toBe("My map");
+    expect(draft.terrain.value.data).toBe("T");
+    expect(draft.mask.value.data).toBe("M");
+    expect(draft.advancedSettings.value.customMask).toBe(true);
+    expect(draft.advancedSettings.value.scale).toBe(3);
+    expect(draft.advancedSettings.value.parallaxName).toBe("Ocean");
+
+    const out = draft.toConfig();
+    expect(out.terrain.data).toBe("T");
+    expect(out.terrain.mask).toBe("M");
+    expect(out.background?.data).toBe("B");
+    expect(out.scale).toBe(3);
+    expect(out.parallax).toEqual({ name: "Ocean", offset: 5 });
+    expect(out.layers).toHaveLength(1);
+    expect(out.ladders).toHaveLength(1);
+  });
+
+  it("applyPaint sets terrain + background, clears the mask, disables custom mask, defaults parallax", () => {
+    draft.applyWfc("MASKDATA", []); // a wallmask was generated first
+    draft.applyPaint({ terrain: "TT", background: "BB", width: 80, height: 40 });
+    expect(draft.terrain.value.data).toBe("TT");
+    expect(draft.background.value.data).toBe("BB");
+    expect(draft.mask.value.data).toBe("");
+    expect(draft.advancedSettings.value.customMask).toBe(false);
+    expect(draft.advancedSettings.value.parallaxName).toBe("Ocean");
+  });
+
+  it("applyWfc sets the mask, enables custom mask, and populates ladders", () => {
+    draft.applyWfc("MASKDATA", [
+      { x: 10, y: 20, width: 6, height: 30 },
+      { x: 40, y: 20, width: 6, height: 30 },
+    ]);
+    expect(draft.mask.value.data).toBe("MASKDATA");
+    expect(draft.advancedSettings.value.customMask).toBe(true);
+    expect(draft.ladders.value).toHaveLength(2);
+    expect(draft.layers.value).toEqual([]);
+  });
+
+  it("applyAiAlign sets terrain, background, and a hidden mask", () => {
+    draft.applyAiAlign({
+      terrain: "AT", background: "AB", mask: "AM", width: 80, height: 40,
+    });
+    expect(draft.terrain.value.data).toBe("AT");
+    expect(draft.background.value.data).toBe("AB");
+    expect(draft.mask.value.data).toBe("AM");
+    expect(draft.mask.value.visible).toBe(false);
+  });
+
+  it("reset clears everything", () => {
+    draft.loadConfig(
+      {
+        terrain: { data: "T" }, layers: [], bbox: BBox.create(10, 10).toJS(),
+        parallax: { name: "", offset: 0 }, scale: 6,
+      },
+      "x"
+    );
+    draft.reset();
+    expect(draft.terrain.value.data).toBe("");
+    expect(draft.name.value).toBe("");
+    expect(draft.ladders.value).toEqual([]);
+  });
+});

--- a/src/data/builder/__spec__/draft.spec.ts
+++ b/src/data/builder/__spec__/draft.spec.ts
@@ -54,6 +54,12 @@ describe("useMapDraft", () => {
     expect(draft.advancedSettings.value.parallaxName).toBe("Ocean");
   });
 
+  it("setMaskImage stores the data as a hidden mask", () => {
+    draft.setMaskImage("MASKDATA");
+    expect(draft.mask.value.data).toBe("MASKDATA");
+    expect(draft.mask.value.visible).toBe(false);
+  });
+
   it("applyWfc sets the mask, enables custom mask, and populates ladders", () => {
     draft.applyWfc("MASKDATA", [
       { x: 10, y: 20, width: 6, height: 30 },

--- a/src/data/builder/draft.ts
+++ b/src/data/builder/draft.ts
@@ -46,6 +46,7 @@ const setImage = (
 
 const setTerrainImage = (data: string) => setImage(terrain, data, true);
 const setBackgroundImage = (data: string) => setImage(background, data, true);
+const setMaskImage = (data: string) => setImage(mask, data, false);
 
 const applyWfc = (maskData: string, wfcLadders: LadderInfo[]) => {
   mask.value = { data: maskData, visible: true };
@@ -159,7 +160,7 @@ const reset = () => {
 export function useMapDraft() {
   return {
     terrain, mask, background, layers, ladders, advancedSettings, name, oldScale,
-    setTerrainImage, setBackgroundImage,
+    setTerrainImage, setBackgroundImage, setMaskImage,
     applyWfc, applyPaint, applyAiAlign,
     loadConfig, toConfig, build, reset,
   };

--- a/src/data/builder/draft.ts
+++ b/src/data/builder/draft.ts
@@ -1,0 +1,166 @@
+import { ref } from "vue";
+import { BBox } from "../map/bbox";
+import { Config, Layer, Map } from "../map";
+import type { LadderInfo } from "../wfc/postProcess";
+import { logEvent } from "../../util/firebase";
+
+export interface AdvancedSettings {
+  bbox: BBox;
+  scale: number;
+  customMask: boolean;
+  parallaxName: string;
+  parallaxOffset: number;
+}
+
+const emptyAdvanced = (): AdvancedSettings => ({
+  scale: 6,
+  bbox: BBox.create(0, 0),
+  customMask: false,
+  parallaxName: "",
+  parallaxOffset: 0,
+});
+
+const terrain = ref({ data: "", visible: false });
+const mask = ref({ data: "", visible: false });
+const background = ref({ data: "", visible: false });
+const layers = ref<Array<Layer & { visible: boolean }>>([]);
+const ladders = ref<BBox[]>([]);
+const advancedSettings = ref<AdvancedSettings>(emptyAdvanced());
+const name = ref("");
+const oldScale = ref(advancedSettings.value.scale);
+
+const setImage = (
+  target: typeof terrain,
+  data: string,
+  visible: boolean
+) => {
+  target.value = { data, visible };
+  if (advancedSettings.value.bbox.isEmpty() && data) {
+    const image = new Image();
+    image.src = data;
+    image.onload = () => {
+      advancedSettings.value.bbox = BBox.create(image.width, image.height);
+    };
+  }
+};
+
+const setTerrainImage = (data: string) => setImage(terrain, data, true);
+const setBackgroundImage = (data: string) => setImage(background, data, true);
+
+const applyWfc = (maskData: string, wfcLadders: LadderInfo[]) => {
+  mask.value = { data: maskData, visible: true };
+  advancedSettings.value.customMask = true;
+  ladders.value = wfcLadders.map(
+    (l) =>
+      new BBox(l.x - l.width / 2, l.y, l.x + l.width / 2, l.y + l.height)
+  );
+  layers.value = [];
+
+  const image = new Image();
+  image.src = maskData;
+  image.onload = () => {
+    advancedSettings.value.bbox = BBox.create(image.width, image.height);
+  };
+};
+
+const applyPaint = (result: {
+  terrain: string;
+  background: string;
+  width: number;
+  height: number;
+}) => {
+  terrain.value = { data: result.terrain, visible: true };
+  background.value = { data: result.background, visible: true };
+  // the painted terrain's alpha is the wallmask, so drop any generated mask
+  mask.value = { data: "", visible: false };
+  advancedSettings.value.customMask = false;
+  advancedSettings.value.bbox = BBox.create(result.width, result.height);
+  if (!advancedSettings.value.parallaxName) {
+    advancedSettings.value.parallaxName = "Ocean";
+  }
+};
+
+const applyAiAlign = (result: {
+  terrain: string;
+  background: string;
+  mask: string;
+  width: number;
+  height: number;
+}) => {
+  terrain.value = { data: result.terrain, visible: true };
+  background.value = { data: result.background, visible: true };
+  mask.value = { data: result.mask, visible: false };
+  advancedSettings.value.bbox = BBox.create(result.width, result.height);
+};
+
+const loadConfig = (config: Config, mapName: string) => {
+  oldScale.value = config.scale;
+  terrain.value = { data: config.terrain.data as string, visible: true };
+  background.value = {
+    data: (config.background?.data as string) || "",
+    visible: true,
+  };
+  layers.value = config.layers.map((layer) => ({ ...layer, visible: true }));
+  advancedSettings.value = {
+    bbox: BBox.fromJS(config.bbox) || BBox.create(0, 0),
+    scale: config.scale,
+    customMask: !!config.terrain.mask,
+    parallaxName: config.parallax.name,
+    parallaxOffset: config.parallax.offset,
+  };
+  name.value = mapName;
+  ladders.value =
+    (config.ladders
+      ?.map((bbox) => BBox.fromJS(bbox))
+      .filter(Boolean) as BBox[]) || [];
+  mask.value = config.terrain.mask
+    ? { data: config.terrain.mask as string, visible: false }
+    : { data: "", visible: false };
+};
+
+const toConfig = (): Config => ({
+  terrain: {
+    data: terrain.value.data || mask.value.data,
+    mask: mask.value.data,
+  },
+  background: background.value.data ? { data: background.value.data } : undefined,
+  layers: layers.value.filter((layer) => !!layer.data).map((layer) => ({ ...layer })),
+  bbox: advancedSettings.value.bbox,
+  parallax: {
+    name: advancedSettings.value.parallaxName,
+    offset: advancedSettings.value.parallaxOffset,
+  },
+  scale: advancedSettings.value.scale,
+  ladders: ladders.value,
+});
+
+const build = async () => {
+  const map = await Map.fromConfig(toConfig());
+  const url = URL.createObjectURL(await map.toBlob());
+  setTimeout(() => window.URL.revokeObjectURL(url), 1000);
+  const link = document.createElement("a");
+  link.download = `${name.value || "map"}.png`;
+  link.href = url;
+  link.click();
+  logEvent("build_map");
+};
+
+const reset = () => {
+  terrain.value = { data: "", visible: false };
+  mask.value = { data: "", visible: false };
+  background.value = { data: "", visible: false };
+  layers.value = [];
+  ladders.value = [];
+  advancedSettings.value = emptyAdvanced();
+  name.value = "";
+  oldScale.value = advancedSettings.value.scale;
+};
+
+export function useMapDraft() {
+  return {
+    terrain, mask, background, layers, ladders, advancedSettings, name, oldScale,
+    setTerrainImage, setBackgroundImage,
+    applyWfc, applyPaint, applyAiAlign,
+    loadConfig, toConfig, build, reset,
+  };
+}

--- a/src/data/wfc/runWfc.ts
+++ b/src/data/wfc/runWfc.ts
@@ -1,0 +1,69 @@
+import type { LadderInfo } from "./postProcess";
+import WfcWorker from "./wfc.worker?worker";
+
+export interface WfcSettings {
+  width: number;
+  height: number;
+  density: number;
+  edgeTop: number;
+  edgeBottom: number;
+  edgeLeft: number;
+  edgeRight: number;
+  continuityBonus: number;
+  preventBlockages: boolean;
+  densityMode: "edges" | "image";
+  densityMask: Uint8Array | null;
+  densityImageData: string;
+}
+
+export interface WfcResult {
+  mask: string;
+  ladders: LadderInfo[];
+}
+
+// Runs the WFC worker once. The returned promise resolves with the generated
+// mask + ladders or rejects with an Error so callers always get to react to
+// failures. The worker handle is returned too so callers can terminate it
+// early (e.g. on unmount).
+export function runWfc(settings: WfcSettings): {
+  promise: Promise<WfcResult>;
+  worker: Worker;
+} {
+  const worker = new WfcWorker();
+
+  const promise = new Promise<WfcResult>((resolve, reject) => {
+    worker.postMessage({
+      width: settings.width,
+      height: settings.height,
+      density: settings.density / 100,
+      edges: {
+        top: settings.edgeTop / 100,
+        bottom: settings.edgeBottom / 100,
+        left: settings.edgeLeft / 100,
+        right: settings.edgeRight / 100,
+      },
+      continuityBonus: settings.continuityBonus,
+      preventBlockages: settings.preventBlockages,
+      ...(settings.densityMode === "image" && settings.densityMask
+        ? { densityMask: settings.densityMask }
+        : {}),
+    });
+
+    worker.onmessage = (e: MessageEvent) => {
+      if (e.data.type === "progress") return;
+      worker.terminate();
+      if (e.data.success && e.data.mask) {
+        resolve({ mask: e.data.mask, ladders: e.data.ladders ?? [] });
+      } else {
+        reject(new Error(e.data.error ?? "Generation failed."));
+      }
+    };
+
+    worker.onerror = () => {
+      worker.terminate();
+      reject(new Error("An unexpected error occurred."));
+    };
+  });
+
+  return { promise, worker };
+}


### PR DESCRIPTION
## Summary

Adds a configuration wizard that opens from the home menu and guides map creation down four paths, backed by a single shared map-draft store.

- **Home-screen wizard** — the **Builder** menu entry opens a wizard overlay (it only navigates to `/builder` when a path needs it). Four options: autogenerate map, autogenerate terrain, create manually, and an inline load-map select.
- **Autogenerate map** — generate a wallmask (WFC) → paint terrain → builder. `g` regenerates the wallmask while painting.
- **Autogenerate terrain** — generate a wallmask → an "Add terrain" preview screen with export-for-AI and import-AI-terrain (align) → builder. `g` regenerates here too.
- **Create manually** — upload terrain (auto-advances) → upload background (skippable) → a "Finalize map" screen (scrollable advanced help) with **Build** or **Continue in builder**.
- **Load map** — pick an existing map inline and edit it.
- **Unified state** — a singleton `useMapDraft` store is the single source of truth; the builder composables were refactored onto it so the wizard and builder share one map. The builder's old terrain tool buttons are replaced by a single "open wizard" button that reopens the wizard at its last screen.
- Reuses the existing WFC / paint / AI-align dialogs (now with a consistent Back/Next, seamless backdrop) and a new compact `MapSelect`.

History is organised into 7 atomic commits (each type-checks independently).

## Test plan

- [x] `yarn check-types`, `yarn build`, `yarn test` (421 tests) all pass — and each commit type-checks on its own
- [x] Manually verified in-browser: all four paths reach the builder; `g` regenerates on the paint and preview screens; back-navigation and the close button work; reopening from the builder resumes at the last screen; after painting, no separate wallmask is carried into the builder; starting a fresh path clears the previous map
- [ ] Reviewer: exercise each wizard path end-to-end and confirm a built/tested map plays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)