### PR TITLE
Builder UI cleanup: build dialog, preview title row, download icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ public/sfx/original
 public/sfx/original_done
 docs/superpowers
 .playwright-mcp
+
+.superpowers/

--- a/src/components/molecules/BuildDialog.vue
+++ b/src/components/molecules/BuildDialog.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import Dialog from "./Dialog.vue";
+import Input from "../atoms/Input.vue";
+import { useMapDraft } from "../../data/builder/draft";
+
+const { open, onClose } = defineProps<{
+  open: boolean;
+  onClose: () => void;
+}>();
+
+const { name, build } = useMapDraft();
+const localName = ref(name.value);
+
+watch(
+  () => open,
+  (isOpen) => {
+    if (isOpen) {
+      localName.value = name.value;
+    }
+  }
+);
+
+const handleSubmit = () => {
+  name.value = localName.value;
+  build();
+  onClose();
+};
+</script>
+
+<template>
+  <Dialog :open="open" :onClose="onClose" title="Name your map" fitContent>
+    <form class="build-form" @submit.prevent="handleSubmit">
+      <Input label="Name" autofocus v-model="localName" />
+      <button class="primary" type="submit">Build</button>
+    </form>
+  </Dialog>
+</template>
+
+<style lang="scss" scoped>
+.build-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 260px;
+}
+</style>

--- a/src/components/molecules/BuildDialog.vue
+++ b/src/components/molecules/BuildDialog.vue
@@ -2,6 +2,8 @@
 import { ref, watch } from "vue";
 import Dialog from "./Dialog.vue";
 import Input from "../atoms/Input.vue";
+import Collapsible from "../atoms/Collapsible.vue";
+import BuilderDescription from "./BuilderDescription.vue";
 import { useMapDraft } from "../../data/builder/draft";
 
 const { open, onClose, onBuilt } = defineProps<{
@@ -32,18 +34,30 @@ const handleSubmit = () => {
 
 <template>
   <Dialog :open="open" :onClose="onClose" title="Name your map" fitContent>
-    <form class="build-form" @submit.prevent="handleSubmit">
-      <Input label="Name" autofocus v-model="localName" />
-      <button class="primary" type="submit">Build</button>
-    </form>
+    <div class="build-dialog">
+      <form class="build-form" @submit.prevent="handleSubmit">
+        <Input label="Name" autofocus v-model="localName" />
+        <button class="primary" type="submit">Build</button>
+      </form>
+      <Collapsible title="Publishing">
+        <BuilderDescription topic="publishing" />
+      </Collapsible>
+    </div>
   </Dialog>
 </template>
 
 <style lang="scss" scoped>
+.build-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 360px;
+  max-width: 100%;
+}
+
 .build-form {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  min-width: 260px;
 }
 </style>

--- a/src/components/molecules/BuildDialog.vue
+++ b/src/components/molecules/BuildDialog.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
 import Dialog from "./Dialog.vue";
-import Input from "../atoms/Input.vue";
-import BuilderDescription from "./BuilderDescription.vue";
-import { useMapDraft } from "../../data/builder/draft";
+import BuildForm from "./BuildForm.vue";
 
 const { open, onClose, onBuilt } = defineProps<{
   open: boolean;
@@ -11,21 +8,7 @@ const { open, onClose, onBuilt } = defineProps<{
   onBuilt?: () => void;
 }>();
 
-const { name, build } = useMapDraft();
-const localName = ref(name.value);
-
-watch(
-  () => open,
-  (isOpen) => {
-    if (isOpen) {
-      localName.value = name.value;
-    }
-  }
-);
-
-const handleSubmit = () => {
-  name.value = localName.value;
-  build();
+const handleBuilt = () => {
   onBuilt?.();
   onClose();
 };
@@ -33,13 +16,9 @@ const handleSubmit = () => {
 
 <template>
   <Dialog :open="open" :onClose="onClose" title="Name your map" fitContent>
-    <form class="build-dialog" @submit.prevent="handleSubmit">
-      <div class="description"><BuilderDescription topic="publishing" /></div>
-      <Input label="Name" autofocus v-model="localName" />
-      <div class="actions">
-        <button class="primary" type="submit">Build</button>
-      </div>
-    </form>
+    <div class="build-dialog">
+      <BuildForm :active="open" :onBuilt="handleBuilt" />
+    </div>
   </Dialog>
 </template>
 
@@ -52,17 +31,5 @@ const handleSubmit = () => {
   overflow: auto;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-}
-
-.description img {
-  image-rendering: pixelated;
-  vertical-align: middle;
-}
-
-.actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: auto;
 }
 </style>

--- a/src/components/molecules/BuildDialog.vue
+++ b/src/components/molecules/BuildDialog.vue
@@ -2,7 +2,6 @@
 import { ref, watch } from "vue";
 import Dialog from "./Dialog.vue";
 import Input from "../atoms/Input.vue";
-import Collapsible from "../atoms/Collapsible.vue";
 import BuilderDescription from "./BuilderDescription.vue";
 import { useMapDraft } from "../../data/builder/draft";
 
@@ -34,30 +33,36 @@ const handleSubmit = () => {
 
 <template>
   <Dialog :open="open" :onClose="onClose" title="Name your map" fitContent>
-    <div class="build-dialog">
-      <form class="build-form" @submit.prevent="handleSubmit">
-        <Input label="Name" autofocus v-model="localName" />
+    <form class="build-dialog" @submit.prevent="handleSubmit">
+      <div class="description"><BuilderDescription topic="publishing" /></div>
+      <Input label="Name" autofocus v-model="localName" />
+      <div class="actions">
         <button class="primary" type="submit">Build</button>
-      </form>
-      <Collapsible title="Publishing">
-        <BuilderDescription topic="publishing" />
-      </Collapsible>
-    </div>
+      </div>
+    </form>
   </Dialog>
 </template>
 
 <style lang="scss" scoped>
+/* fixed size so the build dialog matches the wizard screens */
 .build-dialog {
+  width: var(--wizard-body-width);
+  height: var(--wizard-body-height);
+  max-width: 100%;
+  overflow: auto;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  width: 360px;
-  max-width: 100%;
+  gap: 10px;
 }
 
-.build-form {
+.description img {
+  image-rendering: pixelated;
+  vertical-align: middle;
+}
+
+.actions {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
+  justify-content: flex-end;
+  margin-top: auto;
 }
 </style>

--- a/src/components/molecules/BuildDialog.vue
+++ b/src/components/molecules/BuildDialog.vue
@@ -4,9 +4,10 @@ import Dialog from "./Dialog.vue";
 import Input from "../atoms/Input.vue";
 import { useMapDraft } from "../../data/builder/draft";
 
-const { open, onClose } = defineProps<{
+const { open, onClose, onBuilt } = defineProps<{
   open: boolean;
   onClose: () => void;
+  onBuilt?: () => void;
 }>();
 
 const { name, build } = useMapDraft();
@@ -24,6 +25,7 @@ watch(
 const handleSubmit = () => {
   name.value = localName.value;
   build();
+  onBuilt?.();
   onClose();
 };
 </script>

--- a/src/components/molecules/BuildForm.vue
+++ b/src/components/molecules/BuildForm.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import Input from "../atoms/Input.vue";
+import BuilderDescription from "./BuilderDescription.vue";
+import { useMapDraft } from "../../data/builder/draft";
+
+const { active, onBack, onBuilt } = defineProps<{
+  // becomes true when the form is shown; (re)seeds the name from the draft
+  active: boolean;
+  onBack?: () => void;
+  onBuilt?: () => void;
+}>();
+
+const { name, build } = useMapDraft();
+const localName = ref(name.value);
+
+watch(
+  () => active,
+  (isActive) => {
+    if (isActive) localName.value = name.value;
+  },
+  { immediate: true }
+);
+
+const handleSubmit = () => {
+  name.value = localName.value;
+  build();
+  onBuilt?.();
+};
+</script>
+
+<template>
+  <form class="build-form" @submit.prevent="handleSubmit">
+    <div class="description"><BuilderDescription topic="publishing" /></div>
+    <Input label="Name" autofocus v-model="localName" />
+    <div class="actions">
+      <button v-if="onBack" type="button" class="secondary" @click="onBack">
+        Back
+      </button>
+      <button class="primary" type="submit">Build</button>
+    </div>
+  </form>
+</template>
+
+<style lang="scss" scoped>
+.build-form {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.description img {
+  image-rendering: pixelated;
+  vertical-align: middle;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: auto;
+
+  // back button (when present) pinned left, build to the right
+  .secondary {
+    margin-right: auto;
+  }
+}
+</style>

--- a/src/components/molecules/Dialog.vue
+++ b/src/components/molecules/Dialog.vue
@@ -12,6 +12,8 @@ const props = defineProps<{
   // seamless: no own backdrop dim / scale-in, for when a parent already provides
   // a constant backdrop (e.g. the builder wizard) so screens don't double-dim or pop
   seamless?: boolean;
+  // fitContent: let the dialog size to its content (no inner scroller / scrollbar)
+  fitContent?: boolean;
 }>();
 
 const slots = defineSlots<{
@@ -67,7 +69,7 @@ watch(
           <h2>{{ props.title }}</h2>
           <IconButton title="Close" :onClick="$props.onClose" :icon="close" />
         </div>
-        <div class="scroller">
+        <div :class="{ scroller: true, 'scroller--fit': props.fitContent }">
           <slot name="default"></slot>
         </div>
       </TornPanel>
@@ -146,6 +148,11 @@ dialog {
 
       display: flex;
       flex-direction: column;
+
+      &--fit {
+        max-height: none;
+        overflow: visible;
+      }
     }
   }
 }

--- a/src/components/molecules/ImageInput.vue
+++ b/src/components/molecules/ImageInput.vue
@@ -3,6 +3,7 @@ import { ref } from "vue";
 import eye from "pixelarticons/svg/eye.svg";
 import eyeClosed from "pixelarticons/svg/eye-off.svg";
 import close from "pixelarticons/svg/close.svg";
+import download from "pixelarticons/svg/download.svg";
 import IconButton from "../atoms/IconButton.vue";
 
 const {
@@ -69,6 +70,13 @@ const handleClear = () => {
   }
 };
 
+const handleDownload = () => {
+  const link = document.createElement("a");
+  link.href = modelValue;
+  link.download = `${name}.png`;
+  link.click();
+};
+
 function handleDrop(event: DragEvent) {
   event.preventDefault();
 
@@ -107,6 +115,11 @@ function handleDragLeave() {
           :icon="visible ? eye : eyeClosed"
           :hoverIcon="visible ? eyeClosed : eye"
           :title="visible ? 'Hide' : 'Show'"
+        />
+        <IconButton
+          :onClick="handleDownload"
+          :icon="download"
+          title="Download"
         />
         <IconButton
           v-if="clearable"

--- a/src/components/organisms/AiAlignDialog.vue
+++ b/src/components/organisms/AiAlignDialog.vue
@@ -9,13 +9,16 @@ const PREVIEW_SCALE = 6;
 const props = defineProps<{
   maskSrc: string;
   aiSrc: string;
-  onConfirm: (result: {
-    terrain: string;
-    background: string;
-    mask: string;
-    width: number;
-    height: number;
-  }) => void;
+  onConfirm: (
+    result: {
+      terrain: string;
+      background: string;
+      mask: string;
+      width: number;
+      height: number;
+    },
+    action: "build" | "continue"
+  ) => void;
   onClose: () => void;
 }>();
 
@@ -97,7 +100,7 @@ watch(
   { immediate: true }
 );
 
-function handleConfirm() {
+function handleConfirm(action: "build" | "continue") {
   const mi = maskImg.value;
   const ai = aiImg.value;
   if (!mi || !ai) return;
@@ -208,7 +211,7 @@ function handleConfirm() {
     bgCanvas.convertToBlob({ type: "image/webp", quality: WEBP_QUALITY }).then(blobToDataUrl),
     maskCanvas.convertToBlob({ type: "image/png" }).then(blobToDataUrl),
   ]).then(([terrain, background, mask]) => {
-    props.onConfirm({ terrain, background, mask, width: cropW, height: cropH });
+    props.onConfirm({ terrain, background, mask, width: cropW, height: cropH }, action);
   });
 }
 </script>
@@ -261,7 +264,10 @@ function handleConfirm() {
 
       <div class="actions">
         <button class="secondary" @click="onClose">Back</button>
-        <button class="primary" @click="handleConfirm">Next</button>
+        <button class="primary" @click="handleConfirm('build')">Build</button>
+        <button class="primary" @click="handleConfirm('continue')">
+          Continue in builder
+        </button>
       </div>
     </div>
   </Dialog>

--- a/src/components/organisms/BuilderSettings.vue
+++ b/src/components/organisms/BuilderSettings.vue
@@ -29,7 +29,7 @@ const handleClose = () => {
 </script>
 
 <template>
-  <Dialog open :onClose="handleClose" title="Advanced settings">
+  <Dialog open :onClose="handleClose" title="Advanced settings" fitContent>
     <div class="inputs">
       <Input label="Scale" autofocus v-model="settings.scale" :min="1" />
       <span></span>
@@ -92,6 +92,13 @@ const handleClose = () => {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
+
+  :deep(input),
+  select {
+    box-sizing: border-box;
+    min-width: 0;
+    max-width: 100%;
+  }
 }
 
 label {

--- a/src/components/organisms/BuilderWizard.vue
+++ b/src/components/organisms/BuilderWizard.vue
@@ -9,6 +9,7 @@ import AiAlignDialog from "./AiAlignDialog.vue";
 import MapSelect from "./MapSelect.vue";
 import ImageInput from "../molecules/ImageInput.vue";
 import BuilderDescription from "../molecules/BuilderDescription.vue";
+import BuildDialog from "../molecules/BuildDialog.vue";
 import Collapsible from "../atoms/Collapsible.vue";
 import TornPanel from "../atoms/TornPanel.vue";
 import IconButton from "../atoms/IconButton.vue";
@@ -63,6 +64,8 @@ const handleWfcGenerated = (maskData: string, ladders: LadderInfo[]) => {
   draft.applyWfc(maskData, ladders);
   next();
 };
+
+const buildOpen = ref(false);
 
 const wfcGenerating = ref(false);
 const wfcError = ref("");
@@ -176,8 +179,7 @@ const handleLoad = (config: Config, name: string) => {
 };
 
 const handleBuild = () => {
-  draft.build();
-  closeWizard();
+  buildOpen.value = true;
 };
 
 const handleKeydown = (e: KeyboardEvent) => {
@@ -330,6 +332,7 @@ onUnmounted(() => {
       :onConfirm="handleAiAlignConfirm"
       :onClose="() => (showAiAlign = false)"
     />
+    <BuildDialog :open="buildOpen" :onClose="() => (buildOpen = false)" />
   </template>
 </template>
 

--- a/src/components/organisms/BuilderWizard.vue
+++ b/src/components/organisms/BuilderWizard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useRouter } from "vue-router";
 import { useBuilderWizard } from "../pages/composables/useBuilderWizard";
 import { useMapDraft } from "../../data/builder/draft";
@@ -9,7 +9,7 @@ import AiAlignDialog from "./AiAlignDialog.vue";
 import MapSelect from "./MapSelect.vue";
 import ImageInput from "../molecules/ImageInput.vue";
 import BuilderDescription from "../molecules/BuilderDescription.vue";
-import Input from "../atoms/Input.vue";
+import BuildForm from "../molecules/BuildForm.vue";
 import Collapsible from "../atoms/Collapsible.vue";
 import TornPanel from "../atoms/TornPanel.vue";
 import IconButton from "../atoms/IconButton.vue";
@@ -189,17 +189,6 @@ const handleLoad = (config: Config, name: string) => {
   goToBuilder();
 };
 
-const buildName = ref("");
-watch(screen, (s) => {
-  if (s === "build") buildName.value = draft.name.value;
-});
-
-const handleBuildSubmit = () => {
-  draft.name.value = buildName.value;
-  draft.build();
-  closeWizard();
-};
-
 const handleKeydown = (e: KeyboardEvent) => {
   if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
   if (
@@ -339,16 +328,12 @@ onUnmounted(() => {
               </div>
             </template>
 
-            <template v-else-if="screen === 'build'">
-              <form class="build-screen" @submit.prevent="handleBuildSubmit">
-                <div class="description"><BuilderDescription topic="publishing" /></div>
-                <Input label="Name" autofocus v-model="buildName" />
-                <div class="actions">
-                  <button type="button" class="secondary" @click="goBack">Back</button>
-                  <button type="submit" class="primary">Build</button>
-                </div>
-              </form>
-            </template>
+            <BuildForm
+              v-else-if="screen === 'build'"
+              :active="screen === 'build'"
+              :onBack="goBack"
+              :onBuilt="closeWizard"
+            />
           </div>
         </TornPanel>
       </div>
@@ -505,13 +490,6 @@ onUnmounted(() => {
 }
 
 .description img { image-rendering: pixelated; vertical-align: middle; }
-
-.build-screen {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
 
 .advanced-scroll {
   max-height: 240px;

--- a/src/components/organisms/BuilderWizard.vue
+++ b/src/components/organisms/BuilderWizard.vue
@@ -29,7 +29,6 @@ const draft = useMapDraft();
 const TITLES: Partial<Record<string, string>> = {
   choose: "Create a map",
   "autoTerrain-preview": "Add terrain",
-  "autoTerrain-advanced": "Finalize map",
   "manual-terrain": "Add your terrain",
   "manual-background": "Add a background",
   "manual-advanced": "Finalize map",
@@ -149,12 +148,19 @@ const handleAiFile = (event: Event) => {
   reader.readAsDataURL(file);
   (event.target as HTMLInputElement).value = "";
 };
-const handleAiAlignConfirm = (result: {
-  terrain: string; background: string; mask: string; width: number; height: number;
-}) => {
+const handleAiAlignConfirm = (
+  result: {
+    terrain: string; background: string; mask: string; width: number; height: number;
+  },
+  action: "build" | "continue"
+) => {
   draft.applyAiAlign(result);
   showAiAlign.value = false;
-  next();
+  if (action === "build") {
+    next();
+  } else {
+    goToBuilder();
+  }
 };
 
 const handleAddTerrain = (_: File, data: string) => {
@@ -314,12 +320,7 @@ onUnmounted(() => {
               </div>
             </template>
 
-            <template
-              v-else-if="
-                screen === 'manual-advanced' ||
-                screen === 'autoTerrain-advanced'
-              "
-            >
+            <template v-else-if="screen === 'manual-advanced'">
               <Collapsible title="Advanced settings">
                 <div class="advanced-scroll">
                   <div class="description">

--- a/src/components/organisms/BuilderWizard.vue
+++ b/src/components/organisms/BuilderWizard.vue
@@ -29,7 +29,6 @@ const draft = useMapDraft();
 const TITLES: Partial<Record<string, string>> = {
   choose: "Create a map",
   "autoTerrain-preview": "Add terrain",
-  "autoMap-advanced": "Finalize map",
   "autoTerrain-advanced": "Finalize map",
   "manual-terrain": "Add your terrain",
   "manual-background": "Add a background",
@@ -168,11 +167,16 @@ const handleAddBackground = (_: File, data: string) => {
   next();
 };
 
-const handlePaintConfirm = (result: {
-  terrain: string; background: string; width: number; height: number;
-}) => {
+const handlePaintConfirm = (
+  result: { terrain: string; background: string; width: number; height: number },
+  action: "build" | "continue"
+) => {
   draft.applyPaint(result);
-  next();
+  if (action === "build") {
+    buildOpen.value = true;
+  } else {
+    goToBuilder();
+  }
 };
 
 const handleLoad = (config: Config, name: string) => {
@@ -307,7 +311,6 @@ onUnmounted(() => {
             <template
               v-else-if="
                 screen === 'manual-advanced' ||
-                screen === 'autoMap-advanced' ||
                 screen === 'autoTerrain-advanced'
               "
             >

--- a/src/components/organisms/BuilderWizard.vue
+++ b/src/components/organisms/BuilderWizard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useBuilderWizard } from "../pages/composables/useBuilderWizard";
 import { useMapDraft } from "../../data/builder/draft";
@@ -9,7 +9,7 @@ import AiAlignDialog from "./AiAlignDialog.vue";
 import MapSelect from "./MapSelect.vue";
 import ImageInput from "../molecules/ImageInput.vue";
 import BuilderDescription from "../molecules/BuilderDescription.vue";
-import BuildDialog from "../molecules/BuildDialog.vue";
+import Input from "../atoms/Input.vue";
 import Collapsible from "../atoms/Collapsible.vue";
 import TornPanel from "../atoms/TornPanel.vue";
 import IconButton from "../atoms/IconButton.vue";
@@ -33,6 +33,7 @@ const TITLES: Partial<Record<string, string>> = {
   "manual-terrain": "Add your terrain",
   "manual-background": "Add a background",
   "manual-advanced": "Finalize map",
+  build: "Name your map",
 };
 const title = computed(() => TITLES[screen.value] ?? "");
 
@@ -65,8 +66,6 @@ const handleWfcGenerated = (maskData: string, ladders: LadderInfo[]) => {
   draft.applyWfc(maskData, ladders);
   next();
 };
-
-const buildOpen = ref(false);
 
 const wfcGenerating = ref(false);
 const wfcError = ref("");
@@ -173,7 +172,7 @@ const handlePaintConfirm = (
 ) => {
   draft.applyPaint(result);
   if (action === "build") {
-    buildOpen.value = true;
+    next();
   } else {
     goToBuilder();
   }
@@ -184,8 +183,15 @@ const handleLoad = (config: Config, name: string) => {
   goToBuilder();
 };
 
-const handleBuild = () => {
-  buildOpen.value = true;
+const buildName = ref("");
+watch(screen, (s) => {
+  if (s === "build") buildName.value = draft.name.value;
+});
+
+const handleBuildSubmit = () => {
+  draft.name.value = buildName.value;
+  draft.build();
+  closeWizard();
 };
 
 const handleKeydown = (e: KeyboardEvent) => {
@@ -327,9 +333,20 @@ onUnmounted(() => {
               </Collapsible>
               <div class="actions">
                 <button class="secondary" @click="goBack">Back</button>
-                <button class="primary" @click="handleBuild">Build</button>
+                <button class="primary" @click="next">Build</button>
                 <button class="primary" @click="goToBuilder">Continue in builder</button>
               </div>
+            </template>
+
+            <template v-else-if="screen === 'build'">
+              <form class="build-screen" @submit.prevent="handleBuildSubmit">
+                <div class="description"><BuilderDescription topic="publishing" /></div>
+                <Input label="Name" autofocus v-model="buildName" />
+                <div class="actions">
+                  <button type="button" class="secondary" @click="goBack">Back</button>
+                  <button type="submit" class="primary">Build</button>
+                </div>
+              </form>
             </template>
           </div>
         </TornPanel>
@@ -343,7 +360,6 @@ onUnmounted(() => {
       :onConfirm="handleAiAlignConfirm"
       :onClose="() => (showAiAlign = false)"
     />
-    <BuildDialog :open="buildOpen" :onClose="() => (buildOpen = false)" :onBuilt="closeWizard" />
   </template>
 </template>
 
@@ -488,6 +504,13 @@ onUnmounted(() => {
 }
 
 .description img { image-rendering: pixelated; vertical-align: middle; }
+
+.build-screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
 
 .advanced-scroll {
   max-height: 240px;

--- a/src/components/organisms/BuilderWizard.vue
+++ b/src/components/organisms/BuilderWizard.vue
@@ -332,7 +332,7 @@ onUnmounted(() => {
       :onConfirm="handleAiAlignConfirm"
       :onClose="() => (showAiAlign = false)"
     />
-    <BuildDialog :open="buildOpen" :onClose="() => (buildOpen = false)" />
+    <BuildDialog :open="buildOpen" :onClose="() => (buildOpen = false)" :onBuilt="closeWizard" />
   </template>
 </template>
 

--- a/src/components/organisms/BuilderWizard.vue
+++ b/src/components/organisms/BuilderWizard.vue
@@ -29,6 +29,8 @@ const draft = useMapDraft();
 const TITLES: Partial<Record<string, string>> = {
   choose: "Create a map",
   "autoTerrain-preview": "Add terrain",
+  "autoMap-advanced": "Finalize map",
+  "autoTerrain-advanced": "Finalize map",
   "manual-terrain": "Add your terrain",
   "manual-background": "Add a background",
   "manual-advanced": "Finalize map",
@@ -154,7 +156,7 @@ const handleAiAlignConfirm = (result: {
 }) => {
   draft.applyAiAlign(result);
   showAiAlign.value = false;
-  goToBuilder();
+  next();
 };
 
 const handleAddTerrain = (_: File, data: string) => {
@@ -170,7 +172,7 @@ const handlePaintConfirm = (result: {
   terrain: string; background: string; width: number; height: number;
 }) => {
   draft.applyPaint(result);
-  goToBuilder();
+  next();
 };
 
 const handleLoad = (config: Config, name: string) => {
@@ -302,7 +304,13 @@ onUnmounted(() => {
               </div>
             </template>
 
-            <template v-else-if="screen === 'manual-advanced'">
+            <template
+              v-else-if="
+                screen === 'manual-advanced' ||
+                screen === 'autoMap-advanced' ||
+                screen === 'autoTerrain-advanced'
+              "
+            >
               <Collapsible title="Advanced settings">
                 <div class="advanced-scroll">
                   <div class="description">

--- a/src/components/organisms/TerrainPaintDialog.vue
+++ b/src/components/organisms/TerrainPaintDialog.vue
@@ -14,12 +14,15 @@ const PREVIEW_SCALE = 2;
 const props = defineProps<{
   alphaSrc: string;
   ladders: PlainBBox[];
-  onConfirm: (result: {
-    terrain: string;
-    background: string;
-    width: number;
-    height: number;
-  }) => void;
+  onConfirm: (
+    result: {
+      terrain: string;
+      background: string;
+      width: number;
+      height: number;
+    },
+    action: "build" | "continue"
+  ) => void;
   onClose: () => void;
   onBack: () => void;
 }>();
@@ -179,7 +182,7 @@ const blobToDataUrl = (blob: Blob): Promise<string> =>
     reader.readAsDataURL(blob);
   });
 
-function handleConfirm() {
+function handleConfirm(action: "build" | "continue") {
   const ad = alphaData.value;
   const res = result.value;
   if (!ad || !res || res.zones.length === 0) return;
@@ -192,12 +195,15 @@ function handleConfirm() {
 
   Promise.all([toDataUrl(res.terrain), toDataUrl(res.background)]).then(
     ([terrain, background]) => {
-      props.onConfirm({
-        terrain,
-        background,
-        width: ad.width,
-        height: ad.height,
-      });
+      props.onConfirm(
+        {
+          terrain,
+          background,
+          width: ad.width,
+          height: ad.height,
+        },
+        action
+      );
     }
   );
 }
@@ -237,8 +243,19 @@ function handleConfirm() {
 
       <div class="actions">
         <button class="secondary" @click="onBack">Back</button>
-        <button class="primary" :disabled="zones.length === 0" @click="handleConfirm">
-          Next
+        <button
+          class="primary"
+          :disabled="zones.length === 0"
+          @click="handleConfirm('build')"
+        >
+          Build
+        </button>
+        <button
+          class="primary"
+          :disabled="zones.length === 0"
+          @click="handleConfirm('continue')"
+        >
+          Continue in builder
         </button>
       </div>
     </div>

--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -13,8 +13,6 @@ import plus from "pixelarticons/svg/plus.svg";
 import shuffle from "pixelarticons/svg/shuffle.svg";
 import close from "pixelarticons/svg/close.svg";
 import BuildDialog from "../molecules/BuildDialog.vue";
-import Collapsible from "../atoms/Collapsible.vue";
-import BuilderDescription from "../molecules/BuilderDescription.vue";
 import { useBuilderLayers } from "./composables/useBuilderLayers";
 import { useBuilderLadders } from "./composables/useBuilderLadders";
 import { useBuilderMap } from "./composables/useBuilderMap";
@@ -195,13 +193,6 @@ const handleBBoxChange = (newBBox: BBox) => {
       ref="preview"
       @mousedown="handleCreateLadder"
     >
-      <div v-if="!terrain.data && !background.data && !mask.data" class="description">
-        <div class="section">
-          <Collapsible title="Publishing" defaultOpen>
-            <BuilderDescription topic="publishing" />
-          </Collapsible>
-        </div>
-      </div>
       <img v-if="background.visible" :src="background.data" class="layer" />
       <img v-if="terrain.visible" :src="terrain.data" class="layer" />
       <img v-if="mask.visible" :src="mask.data" class="layer wallmask" />
@@ -406,21 +397,6 @@ const handleBBoxChange = (newBBox: BBox) => {
         .meta {
           display: block;
         }
-      }
-    }
-
-    .description {
-      position: absolute;
-      padding: 20px;
-      max-width: 800px;
-
-      .section {
-        margin-top: 16px;
-      }
-
-      code {
-        font-family: monospace;
-        font-size: 14px;
       }
     }
   }

--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from "vue";
 import { Map, Config, Layer } from "../../data/map";
-import Input from "../atoms/Input.vue";
 import BoundingBox from "../molecules/BoundingBox.vue";
 import { BBox } from "../../data/map/bbox";
 import { useRouter } from "vue-router";
@@ -12,6 +11,8 @@ import ImageInput from "../molecules/ImageInput.vue";
 import IconButton from "../atoms/IconButton.vue";
 import plus from "pixelarticons/svg/plus.svg";
 import shuffle from "pixelarticons/svg/shuffle.svg";
+import close from "pixelarticons/svg/close.svg";
+import BuildDialog from "../molecules/BuildDialog.vue";
 import Collapsible from "../atoms/Collapsible.vue";
 import BuilderDescription from "../molecules/BuilderDescription.vue";
 import { useBuilderLayers } from "./composables/useBuilderLayers";
@@ -30,9 +31,10 @@ const preview = ref<HTMLDivElement>();
 const wizard = useBuilderWizard();
 
 const settingsOpen = ref(false);
+const buildOpen = ref(false);
 
 const {
-  terrain, mask, background, layers, ladders, advancedSettings, name, oldScale,
+  terrain, mask, background, layers, ladders, advancedSettings, oldScale,
 } = useMapDraft();
 
 const {
@@ -44,7 +46,7 @@ const {
 
 const { creatingLadder, handleCreateLadder } = useBuilderLadders(preview);
 
-const { handleBuild, handleTest, loadMap } = useBuilderMap();
+const { handleTest, loadMap } = useBuilderMap();
 
 onMounted(async () => {
   if (config) {
@@ -103,92 +105,90 @@ const handleBBoxChange = (newBBox: BBox) => {
 
 <template>
   <div class="builder" :style="{ '--scale': advancedSettings.scale }">
-    <section class="controls flex-list">
-      <Input label="Name" autofocus v-model="name" />
-      <div class="section">
-        <h2>
-          Terrain
+    <section class="controls">
+      <div class="title-row">
+        <h2>Preview</h2>
+        <span class="title-buttons">
           <IconButton title="Open wizard" :onClick="() => wizard.openLast()" :icon="shuffle" />
-        </h2>
-        <ImageInput
-          name="Terrain"
-          :onAdd="handleAddTerrain"
-          v-model="terrain.data"
-          :onToggleVisibility="handleSetTerrainVisibility"
-          clearable
-        />
-        <div v-if="advancedSettings.customMask" class="mask-row">
-          <ImageInput
-            name="Mask"
-            :onAdd="handleAddMask"
-            v-model="mask.data"
-            :onToggleVisibility="handleSetMaskVisibility"
-            clearable
-            :defaultHidden="!mask.visible"
-          />
-        </div>
-        <ImageInput
-          name="Background"
-          :onAdd="handleAddBackground"
-          v-model="background.data"
-          :onToggleVisibility="handleSetBackgroundVisibility"
-          clearable
-        />
+          <IconButton title="Close" :onClick="() => router.replace('/')" :icon="close" />
+        </span>
       </div>
 
-      <div class="section">
-        <h2>
-          Overlays
-          <IconButton
-            title="Add layer"
-            :onClick="handleAddLayer"
-            :icon="plus"
-          />
-        </h2>
-        <div v-for="(layer, i) in layers" class="section">
+      <div class="controls-scroll">
+        <div class="section">
           <ImageInput
-            :name="`Layer ${i}`"
-            :onClear="() => handleRemoveLayer(i)"
-            v-model="(layer.data as string)"
-            :onToggleVisibility="(visible: boolean) => handleSetLayerVisibility(visible, i)"
+            name="Terrain"
+            :onAdd="handleAddTerrain"
+            v-model="terrain.data"
+            :onToggleVisibility="handleSetTerrainVisibility"
+            clearable
+          />
+          <div v-if="advancedSettings.customMask" class="mask-row">
+            <ImageInput
+              name="Mask"
+              :onAdd="handleAddMask"
+              v-model="mask.data"
+              :onToggleVisibility="handleSetMaskVisibility"
+              clearable
+              :defaultHidden="!mask.visible"
+            />
+          </div>
+          <ImageInput
+            name="Background"
+            :onAdd="handleAddBackground"
+            v-model="background.data"
+            :onToggleVisibility="handleSetBackgroundVisibility"
             clearable
           />
         </div>
-      </div>
 
-      <div class="section">
-        <h2>
-          Ladders {{ ladders.length ? `(${ladders.length})` : "" }}
-          <IconButton
-            title="Add ladder"
-            :onClick="() => (creatingLadder = true)"
-            :icon="plus"
+        <div class="section">
+          <h2>
+            Overlays
+            <IconButton title="Add layer" :onClick="handleAddLayer" :icon="plus" />
+          </h2>
+          <div v-for="(layer, i) in layers" class="section">
+            <ImageInput
+              :name="`Layer ${i}`"
+              :onClear="() => handleRemoveLayer(i)"
+              v-model="(layer.data as string)"
+              :onToggleVisibility="(visible: boolean) => handleSetLayerVisibility(visible, i)"
+              clearable
+            />
+          </div>
+        </div>
+
+        <div class="section">
+          <h2>
+            Ladders {{ ladders.length ? `(${ladders.length})` : "" }}
+            <IconButton
+              title="Add ladder"
+              :onClick="() => (creatingLadder = true)"
+              :icon="plus"
+            />
+          </h2>
+        </div>
+
+        <div class="section">
+          <button class="secondary" @click="settingsOpen = true">
+            Adv. settings
+          </button>
+          <BuilderSettings
+            v-if="settingsOpen"
+            :settings="advancedSettings"
+            :onClose="() => (settingsOpen = false)"
           />
-        </h2>
+        </div>
       </div>
 
-      <div class="section">
-        <button class="secondary" @click="settingsOpen = true">
-          Adv. settings
+      <div class="controls-footer">
+        <button class="primary" title="Build and save map to file system" @click="buildOpen = true">
+          Build
         </button>
-        <BuilderSettings
-          v-if="settingsOpen"
-          :settings="advancedSettings"
-          :onClose="() => (settingsOpen = false)"
-        />
+        <button class="primary" title="Build and test" @click="() => handleTest(onPlay)">
+          Test
+        </button>
       </div>
-
-      <button
-        class="primary"
-        title="Build and save map to file system"
-        @click="handleBuild"
-      >
-        Build
-      </button>
-      <button class="primary" title="Build and test" @click="() => handleTest(onPlay)">
-        Test
-      </button>
-      <button class="secondary" @click="() => router.replace('/')">Back</button>
     </section>
     <section
       :class="{ preview: true, 'add-ladder': creatingLadder }"
@@ -231,6 +231,7 @@ const handleBBoxChange = (newBBox: BBox) => {
       />
     </section>
     <BuilderWizard />
+    <BuildDialog :open="buildOpen" :onClose="() => (buildOpen = false)" />
   </div>
 </template>
 
@@ -249,33 +250,67 @@ const handleBBoxChange = (newBBox: BBox) => {
     width: 200px;
     border-right: 2px solid var(--border-accent);
     box-shadow: 2px 0 0 var(--shadow-hard);
-    padding: 10px;
-    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
 
-    .section {
+    .title-row {
       display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px;
 
-    .mask-row {
-      display: flex;
-      align-items: flex-start;
-      gap: 4px;
+      h2 {
+        margin: 0;
+      }
 
-      > div {
-        flex: 1;
+      .title-buttons {
+        display: flex;
+        gap: 4px;
       }
     }
 
-    > .section + .section {
-      padding-top: 10px;
-      background: repeating-linear-gradient(
-          90deg,
-          var(--border-accent-faint) 0 4px,
-          transparent 4px 8px
-        )
-        top / 100% 2px no-repeat;
+    .controls-scroll {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0 10px 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+
+      .section {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .mask-row {
+        display: flex;
+        align-items: flex-start;
+        gap: 4px;
+
+        > div {
+          flex: 1;
+        }
+      }
+
+      > .section + .section {
+        padding-top: 10px;
+        background: repeating-linear-gradient(
+            90deg,
+            var(--border-accent-faint) 0 4px,
+            transparent 4px 8px
+          )
+          top / 100% 2px no-repeat;
+      }
+    }
+
+    .controls-footer {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 10px;
+      border-top: 2px solid var(--border-accent-faint);
     }
 
     .layer-title {

--- a/src/components/pages/composables/__spec__/useBuilderWizard.spec.ts
+++ b/src/components/pages/composables/__spec__/useBuilderWizard.spec.ts
@@ -31,12 +31,10 @@ describe("useBuilderWizard", () => {
     expect(w.screen.value).toBe("build");
   });
 
-  it("autoTerrain advances wfc -> preview -> advanced -> build and caps there", () => {
+  it("autoTerrain advances wfc -> preview -> build and caps there", () => {
     w.selectPath("autoTerrain");
     w.next();
     expect(w.screen.value).toBe("autoTerrain-preview");
-    w.next();
-    expect(w.screen.value).toBe("autoTerrain-advanced");
     w.next();
     expect(w.screen.value).toBe("build");
     w.next();

--- a/src/components/pages/composables/__spec__/useBuilderWizard.spec.ts
+++ b/src/components/pages/composables/__spec__/useBuilderWizard.spec.ts
@@ -21,14 +21,12 @@ describe("useBuilderWizard", () => {
     expect(w.screen.value).toBe("manual-terrain");
   });
 
-  it("autoMap advances wfc -> paint -> advanced and caps there", () => {
+  it("autoMap advances wfc -> paint and caps there", () => {
     w.selectPath("autoMap");
     w.next();
     expect(w.screen.value).toBe("autoMap-paint");
     w.next();
-    expect(w.screen.value).toBe("autoMap-advanced");
-    w.next();
-    expect(w.screen.value).toBe("autoMap-advanced");
+    expect(w.screen.value).toBe("autoMap-paint");
   });
 
   it("autoTerrain advances wfc -> preview -> advanced and caps there", () => {

--- a/src/components/pages/composables/__spec__/useBuilderWizard.spec.ts
+++ b/src/components/pages/composables/__spec__/useBuilderWizard.spec.ts
@@ -21,12 +21,24 @@ describe("useBuilderWizard", () => {
     expect(w.screen.value).toBe("manual-terrain");
   });
 
-  it("autoTerrain advances wfc -> preview and caps there", () => {
+  it("autoMap advances wfc -> paint -> advanced and caps there", () => {
+    w.selectPath("autoMap");
+    w.next();
+    expect(w.screen.value).toBe("autoMap-paint");
+    w.next();
+    expect(w.screen.value).toBe("autoMap-advanced");
+    w.next();
+    expect(w.screen.value).toBe("autoMap-advanced");
+  });
+
+  it("autoTerrain advances wfc -> preview -> advanced and caps there", () => {
     w.selectPath("autoTerrain");
     w.next();
     expect(w.screen.value).toBe("autoTerrain-preview");
     w.next();
-    expect(w.screen.value).toBe("autoTerrain-preview");
+    expect(w.screen.value).toBe("autoTerrain-advanced");
+    w.next();
+    expect(w.screen.value).toBe("autoTerrain-advanced");
   });
 
   it("advances through the manual path", () => {

--- a/src/components/pages/composables/__spec__/useBuilderWizard.spec.ts
+++ b/src/components/pages/composables/__spec__/useBuilderWizard.spec.ts
@@ -21,22 +21,26 @@ describe("useBuilderWizard", () => {
     expect(w.screen.value).toBe("manual-terrain");
   });
 
-  it("autoMap advances wfc -> paint and caps there", () => {
+  it("autoMap advances wfc -> paint -> build and caps there", () => {
     w.selectPath("autoMap");
     w.next();
     expect(w.screen.value).toBe("autoMap-paint");
     w.next();
-    expect(w.screen.value).toBe("autoMap-paint");
+    expect(w.screen.value).toBe("build");
+    w.next();
+    expect(w.screen.value).toBe("build");
   });
 
-  it("autoTerrain advances wfc -> preview -> advanced and caps there", () => {
+  it("autoTerrain advances wfc -> preview -> advanced -> build and caps there", () => {
     w.selectPath("autoTerrain");
     w.next();
     expect(w.screen.value).toBe("autoTerrain-preview");
     w.next();
     expect(w.screen.value).toBe("autoTerrain-advanced");
     w.next();
-    expect(w.screen.value).toBe("autoTerrain-advanced");
+    expect(w.screen.value).toBe("build");
+    w.next();
+    expect(w.screen.value).toBe("build");
   });
 
   it("advances through the manual path", () => {
@@ -46,7 +50,9 @@ describe("useBuilderWizard", () => {
     w.next();
     expect(w.screen.value).toBe("manual-advanced");
     w.next();
-    expect(w.screen.value).toBe("manual-advanced");
+    expect(w.screen.value).toBe("build");
+    w.next();
+    expect(w.screen.value).toBe("build");
   });
 
   it("back steps within a path then to the chooser, returning false at the chooser", () => {

--- a/src/components/pages/composables/useBuilderMap.ts
+++ b/src/components/pages/composables/useBuilderMap.ts
@@ -5,9 +5,7 @@ import { Team } from "../../../data/team";
 import { defaults, GameSettings } from "../../../util/localStorage/settings";
 
 export function useBuilderMap() {
-  const { toConfig, build, loadConfig } = useMapDraft();
-
-  const handleBuild = () => build();
+  const { toConfig, loadConfig } = useMapDraft();
 
   const handleTest = async (
     onPlay: (key: string, map: Map | Config, settings: GameSettings) => void
@@ -20,5 +18,5 @@ export function useBuilderMap() {
 
   const loadMap = (config: Config, mapName: string) => loadConfig(config, mapName);
 
-  return { handleBuild, handleTest, loadMap };
+  return { handleTest, loadMap };
 }

--- a/src/components/pages/composables/useBuilderWizard.ts
+++ b/src/components/pages/composables/useBuilderWizard.ts
@@ -6,16 +6,18 @@ export type WizardScreen =
   | "choose"
   | "autoMap-wfc"
   | "autoMap-paint"
+  | "autoMap-advanced"
   | "autoTerrain-wfc"
   | "autoTerrain-preview"
+  | "autoTerrain-advanced"
   | "manual-terrain"
   | "manual-background"
   | "manual-advanced";
 
 const SCREENS: Record<WizardPath, WizardScreen[]> = {
   choose: ["choose"],
-  autoMap: ["autoMap-wfc", "autoMap-paint"],
-  autoTerrain: ["autoTerrain-wfc", "autoTerrain-preview"],
+  autoMap: ["autoMap-wfc", "autoMap-paint", "autoMap-advanced"],
+  autoTerrain: ["autoTerrain-wfc", "autoTerrain-preview", "autoTerrain-advanced"],
   manual: ["manual-terrain", "manual-background", "manual-advanced"],
 };
 

--- a/src/components/pages/composables/useBuilderWizard.ts
+++ b/src/components/pages/composables/useBuilderWizard.ts
@@ -8,7 +8,6 @@ export type WizardScreen =
   | "autoMap-paint"
   | "autoTerrain-wfc"
   | "autoTerrain-preview"
-  | "autoTerrain-advanced"
   | "manual-terrain"
   | "manual-background"
   | "manual-advanced"
@@ -17,7 +16,7 @@ export type WizardScreen =
 const SCREENS: Record<WizardPath, WizardScreen[]> = {
   choose: ["choose"],
   autoMap: ["autoMap-wfc", "autoMap-paint", "build"],
-  autoTerrain: ["autoTerrain-wfc", "autoTerrain-preview", "autoTerrain-advanced", "build"],
+  autoTerrain: ["autoTerrain-wfc", "autoTerrain-preview", "build"],
   manual: ["manual-terrain", "manual-background", "manual-advanced", "build"],
 };
 

--- a/src/components/pages/composables/useBuilderWizard.ts
+++ b/src/components/pages/composables/useBuilderWizard.ts
@@ -6,7 +6,6 @@ export type WizardScreen =
   | "choose"
   | "autoMap-wfc"
   | "autoMap-paint"
-  | "autoMap-advanced"
   | "autoTerrain-wfc"
   | "autoTerrain-preview"
   | "autoTerrain-advanced"
@@ -16,7 +15,7 @@ export type WizardScreen =
 
 const SCREENS: Record<WizardPath, WizardScreen[]> = {
   choose: ["choose"],
-  autoMap: ["autoMap-wfc", "autoMap-paint", "autoMap-advanced"],
+  autoMap: ["autoMap-wfc", "autoMap-paint"],
   autoTerrain: ["autoTerrain-wfc", "autoTerrain-preview", "autoTerrain-advanced"],
   manual: ["manual-terrain", "manual-background", "manual-advanced"],
 };

--- a/src/components/pages/composables/useBuilderWizard.ts
+++ b/src/components/pages/composables/useBuilderWizard.ts
@@ -11,13 +11,14 @@ export type WizardScreen =
   | "autoTerrain-advanced"
   | "manual-terrain"
   | "manual-background"
-  | "manual-advanced";
+  | "manual-advanced"
+  | "build";
 
 const SCREENS: Record<WizardPath, WizardScreen[]> = {
   choose: ["choose"],
-  autoMap: ["autoMap-wfc", "autoMap-paint"],
-  autoTerrain: ["autoTerrain-wfc", "autoTerrain-preview", "autoTerrain-advanced"],
-  manual: ["manual-terrain", "manual-background", "manual-advanced"],
+  autoMap: ["autoMap-wfc", "autoMap-paint", "build"],
+  autoTerrain: ["autoTerrain-wfc", "autoTerrain-preview", "autoTerrain-advanced", "build"],
+  manual: ["manual-terrain", "manual-background", "manual-advanced", "build"],
 };
 
 const path = ref<WizardPath>("choose");


### PR DESCRIPTION
### Description

Tidies up the map builder UI:

- Removes the always-on "Name" input; the map name is now entered in a dialog when you click **Build** (both in the builder and the wizard).
- Renames the left panel's top heading to a **Preview** title row containing the wizard (shuffle) icon and a new close (✕) icon; removes the separate **Back** button.
- Pins **Build**/**Test** to the bottom of the panel; the middle scrolls.
- Adds a **download** icon to image inputs (terrain/background/mask/overlays) to re-download an uploaded image.
- Removes the Firefox scrollbars on the **Advanced settings** dialog via a `fitContent` opt-out on the shared `Dialog`.

### Manual check

- Open the builder (main menu > builder)
- [ ] There is no "Name" input; the left panel top row reads "Preview" with a wizard (shuffle) icon and a close (✕) icon, right-aligned
- [ ] Clicking the ✕ returns you to the main menu (the old "Back" button is gone)
- [ ] The middle of the left panel scrolls while the "Preview" title row and the Build/Test footer stay pinned
- Add a terrain (and/or background/mask/overlay) image
- [ ] Each uploaded image shows a download icon; clicking it re-downloads that image
- [ ] Clicking "Build" opens a "Name your map" dialog, prefilled and focused; pressing Enter (or "Build") downloads `<name>.png` and closes the dialog
- Open the wizard and reach its final "Build" button
- [ ] The wizard's "Build" also opens the name dialog, and the wizard closes after building
- Open "Adv. settings"
- [ ] The Advanced settings dialog shows no scrollbars (verify in Firefox)

[Checklist for a thorough manual check](https://teamleader.atlassian.net/wiki/spaces/ENG/pages/3332735012/Manual+check+list)