### PR TITLE
Hand-drawn wallmask editor in the builder wizard

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,9 @@ import { RouterView } from "vue-router";
 
   --small-radius: 3px;
   --big-radius: 6px;
+  // shared body size so every builder-wizard screen is the same height & width
+  --wizard-body-height: min(460px, 60vh);
+  --wizard-body-width: min(552px, 86vw);
   --stroke-length: 43.425px;
   --glow-warm: rgba(180, 120, 40, 0.3);
   --glow-warm-soft: rgba(180, 120, 40, 0.1);

--- a/src/components/molecules/ImageInput.vue
+++ b/src/components/molecules/ImageInput.vue
@@ -163,6 +163,7 @@ function handleDragLeave() {
     height: 100px;
     box-sizing: border-box;
     object-fit: cover;
+    background: repeating-conic-gradient(#ccc 0% 25%, #eee 0% 50%) 0 0 / 16px 16px;
     border: 1px solid var(--border-accent-faint);
     border-radius: var(--small-radius);
     box-shadow: 0 1px 4px rgba(30, 15, 5, 0.2);

--- a/src/components/organisms/BuilderWizard.vue
+++ b/src/components/organisms/BuilderWizard.vue
@@ -36,9 +36,8 @@ const title = computed(() => TITLES[screen.value] ?? "");
 
 const wfcSettings = ref<WfcSettings>({
   width: 10, height: 4, density: 60,
-  edgeTop: 25, edgeBottom: 75, edgeLeft: 0, edgeRight: 0,
   continuityBonus: 2, preventBlockages: true,
-  densityMode: "edges", densityMask: null, densityImageData: "",
+  densityMask: null,
 });
 const wfcLadders = ref<LadderInfo[]>([]);
 
@@ -223,14 +222,16 @@ onUnmounted(() => {
       v-if="screen === 'autoMap-wfc' || screen === 'autoTerrain-wfc'"
       :settings="wfcSettings"
       :onGenerate="handleWfcGenerated"
-      :onClose="goBack"
+      :onClose="closeWizard"
+      :onBack="goBack"
     />
     <TerrainPaintDialog
       v-else-if="screen === 'autoMap-paint'"
       :alphaSrc="draft.mask.value.data || draft.terrain.value.data"
       :ladders="draft.ladders.value.map((l) => l.toJS())"
       :onConfirm="handlePaintConfirm"
-      :onClose="goBack"
+      :onClose="closeWizard"
+      :onBack="goBack"
     />
 
     <div v-else class="wizard-overlay">
@@ -375,8 +376,9 @@ onUnmounted(() => {
 }
 
 .wizard-panel {
-  width: 100%;
-  max-width: 640px;
+  // shrink-wrap to the shared body width (+ panel chrome) so it matches the dialogs
+  width: auto;
+  max-width: 100%;
 }
 
 .wizard-head {
@@ -385,12 +387,12 @@ onUnmounted(() => {
   align-items: center;
   margin-bottom: 10px;
   margin-right: -10px;
-  min-height: 40px;
 }
 
-/* fixed height so every wizard screen is the same size as the paint dialog */
+/* fixed size so every wizard screen matches the wfc/paint dialogs */
 .wizard-body {
-  height: min(460px, 76vh);
+  width: var(--wizard-body-width);
+  height: var(--wizard-body-height);
   overflow: auto;
   display: flex;
   flex-direction: column;
@@ -467,6 +469,7 @@ onUnmounted(() => {
     display: block;
     image-rendering: pixelated;
     width: 100%;
+    background: repeating-conic-gradient(#ccc 0% 25%, #eee 0% 50%) 0 0 / 16px 16px;
   }
 }
 

--- a/src/components/organisms/TerrainPaintDialog.vue
+++ b/src/components/organisms/TerrainPaintDialog.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
     height: number;
   }) => void;
   onClose: () => void;
+  onBack: () => void;
 }>();
 
 const SEED = 1;
@@ -137,8 +138,10 @@ const handlePreviewClick = (event: MouseEvent) => {
   const res = result.value;
   const ad = alphaData.value;
   if (!res || !ad) return;
-  const x = Math.floor(event.offsetX / PREVIEW_SCALE);
-  const y = Math.floor(event.offsetY / PREVIEW_SCALE);
+  // The canvas is scaled to fit, so map from displayed size to map coordinates.
+  const canvas = event.currentTarget as HTMLCanvasElement;
+  const x = Math.floor((event.offsetX / canvas.clientWidth) * ad.width);
+  const y = Math.floor((event.offsetY / canvas.clientHeight) * ad.height);
   if (x < 0 || y < 0 || x >= ad.width || y >= ad.height) return;
   const zone = res.zoneMap[y * ad.width + x];
   selectedZone.value = zone >= 0 ? zone : null;
@@ -233,7 +236,7 @@ function handleConfirm() {
       <p v-if="error" class="error">{{ error }}</p>
 
       <div class="actions">
-        <button class="secondary" @click="onClose">Back</button>
+        <button class="secondary" @click="onBack">Back</button>
         <button class="primary" :disabled="zones.length === 0" @click="handleConfirm">
           Next
         </button>
@@ -247,21 +250,30 @@ function handleConfirm() {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  min-width: 400px;
+  width: var(--wizard-body-width);
+  height: var(--wizard-body-height);
 }
 
+// invisible centering area; the border lives on the canvas so it hugs the map
 .preview-scroll {
-  overflow: auto;
-  max-width: 600px;
-  max-height: 300px;
-  border: 1px solid var(--border-accent-faint);
-  border-radius: 4px;
-  scrollbar-color: var(--background-dark) transparent;
-  scrollbar-width: thin;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .preview {
   display: block;
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: 0;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  border: 1px solid var(--border-accent-faint);
+  border-radius: 4px;
   cursor: pointer;
   image-rendering: pixelated;
   background: repeating-conic-gradient(#ccc 0% 25%, #eee 0% 50%) 0 0 / 16px 16px;
@@ -332,7 +344,7 @@ function handleConfirm() {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-top: 4px;
+  margin-top: auto;
 
   // back button pinned left, primary action to the right
   > :first-child {

--- a/src/components/organisms/WfcDialog.vue
+++ b/src/components/organisms/WfcDialog.vue
@@ -1,63 +1,123 @@
 <!-- src/components/organisms/WfcDialog.vue -->
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref, watch, onMounted, onUnmounted } from "vue";
 import Dialog from "../molecules/Dialog.vue";
 import Input from "../atoms/Input.vue";
-import ImageInput from "../molecules/ImageInput.vue";
 import { TILE_SIZE_PX } from "../../data/wfc/tiles";
+import { buildDefaultMask } from "../../data/wfc/mask";
 import type { LadderInfo } from "../../data/wfc/postProcess";
 import { runWfc, type WfcSettings } from "../../data/wfc/runWfc";
 
 export type { WfcSettings };
 
-const { onGenerate, onClose, settings, initialError } = defineProps<{
+const { onGenerate, onClose, onBack, settings, initialError } = defineProps<{
   onGenerate: (maskData: string, ladders: LadderInfo[]) => void;
   onClose: () => void;
+  onBack: () => void;
   settings: WfcSettings;
   initialError?: string;
 }>();
 
 const generating = ref(false);
 const error = ref(initialError ?? "");
+const canvas = ref<HTMLCanvasElement | null>(null);
+const maskWrap = ref<HTMLElement | null>(null);
+const painting = ref<null | "draw" | "erase">(null);
+let resizeObserver: ResizeObserver | null = null;
 
-function processImageToMask() {
-  if (!settings.densityImageData || settings.densityMode !== "image") {
-    settings.densityMask = null;
-    return;
-  }
+// Scale the canvas to fit whatever space the editor row has, preserving the
+// map aspect. Driving the display size off the available box (rather than a
+// fixed height) keeps the dialog scrollbar-free at any viewport or map shape.
+function fitCanvas() {
+  const wrap = maskWrap.value;
+  const c = canvas.value;
+  if (!wrap || !c) return;
+  const availW = wrap.clientWidth;
+  const availH = wrap.clientHeight;
+  if (availW <= 0 || availH <= 0) return;
+  const aspect = settings.width / Math.max(1, settings.height);
+  const dispW = Math.min(availW, availH * aspect);
+  c.style.width = `${dispW}px`;
+  c.style.height = `${dispW / aspect}px`;
+}
 
-  const img = new Image();
-  img.onload = () => {
-    const canvas = document.createElement("canvas");
-    canvas.width = settings.width;
-    canvas.height = settings.height;
-    const ctx = canvas.getContext("2d")!;
-    ctx.drawImage(img, 0, 0, settings.width, settings.height);
-
-    const imageData = ctx.getImageData(0, 0, settings.width, settings.height);
-    const mask = new Uint8Array(settings.width * settings.height);
-    for (let i = 0; i < mask.length; i++) {
-      const r = imageData.data[i * 4];
-      const g = imageData.data[i * 4 + 1];
-      const b = imageData.data[i * 4 + 2];
-      const a = imageData.data[i * 4 + 3];
-      // Darkness × opacity: white/transparent = 0, black opaque = 255
-      const brightness = (r + g + b) / 3;
-      mask[i] = Math.round((1 - brightness / 255) * (a / 255) * 255);
+function draw() {
+  const c = canvas.value;
+  const mask = settings.densityMask;
+  if (!c || !mask) return;
+  const ctx = c.getContext("2d")!;
+  ctx.clearRect(0, 0, c.width, c.height);
+  for (let y = 0; y < settings.height; y++) {
+    for (let x = 0; x < settings.width; x++) {
+      const v = mask[y * settings.width + x];
+      if (!v) continue;
+      ctx.fillStyle = `rgba(0, 0, 0, ${v / 255})`;
+      ctx.fillRect(x, y, 1, 1);
     }
-    settings.densityMask = mask;
-  };
-  img.src = settings.densityImageData;
+  }
 }
 
-function handleImageAdd() {
-  processImageToMask();
+function sizeBackingStore() {
+  const c = canvas.value;
+  if (c) {
+    c.width = settings.width;
+    c.height = settings.height;
+  }
 }
 
-watch(
-  () => [settings.width, settings.height],
-  () => processImageToMask(),
-);
+function resetMask() {
+  settings.densityMask = buildDefaultMask(settings.width, settings.height);
+  sizeBackingStore();
+  fitCanvas();
+  draw();
+}
+
+function paint(e: PointerEvent) {
+  const c = canvas.value;
+  const mask = settings.densityMask;
+  if (!c || !mask || !painting.value) return;
+  const rect = c.getBoundingClientRect();
+  const px = Math.floor(((e.clientX - rect.left) / rect.width) * settings.width);
+  const py = Math.floor(((e.clientY - rect.top) / rect.height) * settings.height);
+  if (px < 0 || px >= settings.width || py < 0 || py >= settings.height) return;
+  mask[py * settings.width + px] =
+    painting.value === "erase" ? 0 : Math.round((settings.density / 100) * 255);
+  draw();
+}
+
+function onPointerDown(e: PointerEvent) {
+  if (e.button === 0) painting.value = "draw";
+  else if (e.button === 2) painting.value = "erase";
+  else return;
+  canvas.value?.setPointerCapture(e.pointerId);
+  paint(e);
+}
+
+function onPointerUp(e: PointerEvent) {
+  painting.value = null;
+  if (canvas.value?.hasPointerCapture(e.pointerId)) {
+    canvas.value.releasePointerCapture(e.pointerId);
+  }
+}
+
+onMounted(() => {
+  // Preserve a previously drawn mask when returning to this step; only build
+  // the default pattern when none exists for the current dimensions.
+  const mask = settings.densityMask;
+  if (mask && mask.length === settings.width * settings.height) {
+    sizeBackingStore();
+    fitCanvas();
+    draw();
+  } else {
+    resetMask();
+  }
+  if (maskWrap.value) {
+    resizeObserver = new ResizeObserver(() => fitCanvas());
+    resizeObserver.observe(maskWrap.value);
+  }
+});
+onUnmounted(() => resizeObserver?.disconnect());
+watch(() => [settings.width, settings.height], resetMask);
 
 const handleGenerate = () => {
   generating.value = true;
@@ -100,99 +160,39 @@ const handleGenerate = () => {
         <input type="checkbox" v-model="settings.preventBlockages" class="checkbox" />
       </label>
 
-      <div class="density-section">
-        <span class="section-title">Density</span>
-        <div class="density-mode-toggle">
-          <button
-            :class="['mode-btn', { active: settings.densityMode === 'edges' }]"
-            @click="settings.densityMode = 'edges'"
-          >
-            Sliders
-          </button>
-          <button
-            :class="['mode-btn', { active: settings.densityMode === 'image' }]"
-            @click="settings.densityMode = 'image'"
-          >
-            Mask
-          </button>
-        </div>
-
-        <template v-if="settings.densityMode === 'edges'">
-          <label class="slider-label">
-            <span class="edge-label">Global</span>
+      <div class="mask-editor">
+        <span class="section-title">Density mask</span>
+        <p class="editor-hint">Left-click to draw, right-click to erase</p>
+        <div class="editor-row">
+          <div class="density-control">
             <input
               type="range"
               v-model.number="settings.density"
               min="0"
               max="100"
-              class="slider"
+              class="density-slider"
             />
             <span class="slider-value">{{ settings.density }}%</span>
-          </label>
-          <div class="edges-grid">
-            <label class="slider-label">
-              <span class="edge-label">Top</span>
-              <input
-                type="range"
-                v-model.number="settings.edgeTop"
-                min="0"
-                max="100"
-                class="slider"
-              />
-              <span class="slider-value">{{ settings.edgeTop }}%</span>
-            </label>
-            <label class="slider-label">
-              <span class="edge-label">Bottom</span>
-              <input
-                type="range"
-                v-model.number="settings.edgeBottom"
-                min="0"
-                max="100"
-                class="slider"
-              />
-              <span class="slider-value">{{ settings.edgeBottom }}%</span>
-            </label>
-            <label class="slider-label">
-              <span class="edge-label">Left</span>
-              <input
-                type="range"
-                v-model.number="settings.edgeLeft"
-                min="0"
-                max="100"
-                class="slider"
-              />
-              <span class="slider-value">{{ settings.edgeLeft }}%</span>
-            </label>
-            <label class="slider-label">
-              <span class="edge-label">Right</span>
-              <input
-                type="range"
-                v-model.number="settings.edgeRight"
-                min="0"
-                max="100"
-                class="slider"
-              />
-              <span class="slider-value">{{ settings.edgeRight }}%</span>
-            </label>
           </div>
-        </template>
-
-        <ImageInput
-          v-else
-          name="Density mask"
-          v-model="settings.densityImageData"
-          :onAdd="handleImageAdd"
-          clearable
-          hideTitle
-          :onClear="() => (settings.densityMask = null)"
-        />
+          <div ref="maskWrap" class="mask-wrap">
+            <canvas
+              ref="canvas"
+              class="mask-canvas"
+              @pointerdown="onPointerDown"
+              @pointermove="paint"
+              @pointerup="onPointerUp"
+              @pointerleave="onPointerUp"
+              @contextmenu.prevent
+            />
+          </div>
+        </div>
       </div>
 
       <p v-if="error" class="error">{{ error }}</p>
 
       <div class="actions">
-        <button class="secondary" @click="onClose">Back</button>
-        <button class="primary" @click="handleGenerate" :disabled="generating || (settings.densityMode === 'image' && !settings.densityImageData)">
+        <button class="secondary" @click="onBack">Back</button>
+        <button class="primary" @click="handleGenerate" :disabled="generating">
           <span v-if="generating" class="spinner-row">
             <span class="spinner">&#x07F7;</span>
             Generating...
@@ -209,7 +209,8 @@ const handleGenerate = () => {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  min-width: 320px;
+  width: var(--wizard-body-width);
+  height: var(--wizard-body-height);
 }
 
 .size-row {
@@ -262,22 +263,76 @@ const handleGenerate = () => {
   }
 }
 
-.density-section {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
 .section-title {
   font-family: Eternal;
   font-size: 24px;
   color: var(--primary);
 }
 
-.edges-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 6px 16px;
+// The editor fills the space left after the fixed controls, so the dialog
+// body never overflows; the canvas is sized to fit by fitCanvas().
+.mask-editor {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.editor-row {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: stretch;
+  gap: 10px;
+}
+
+.mask-wrap {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mask-canvas {
+  // width/height are set by fitCanvas() to fit the wrap, preserving aspect.
+  box-sizing: border-box;
+  background: #fff;
+  border: 1px solid var(--primary);
+  image-rendering: pixelated;
+  cursor: crosshair;
+  touch-action: none;
+}
+
+.density-control {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+
+  .density-slider {
+    flex: 1;
+    min-height: 0;
+    writing-mode: vertical-lr;
+    direction: rtl;
+    accent-color: var(--primary);
+    cursor: pointer;
+  }
+
+  .slider-value {
+    min-width: 40px;
+    text-align: center;
+    font-size: 13px;
+    color: var(--primary);
+  }
+}
+
+.editor-hint {
+  font-size: 12px;
+  color: var(--primary);
+  opacity: 0.6;
 }
 
 .error {
@@ -289,7 +344,7 @@ const handleGenerate = () => {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-top: 4px;
+  margin-top: auto;
 
   // back button pinned left, primary action to the right
   > :first-child {
@@ -304,30 +359,4 @@ const handleGenerate = () => {
   gap: 6px;
 }
 
-.density-mode-toggle {
-  display: flex;
-  gap: 4px;
-
-  .mode-btn {
-    flex: 1;
-    padding: 6px 12px;
-    font-family: Eternal;
-    font-size: 20px;
-    color: var(--primary);
-    background: transparent;
-    border: 1px solid var(--primary);
-    cursor: pointer;
-    opacity: 0.5;
-    transition: opacity 0.15s;
-
-    &.active {
-      opacity: 1;
-      background: rgba(var(--primary-rgb), 0.15);
-    }
-
-    &:hover {
-      opacity: 0.8;
-    }
-  }
-}
 </style>

--- a/src/data/wfc/__spec__/mask.spec.ts
+++ b/src/data/wfc/__spec__/mask.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+import { buildDefaultMask } from "../mask";
+
+describe("buildDefaultMask", () => {
+  test("has the right length", () => {
+    expect(buildDefaultMask(10, 4)).toHaveLength(40);
+  });
+
+  test("height 4: bottom row solid, row above half, top two empty", () => {
+    const mask = buildDefaultMask(2, 4); // band = round(0.8) = 1
+    const rows = [0, 1, 2, 3].map((y) => [mask[y * 2], mask[y * 2 + 1]]);
+    expect(rows[0]).toEqual([0, 0]);
+    expect(rows[1]).toEqual([0, 0]);
+    expect(rows[2]).toEqual([128, 128]);
+    expect(rows[3]).toEqual([255, 255]);
+  });
+
+  test("height 10: bottom 2 rows solid, next 2 rows half, rest empty", () => {
+    const w = 3;
+    const mask = buildDefaultMask(w, 10); // band = 2
+    const rowValue = (y: number) => mask[y * w];
+    expect([8, 9].map(rowValue)).toEqual([255, 255]);
+    expect([6, 7].map(rowValue)).toEqual([128, 128]);
+    expect([0, 1, 2, 3, 4, 5].map(rowValue)).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+});

--- a/src/data/wfc/__spec__/wfc.spec.ts
+++ b/src/data/wfc/__spec__/wfc.spec.ts
@@ -33,8 +33,7 @@ describe("wfc solver", () => {
       width: 3,
       height: 3,
       tiles: testTiles,
-      density: 0.5,
-      edges: { top: 0, bottom: 1, left: 0, right: 0 },
+      densityMask: new Uint8Array(9).fill(128),
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 42,
@@ -50,8 +49,7 @@ describe("wfc solver", () => {
       width: 5,
       height: 5,
       tiles: testTiles,
-      density: 0.5,
-      edges: { top: 0, bottom: 1, left: 0.5, right: 0.5 },
+      densityMask: new Uint8Array(25).fill(128),
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 123,
@@ -62,40 +60,23 @@ describe("wfc solver", () => {
     expect(result.grid![0].length).toBe(5);
   });
 
-  test("respects solid bottom edge constraint", () => {
+  test("mask-zero cells become empty tiles", () => {
+    const width = 5;
+    const height = 3;
+    const mask = new Uint8Array(width * height).fill(255);
+    for (let x = 0; x < width; x++) mask[x] = 0; // top row empty
     const params: WfcParams = {
-      width: 5,
-      height: 3,
+      width,
+      height,
       tiles: testTiles,
-      density: 0.5,
-      edges: { top: 0, bottom: 1, left: 0, right: 0 },
+      densityMask: mask,
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 42,
     };
     const result = solve(params);
     expect(result.success).toBe(true);
-    const bottomRow = result.grid![2];
-    for (const tile of bottomRow) {
-      expect(tile.sockets.bottom).toBe(Socket.SOLID);
-    }
-  });
-
-  test("respects open top edge constraint", () => {
-    const params: WfcParams = {
-      width: 5,
-      height: 3,
-      tiles: testTiles,
-      density: 0.5,
-      edges: { top: 0, bottom: 0, left: 0, right: 0 },
-      continuityBonus: 1.5,
-      preventBlockages: false,
-      seed: 42,
-    };
-    const result = solve(params);
-    expect(result.success).toBe(true);
-    const topRow = result.grid![0];
-    for (const tile of topRow) {
+    for (const tile of result.grid![0]) {
       expect(tile.sockets.top).toBe(Socket.EMPTY);
     }
   });
@@ -105,8 +86,7 @@ describe("wfc solver", () => {
       width: 4,
       height: 4,
       tiles: testTiles,
-      density: 0.5,
-      edges: { top: 0, bottom: 1, left: 0, right: 0 },
+      densityMask: new Uint8Array(16).fill(128),
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 99,
@@ -123,8 +103,7 @@ describe("wfc solver", () => {
       width: 5,
       height: 5,
       tiles: testTiles,
-      density: 0.5,
-      edges: { top: 0, bottom: 1, left: 0.5, right: 0.5 },
+      densityMask: new Uint8Array(25).fill(128),
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 42,
@@ -150,8 +129,7 @@ describe("wfc solver", () => {
       width: 10,
       height: 10,
       tiles: testTiles,
-      density: 0.5,
-      edges: { top: 0, bottom: 1, left: 0, right: 0 },
+      densityMask: new Uint8Array(100).fill(128),
       continuityBonus: 1.5,
       preventBlockages: false,
     };
@@ -186,8 +164,7 @@ describe("wfc solver", () => {
       width: 3,
       height: 3,
       tiles: tilesWithEdge,
-      density: 0.5,
-      edges: { top: 0, bottom: 0, left: 0, right: 0 },
+      densityMask: new Uint8Array(9).fill(128),
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 42,
@@ -220,8 +197,7 @@ describe("wfc solver", () => {
       width: 3,
       height: 3,
       tiles: tilesWithLadder,
-      density: 0.5,
-      edges: { top: 1, bottom: 1, left: 1, right: 1 },
+      densityMask: new Uint8Array(9).fill(128),
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 42,
@@ -274,8 +250,7 @@ describe("wfc solver", () => {
         width: 6,
         height: 4,
         tiles: tilesWithMandatory,
-        density: 0.5,
-        edges: { top: 0, bottom: 1, left: 0, right: 0 },
+        densityMask: new Uint8Array(24).fill(128),
         continuityBonus: 1.5,
         preventBlockages: false,
         seed,
@@ -328,8 +303,7 @@ describe("wfc solver", () => {
       width: 8,
       height: 4,
       tiles: constrainedTiles,
-      density: 0.3,
-      edges: { top: 0, bottom: 1, left: 0, right: 0 },
+      densityMask: new Uint8Array(32).fill(128),
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 42,
@@ -350,8 +324,6 @@ describe("solver with densityMask", () => {
       width: 4,
       height: 4,
       tiles: testTiles,
-      density: 0.8,
-      edges: { top: 0, bottom: 0, left: 0, right: 0 },
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 42,
@@ -369,8 +341,6 @@ describe("solver with densityMask", () => {
       width: 4,
       height: 4,
       tiles: testTiles,
-      density: 0.8,
-      edges: { top: 0, bottom: 0, left: 0, right: 0 },
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 42,
@@ -382,38 +352,33 @@ describe("solver with densityMask", () => {
     expect(emptyCount).toBeGreaterThan(8);
   });
 
-  test("mask hard-constraint overrides edge constraints", () => {
-    // Edges would force the bottom row solid; the mask overrides to empty.
+  test("mask-zero forces every cell empty", () => {
     const width = 4;
     const height = 4;
-    const mask = new Uint8Array(width * height); // all zeros => all empty
+    const mask = new Uint8Array(width * height); // all zeros
     const params: WfcParams = {
       width,
       height,
       tiles: testTiles,
-      density: 0.8,
-      edges: { top: 0, bottom: 1, left: 0, right: 0 },
+      densityMask: mask,
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 42,
-      densityMask: mask,
     };
     const result = solve(params);
     expect(result.success).toBe(true);
-    for (const tile of result.grid![height - 1]) {
+    for (const tile of result.grid!.flat()) {
       expect(tile.density).toBe(0);
     }
   });
 
   test("intermediate mask values bias toward higher-density tiles", () => {
-    // Identical seed/edges; only the mask differs. A high-density mask should
+    // Identical seed; only the mask differs. A high-density mask should
     // produce more solid tiles than a low-density mask.
     const baseParams: Omit<WfcParams, "densityMask"> = {
       width: 6,
       height: 6,
       tiles: testTiles,
-      density: 0.5,
-      edges: { top: 0, bottom: 0, left: 0, right: 0 },
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 7,
@@ -442,12 +407,10 @@ describe("solver with densityMask", () => {
       width: 4,
       height: 4,
       tiles: renamedTiles,
-      density: 0.8,
-      edges: { top: 0, bottom: 0, left: 0, right: 0 },
+      densityMask: mask,
       continuityBonus: 1.5,
       preventBlockages: false,
       seed: 42,
-      densityMask: mask,
     };
     const result = solve(params);
     expect(result.success).toBe(true);
@@ -457,4 +420,3 @@ describe("solver with densityMask", () => {
     }
   });
 });
-

--- a/src/data/wfc/mask.ts
+++ b/src/data/wfc/mask.ts
@@ -1,0 +1,13 @@
+export function buildDefaultMask(width: number, height: number): Uint8Array {
+  const mask = new Uint8Array(width * height);
+  const band = Math.round(height * 0.2);
+  const solidStart = height - band;
+  const halfStart = solidStart - band;
+  for (let y = 0; y < height; y++) {
+    const value = y >= solidStart ? 255 : y >= halfStart ? 128 : 0;
+    for (let x = 0; x < width; x++) {
+      mask[y * width + x] = value;
+    }
+  }
+  return mask;
+}

--- a/src/data/wfc/runWfc.ts
+++ b/src/data/wfc/runWfc.ts
@@ -5,15 +5,9 @@ export interface WfcSettings {
   width: number;
   height: number;
   density: number;
-  edgeTop: number;
-  edgeBottom: number;
-  edgeLeft: number;
-  edgeRight: number;
   continuityBonus: number;
   preventBlockages: boolean;
-  densityMode: "edges" | "image";
   densityMask: Uint8Array | null;
-  densityImageData: string;
 }
 
 export interface WfcResult {
@@ -32,21 +26,17 @@ export function runWfc(settings: WfcSettings): {
   const worker = new WfcWorker();
 
   const promise = new Promise<WfcResult>((resolve, reject) => {
+    if (!settings.densityMask) {
+      reject(new Error("No density mask to generate from."));
+      return;
+    }
+
     worker.postMessage({
       width: settings.width,
       height: settings.height,
-      density: settings.density / 100,
-      edges: {
-        top: settings.edgeTop / 100,
-        bottom: settings.edgeBottom / 100,
-        left: settings.edgeLeft / 100,
-        right: settings.edgeRight / 100,
-      },
       continuityBonus: settings.continuityBonus,
       preventBlockages: settings.preventBlockages,
-      ...(settings.densityMode === "image" && settings.densityMask
-        ? { densityMask: settings.densityMask }
-        : {}),
+      densityMask: settings.densityMask,
     });
 
     worker.onmessage = (e: MessageEvent) => {

--- a/src/data/wfc/wfc.ts
+++ b/src/data/wfc/wfc.ts
@@ -4,12 +4,10 @@ export interface WfcParams {
   width: number;
   height: number;
   tiles: WfcTile[];
-  density: number;
-  edges: { top: number; bottom: number; left: number; right: number };
   continuityBonus: number;
   preventBlockages: boolean;
   seed?: number;
-  densityMask?: Uint8Array;
+  densityMask: Uint8Array;
   /** Per-attempt wall-clock budget. Returns null if exceeded. */
   maxTimeMs?: number;
 }
@@ -48,36 +46,6 @@ export function createRng(seed: number): () => number {
     t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
     return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
   };
-}
-
-function cellDensity(
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-  globalDensity: number,
-  edges: WfcParams["edges"],
-): number {
-  const halfW = width / 2;
-  const halfH = height / 2;
-
-  const topI = Math.max(0, 1 - y / halfH);
-  const bottomI = Math.max(0, 1 - (height - 1 - y) / halfH);
-  const leftI = Math.max(0, 1 - x / halfW);
-  const rightI = Math.max(0, 1 - (width - 1 - x) / halfW);
-
-  const totalEdge = topI + bottomI + leftI + rightI;
-  if (totalEdge === 0) return globalDensity;
-
-  const edgeDensity =
-    (topI * edges.top +
-      bottomI * edges.bottom +
-      leftI * edges.left +
-      rightI * edges.right) /
-    totalEdge;
-
-  const globalI = Math.max(0, 1 - totalEdge);
-  return globalI * globalDensity + (1 - globalI) * edgeDensity;
 }
 
 function isOnEdge(
@@ -208,43 +176,6 @@ function pickWeighted(
     if (r <= 0) return options[i];
   }
   return options[options.length - 1];
-}
-
-function applyEdgeConstraints(
-  grid: Set<WfcTile>[][],
-  edges: WfcParams["edges"],
-  width: number,
-  height: number,
-): void {
-  const constrain = (
-    cell: Set<WfcTile>,
-    dir: Direction,
-    edgeDensity: number,
-  ) => {
-    let filtered: WfcTile[];
-
-    if (edgeDensity >= 1.0) {
-      filtered = [...cell].filter((t) => t.id === "solid");
-    } else if (edgeDensity <= 0) {
-      filtered = [...cell].filter((t) => t.id === "empty");
-    } else {
-      return;
-    }
-
-    if (filtered.length > 0) {
-      cell.clear();
-      for (const t of filtered) cell.add(t);
-    }
-  };
-
-  for (let x = 0; x < width; x++) {
-    constrain(grid[0][x], "top", edges.top);
-    constrain(grid[height - 1][x], "bottom", edges.bottom);
-  }
-  for (let y = 0; y < height; y++) {
-    constrain(grid[y][0], "left", edges.left);
-    constrain(grid[y][width - 1], "right", edges.right);
-  }
 }
 
 function propagate(
@@ -434,17 +365,12 @@ function enforceAllMandatory(
 }
 
 export function solveOnce(params: WfcParams, rng: () => number): SolveOnceResult {
-  const { width, height, tiles, density, edges, continuityBonus, preventBlockages, densityMask, maxTimeMs } = params;
+  const { width, height, tiles, continuityBonus, preventBlockages, densityMask, maxTimeMs } = params;
   const startTime = maxTimeMs !== undefined ? performance.now() : 0;
   const isOutOfTime = () =>
     maxTimeMs !== undefined && performance.now() - startTime > maxTimeMs;
 
-  const getDensity = (x: number, y: number): number => {
-    if (densityMask) {
-      return densityMask[y * width + x] / 255;
-    }
-    return cellDensity(x, y, width, height, density, edges);
-  };
+  const getDensity = (x: number, y: number): number => densityMask[y * width + x] / 255;
 
   const grid: Set<WfcTile>[][] = Array.from({ length: height }, (_, y) =>
     Array.from({ length: width }, (_, x) =>
@@ -452,22 +378,17 @@ export function solveOnce(params: WfcParams, rng: () => number): SolveOnceResult
     ),
   );
 
-  if (densityMask) {
-    // Mask fully controls density; edge sliders are ignored in this mode.
-    for (let y = 0; y < height; y++) {
-      for (let x = 0; x < width; x++) {
-        if (!densityMask[y * width + x]) {
-          const cell = grid[y][x];
-          const emptyOnly = [...cell].filter((t) => t.density === 0);
-          if (emptyOnly.length > 0) {
-            cell.clear();
-            for (const t of emptyOnly) cell.add(t);
-          }
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      if (!densityMask[y * width + x]) {
+        const cell = grid[y][x];
+        const emptyOnly = [...cell].filter((t) => t.density === 0);
+        if (emptyOnly.length > 0) {
+          cell.clear();
+          for (const t of emptyOnly) cell.add(t);
         }
       }
     }
-  } else {
-    applyEdgeConstraints(grid, edges, width, height);
   }
 
   const initQueue: Array<[number, number]> = [];

--- a/src/data/wfc/wfc.worker.ts
+++ b/src/data/wfc/wfc.worker.ts
@@ -5,11 +5,9 @@ import { gridToBlob, type LadderInfo } from "./postProcess";
 export interface WfcWorkerInput {
   width: number;
   height: number;
-  density: number;
-  edges: { top: number; bottom: number; left: number; right: number };
   continuityBonus: number;
   preventBlockages: boolean;
-  densityMask?: Uint8Array;
+  densityMask: Uint8Array;
 }
 
 export type AttemptOutcome = "started" | "failed" | "timed-out";
@@ -53,13 +51,13 @@ async function loadTileImages(tiles: WfcTile[]): Promise<WfcTile[]> {
 
 self.onmessage = async (e: MessageEvent<WfcWorkerInput>) => {
   try {
-    const { width, height, density, edges, continuityBonus, preventBlockages, densityMask } = e.data;
+    const { width, height, continuityBonus, preventBlockages, densityMask } = e.data;
 
     const filteredTiles = preventBlockages ? TILES.filter((t) => t.id !== "wall") : TILES;
     const tiles = await loadTileImages(filteredTiles);
 
     const ATTEMPT_BUDGET_MS = 400;
-    const params = { width, height, tiles, density, edges, continuityBonus, preventBlockages, densityMask, maxTimeMs: ATTEMPT_BUDGET_MS };
+    const params = { width, height, tiles, continuityBonus, preventBlockages, densityMask, maxTimeMs: ATTEMPT_BUDGET_MS };
 
     let solvedGrid: WfcTile[][] | null = null;
     let timedOut = 0;
@@ -104,7 +102,7 @@ self.onmessage = async (e: MessageEvent<WfcWorkerInput>) => {
             : `All ${MAX_RETRIES} attempts ran out of options — the constraints are unsatisfiable for this setup.`;
       self.postMessage({
         success: false,
-        error: `Generation failed. ${detail} Try a smaller grid, lower density, or relax constraints.`,
+        error: `Generation failed. ${detail} Try a smaller grid, a sparser mask, or relax constraints.`,
       } satisfies WfcWorkerOutput);
       return;
     }


### PR DESCRIPTION
### Description

Replaces the WFC density sliders / mask-upload in the builder wizard with an in-dialog **pixel editor**: you draw the density mask directly on a canvas (left-click paints at the brush density, right-click erases). The WFC engine now uses the drawn per-cell mask as its only density source — the global/edge density inputs are gone.

Also tidies up the wizard: the terrain-paint step shows the **whole map** with a transparency checkerboard (border hugs the map), every wizard screen is the **same width and height**, the editor fits its space so the dialog never scrolls, and the close (X) button dismisses the wizard instead of stepping back.

Commits are atomic: `buildDefaultMask` helper → engine mask-only refactor → the editor + wizard → terrain preview.

### Manual check

- Open the Builder and start the wizard (the icon next to "Terrain"), pick **Autogenerate map**
- [ ] On **Generate wallmask**, left-click draws on the mask, right-click erases, and the density slider sets the brush darkness
- [ ] Changing Width/Height resets the mask to the default pattern; the dialog shows no scrollbars even for a tall map (e.g. 10×25)
- [ ] The close (X) dismisses the wizard; **Back** returns to the previous step with the drawing preserved
- [ ] **Next** → terrain paint shows the entire map with a checkerboard behind transparent areas; clicking a zone selects it
- [ ] The choose / wallmask / paint / manual screens are all the same width and height
- Worth checking in Firefox (several layout fixes were Firefox-specific)