### PR TITLE
Add mobile touch controls

### DIFF
--- a/src/components/organisms/MobileControls.vue
+++ b/src/components/organisms/MobileControls.vue
@@ -14,12 +14,12 @@ const controller = props.controller as KeyboardController;
 const { showTouchControls } = useTouchDevice();
 const panMode = ref<PanMode>(PanMode.Focused);
 
-const press = (key: Key) => (event: TouchEvent) => {
+const press = (event: TouchEvent, key: Key) => {
   event.preventDefault();
   controller.keyDown(key);
 };
 
-const release = (key: Key) => (event: TouchEvent) => {
+const release = (event: TouchEvent, key: Key) => {
   event.preventDefault();
   controller.keyUp(key);
 };
@@ -79,50 +79,52 @@ onBeforeUnmount(() => {
 
 <template>
   <div v-if="showTouchControls" class="mobile-controls">
-    <div class="dpad">
-      <button
-        class="btn dpad__up"
-        @touchstart="press(Key.W)"
-        @touchend="release(Key.W)"
-        @touchcancel="release(Key.W)"
-      >
-        ▲
-      </button>
-      <button
-        class="btn dpad__left"
-        @touchstart="press(Key.A)"
-        @touchend="release(Key.A)"
-        @touchcancel="release(Key.A)"
-      >
-        ◀
-      </button>
-      <button
-        class="btn dpad__right"
-        @touchstart="press(Key.D)"
-        @touchend="release(Key.D)"
-        @touchcancel="release(Key.D)"
-      >
-        ▶
-      </button>
-      <button
-        class="btn dpad__down"
-        @touchstart="press(Key.S)"
-        @touchend="release(Key.S)"
-        @touchcancel="release(Key.S)"
-      >
-        ▼
-      </button>
-    </div>
+    <div class="cluster">
+      <div class="actions">
+        <button class="btn" @touchstart="toggleSpellbook">book</button>
+        <button
+          class="btn"
+          :class="`btn--pan-${panLabel()}`"
+          @touchstart="cyclePan"
+        >
+          {{ panLabel() }}
+        </button>
+      </div>
 
-    <div class="actions">
-      <button class="btn" @touchstart="toggleSpellbook">book</button>
-      <button
-        class="btn"
-        :class="`btn--pan-${panLabel()}`"
-        @touchstart="cyclePan"
-      >
-        {{ panLabel() }}
-      </button>
+      <div class="dpad">
+        <button
+          class="btn dpad__up"
+          @touchstart="press($event, Key.W)"
+          @touchend="release($event, Key.W)"
+          @touchcancel="release($event, Key.W)"
+        >
+          ▲
+        </button>
+        <button
+          class="btn dpad__left"
+          @touchstart="press($event, Key.A)"
+          @touchend="release($event, Key.A)"
+          @touchcancel="release($event, Key.A)"
+        >
+          ◀
+        </button>
+        <button
+          class="btn dpad__right"
+          @touchstart="press($event, Key.D)"
+          @touchend="release($event, Key.D)"
+          @touchcancel="release($event, Key.D)"
+        >
+          ▶
+        </button>
+        <button
+          class="btn dpad__down"
+          @touchstart="press($event, Key.S)"
+          @touchend="release($event, Key.S)"
+          @touchcancel="release($event, Key.S)"
+        >
+          ▼
+        </button>
+      </div>
     </div>
   </div>
 </template>
@@ -135,23 +137,30 @@ onBeforeUnmount(() => {
   z-index: 10;
 }
 
-.dpad,
-.actions {
+// Anchored bottom-right but offset left to clear the ~225px inventory dock,
+// keeping every control off the bottom-left HUD.
+.cluster {
   position: absolute;
   bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
+  right: calc(env(safe-area-inset-right, 0px) + 240px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  pointer-events: none;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
   pointer-events: none;
 }
 
 .dpad {
-  left: calc(env(safe-area-inset-left, 0px) + 16px);
+  position: relative;
   width: 180px;
   height: 180px;
-}
-
-.actions {
-  right: calc(env(safe-area-inset-right, 0px) + 16px);
-  display: flex;
-  gap: 12px;
+  pointer-events: none;
 }
 
 .btn {

--- a/src/components/organisms/MobileControls.vue
+++ b/src/components/organisms/MobileControls.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeUnmount, ref } from "vue";
+import { onBeforeUnmount, ref, watch } from "vue";
 import { Controller, Key } from "../../data/controller/controller";
 import { KeyboardController } from "../../data/controller/keyboardController";
 import { getLevel } from "../../data/context";
@@ -56,6 +56,16 @@ const panLabel = () => {
       return "focus";
   }
 };
+
+watch(showTouchControls, (visible) => {
+  if (!visible) {
+    controller.keyUp(Key.W);
+    controller.keyUp(Key.A);
+    controller.keyUp(Key.S);
+    controller.keyUp(Key.D);
+    controller.setSuppressTouchCast(false);
+  }
+});
 
 onBeforeUnmount(() => {
   unsubscribeAttach();

--- a/src/components/organisms/MobileControls.vue
+++ b/src/components/organisms/MobileControls.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import { onBeforeUnmount, ref } from "vue";
+import { Controller, Key } from "../../data/controller/controller";
+import { KeyboardController } from "../../data/controller/keyboardController";
+import { getLevel } from "../../data/context";
+import { PanMode } from "../../graphics/cameraTarget";
+import { useTouchDevice } from "../../util/useTouchDevice";
+
+const props = defineProps<{ controller: Controller }>();
+
+// The local player's controller is always a KeyboardController.
+const controller = props.controller as KeyboardController;
+
+const { showTouchControls } = useTouchDevice();
+const panMode = ref<PanMode>(PanMode.Focused);
+
+const press = (key: Key) => (event: TouchEvent) => {
+  event.preventDefault();
+  controller.keyDown(key);
+};
+
+const release = (key: Key) => (event: TouchEvent) => {
+  event.preventDefault();
+  controller.keyUp(key);
+};
+
+const toggleSpellbook = (event: TouchEvent) => {
+  event.preventDefault();
+  controller.keyDown(Key.M2);
+  controller.keyUp(Key.M2);
+};
+
+const cyclePan = (event: TouchEvent) => {
+  event.preventDefault();
+  const camera = getLevel().cameraTarget;
+  panMode.value = camera.cyclePanMode();
+  controller.setSuppressTouchCast(panMode.value !== PanMode.Focused);
+};
+
+const unsubscribeAttach = getLevel().cameraTarget.addAttachListener(
+  (detached) => {
+    if (!detached) {
+      panMode.value = PanMode.Focused;
+      controller.setSuppressTouchCast(false);
+    }
+  }
+);
+
+const panLabel = () => {
+  switch (panMode.value) {
+    case PanMode.Panning:
+      return "pan";
+    case PanMode.Frozen:
+      return "lock";
+    default:
+      return "focus";
+  }
+};
+
+onBeforeUnmount(() => {
+  unsubscribeAttach();
+  controller.keyUp(Key.W);
+  controller.keyUp(Key.A);
+  controller.keyUp(Key.S);
+  controller.keyUp(Key.D);
+  controller.setSuppressTouchCast(false);
+});
+</script>
+
+<template>
+  <div v-if="showTouchControls" class="mobile-controls">
+    <div class="dpad">
+      <button
+        class="btn dpad__up"
+        @touchstart="press(Key.W)"
+        @touchend="release(Key.W)"
+        @touchcancel="release(Key.W)"
+      >
+        ▲
+      </button>
+      <button
+        class="btn dpad__left"
+        @touchstart="press(Key.A)"
+        @touchend="release(Key.A)"
+        @touchcancel="release(Key.A)"
+      >
+        ◀
+      </button>
+      <button
+        class="btn dpad__right"
+        @touchstart="press(Key.D)"
+        @touchend="release(Key.D)"
+        @touchcancel="release(Key.D)"
+      >
+        ▶
+      </button>
+      <button
+        class="btn dpad__down"
+        @touchstart="press(Key.S)"
+        @touchend="release(Key.S)"
+        @touchcancel="release(Key.S)"
+      >
+        ▼
+      </button>
+    </div>
+
+    <div class="actions">
+      <button class="btn" @touchstart="toggleSpellbook">book</button>
+      <button
+        class="btn"
+        :class="`btn--pan-${panLabel()}`"
+        @touchstart="cyclePan"
+      >
+        {{ panLabel() }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.mobile-controls {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.dpad,
+.actions {
+  position: absolute;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
+  pointer-events: none;
+}
+
+.dpad {
+  left: calc(env(safe-area-inset-left, 0px) + 16px);
+  width: 180px;
+  height: 180px;
+}
+
+.actions {
+  right: calc(env(safe-area-inset-right, 0px) + 16px);
+  display: flex;
+  gap: 12px;
+}
+
+.btn {
+  pointer-events: auto;
+  touch-action: none;
+  user-select: none;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  background: rgba(0, 0, 0, 0.35);
+  color: #fff;
+  font-size: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:active {
+    background: rgba(255, 255, 255, 0.3);
+  }
+
+  &--pan-pan {
+    border-color: #6cf;
+  }
+
+  &--pan-lock {
+    border-color: #fc6;
+  }
+}
+
+.dpad__up {
+  position: absolute;
+  top: 0;
+  left: 60px;
+}
+.dpad__left {
+  position: absolute;
+  top: 60px;
+  left: 0;
+}
+.dpad__right {
+  position: absolute;
+  top: 60px;
+  left: 120px;
+}
+.dpad__down {
+  position: absolute;
+  top: 120px;
+  left: 60px;
+}
+</style>

--- a/src/components/pages/Game.vue
+++ b/src/components/pages/Game.vue
@@ -6,6 +6,7 @@ import Hud from "../organisms/Hud.vue";
 import Tutorial from "../organisms/Tutorial.vue";
 import { Map } from "../../data/map";
 import Inventory from "../organisms/Inventory.vue";
+import MobileControls from "../organisms/MobileControls.vue";
 import { Controller, Key } from "../../data/controller/controller";
 import { useRoute, useRouter } from "vue-router";
 import IngameMenu from "../organisms/IngameMenu.vue";
@@ -85,6 +86,7 @@ const setHudState = (open: boolean) => (forceHudOpen.value = open);
       :setInventoryState="setInventoryState"
     />
     <IngameMenu v-if="menuOpen" :onCancel="handleCancel" />
+    <MobileControls v-if="controller" :controller="controller" />
   </div>
 </template>
 

--- a/src/data/controller/__spec__/keyboardController.spec.ts
+++ b/src/data/controller/__spec__/keyboardController.spec.ts
@@ -1,0 +1,82 @@
+import { KeyboardController } from "../keyboardController";
+import { Key, keyMap } from "../controller";
+import { Viewport } from "../../map/viewport";
+
+const fakeTarget = () =>
+  ({
+    scale: { x: 1, y: 1 },
+    left: 0,
+    top: 0,
+    addListener() {},
+    removeListener() {},
+  } as unknown as Viewport);
+
+const touch = (pointerId: number, x: number, y: number) =>
+  ({
+    pointerId,
+    pointerType: "touch",
+    button: 0,
+    global: { x, y },
+  } as any);
+
+const mouse = (x: number, y: number) =>
+  ({
+    pointerId: 1,
+    pointerType: "mouse",
+    button: 0,
+    global: { x, y },
+  } as any);
+
+describe("KeyboardController touch handling", () => {
+  it("synthesizes M1 for a single touch when not suppressed", () => {
+    const kb = new KeyboardController(fakeTarget());
+    (kb as any).handleMouseDown(touch(1, 10, 10));
+    expect(kb.pressedKeys & keyMap[Key.M1]).toBeTruthy();
+  });
+
+  it("does not synthesize M1 for touch while cast is suppressed", () => {
+    const kb = new KeyboardController(fakeTarget());
+    kb.setSuppressTouchCast(true);
+    (kb as any).handleMouseDown(touch(1, 10, 10));
+    expect(kb.pressedKeys & keyMap[Key.M1]).toBeFalsy();
+  });
+
+  it("still synthesizes M1 for a mouse while cast is suppressed (desktop unchanged)", () => {
+    const kb = new KeyboardController(fakeTarget());
+    kb.setSuppressTouchCast(true);
+    (kb as any).handleMouseDown(mouse(10, 10));
+    expect(kb.pressedKeys & keyMap[Key.M1]).toBeTruthy();
+  });
+
+  it("suppresses and clears M1 when a second touch begins (pinch)", () => {
+    const kb = new KeyboardController(fakeTarget());
+    (kb as any).handleMouseDown(touch(1, 0, 0));
+    expect(kb.pressedKeys & keyMap[Key.M1]).toBeTruthy();
+
+    (kb as any).handleMouseDown(touch(2, 100, 0));
+    expect(kb.pressedKeys & keyMap[Key.M1]).toBeFalsy();
+  });
+
+  it("fires pinch listeners with the distance delta", () => {
+    const kb = new KeyboardController(fakeTarget());
+    const deltas: number[] = [];
+    kb.addPinchListener((delta) => deltas.push(delta));
+
+    (kb as any).handleMouseDown(touch(1, 0, 0));
+    (kb as any).handleMouseDown(touch(2, 100, 0)); // initial distance 100
+    (kb as any).handleMouseMove(touch(2, 140, 0)); // distance now 140
+
+    expect(deltas).toContain(40);
+  });
+
+  it("does not fire pinch listeners for a single touch", () => {
+    const kb = new KeyboardController(fakeTarget());
+    const deltas: number[] = [];
+    kb.addPinchListener((delta) => deltas.push(delta));
+
+    (kb as any).handleMouseDown(touch(1, 0, 0));
+    (kb as any).handleMouseMove(touch(1, 50, 0));
+
+    expect(deltas).toHaveLength(0);
+  });
+});

--- a/src/data/controller/keyboardController.ts
+++ b/src/data/controller/keyboardController.ts
@@ -8,6 +8,9 @@ export class KeyboardController implements Controller {
   private mouseY = 0;
   public pressedKeys = 0;
   private touches = 0;
+  private activeTouches = new Map<number, { x: number; y: number }>();
+  private pinchDistance: number | null = null;
+  private suppressTouchCast = false;
 
   private serverKeys = 0;
   private serverMouseX = 0;
@@ -18,6 +21,7 @@ export class KeyboardController implements Controller {
 
   private eventHandlers = new Map<Key, Set<() => void>>();
   private scrollEventHandlers = new Set<(event: FederatedWheelEvent) => void>();
+  private pinchEventHandlers = new Set<(delta: number) => void>();
 
   constructor(private target: Viewport) {
     window.addEventListener("keydown", this.handleKeyDown);
@@ -25,6 +29,7 @@ export class KeyboardController implements Controller {
     this.target.addListener("pointermove", this.handleMouseMove);
     this.target.addListener("pointerdown", this.handleMouseDown);
     this.target.addListener("pointerup", this.handleMouseUp);
+    this.target.addListener("pointerupoutside", this.handleMouseUp);
     this.target.addListener("wheel", this.handleScroll);
     window.addEventListener("contextmenu", this.handleContextMenu);
   }
@@ -40,21 +45,71 @@ export class KeyboardController implements Controller {
   };
 
   private handleMouseMove = (event: FederatedPointerEvent) => {
-    this.mouseMove(
-      event.global.x / this.target.scale.x + this.target.left,
-      event.global.y / this.target.scale.y + this.target.top
-    );
+    const x = event.global.x / this.target.scale.x + this.target.left;
+    const y = event.global.y / this.target.scale.y + this.target.top;
+
+    if (
+      event.pointerType === "touch" &&
+      this.activeTouches.has(event.pointerId)
+    ) {
+      this.activeTouches.set(event.pointerId, {
+        x: event.global.x,
+        y: event.global.y,
+      });
+
+      if (this.activeTouches.size >= 2) {
+        const distance = this.touchDistance();
+        if (this.pinchDistance !== null) {
+          const delta = distance - this.pinchDistance;
+          if (delta !== 0) {
+            this.pinchEventHandlers.forEach((fn) => fn(delta));
+          }
+        }
+        this.pinchDistance = distance;
+        return;
+      }
+    }
+
+    this.mouseMove(x, y);
   };
 
   private handleMouseDown = (event: FederatedPointerEvent) => {
+    const x = event.global.x / this.target.scale.x + this.target.left;
+    const y = event.global.y / this.target.scale.y + this.target.top;
+
+    if (event.pointerType === "touch") {
+      this.activeTouches.set(event.pointerId, {
+        x: event.global.x,
+        y: event.global.y,
+      });
+
+      if (this.activeTouches.size >= 2) {
+        this.pressedKeys &= ~keyMap[Key.M1];
+        this.pinchDistance = this.touchDistance();
+        return;
+      }
+
+      if (this.suppressTouchCast) {
+        this.mouseMove(x, y);
+        return;
+      }
+    }
+
     this.mouseDown(
-      event.global.x / this.target.scale.x + this.target.left,
-      event.global.y / this.target.scale.y + this.target.top,
+      x,
+      y,
       event.button === 0 ? Key.M1 : event.button === 2 ? Key.M2 : Key.M3
     );
   };
 
   private handleMouseUp = (event: FederatedPointerEvent) => {
+    if (event.pointerType === "touch") {
+      this.activeTouches.delete(event.pointerId);
+      if (this.activeTouches.size < 2) {
+        this.pinchDistance = null;
+      }
+    }
+
     this.mouseUp(
       event.global.x / this.target.scale.x + this.target.left,
       event.global.y / this.target.scale.y + this.target.top,
@@ -72,6 +127,7 @@ export class KeyboardController implements Controller {
     this.target.removeListener("pointermove", this.handleMouseMove);
     this.target.removeListener("pointerdown", this.handleMouseDown);
     this.target.removeListener("pointerup", this.handleMouseUp);
+    this.target.removeListener("pointerupoutside", this.handleMouseUp);
     window.removeEventListener("contextmenu", this.handleContextMenu);
   }
 
@@ -155,6 +211,27 @@ export class KeyboardController implements Controller {
 
   removeScrollListener(fn: (event: FederatedWheelEvent) => void) {
     this.scrollEventHandlers.delete(fn);
+  }
+
+  addPinchListener(fn: (delta: number) => void) {
+    this.pinchEventHandlers.add(fn);
+    return () => this.removePinchListener(fn);
+  }
+
+  removePinchListener(fn: (delta: number) => void) {
+    this.pinchEventHandlers.delete(fn);
+  }
+
+  setSuppressTouchCast(value: boolean) {
+    this.suppressTouchCast = value;
+  }
+
+  private touchDistance(): number {
+    const points = [...this.activeTouches.values()];
+    if (points.length < 2) return 0;
+    const dx = points[0].x - points[1].x;
+    const dy = points[0].y - points[1].y;
+    return Math.sqrt(dx * dx + dy * dy);
   }
 
   isMouseDown() {

--- a/src/data/controller/keyboardController.ts
+++ b/src/data/controller/keyboardController.ts
@@ -29,7 +29,7 @@ export class KeyboardController implements Controller {
     this.target.addListener("pointermove", this.handleMouseMove);
     this.target.addListener("pointerdown", this.handleMouseDown);
     this.target.addListener("pointerup", this.handleMouseUp);
-    this.target.addListener("pointerupoutside", this.handleMouseUp);
+    this.target.addListener("pointerupoutside", this.handlePointerUpOutside);
     this.target.addListener("wheel", this.handleScroll);
     window.addEventListener("contextmenu", this.handleContextMenu);
   }
@@ -117,6 +117,21 @@ export class KeyboardController implements Controller {
     );
   };
 
+  private handlePointerUpOutside = (event: FederatedPointerEvent) => {
+    if (event.pointerType !== "touch") return;
+
+    this.activeTouches.delete(event.pointerId);
+    if (this.activeTouches.size < 2) {
+      this.pinchDistance = null;
+    }
+
+    this.mouseUp(
+      event.global.x / this.target.scale.x + this.target.left,
+      event.global.y / this.target.scale.y + this.target.top,
+      event.button === 0 ? Key.M1 : event.button === 2 ? Key.M2 : Key.M3
+    );
+  };
+
   private handleScroll = (event: FederatedWheelEvent) => {
     this.scrollEventHandlers.forEach((fn) => fn(event));
   };
@@ -127,7 +142,7 @@ export class KeyboardController implements Controller {
     this.target.removeListener("pointermove", this.handleMouseMove);
     this.target.removeListener("pointerdown", this.handleMouseDown);
     this.target.removeListener("pointerup", this.handleMouseUp);
-    this.target.removeListener("pointerupoutside", this.handleMouseUp);
+    this.target.removeListener("pointerupoutside", this.handlePointerUpOutside);
     window.removeEventListener("contextmenu", this.handleContextMenu);
   }
 

--- a/src/graphics/__spec__/cameraTarget.spec.ts
+++ b/src/graphics/__spec__/cameraTarget.spec.ts
@@ -1,4 +1,4 @@
-import { CameraTarget } from "../cameraTarget";
+import { CameraTarget, PanMode } from "../cameraTarget";
 import { Viewport } from "../../data/map/viewport";
 import { setGameContext } from "../../data/context";
 import type { Manager } from "../../data/network/manager";
@@ -7,6 +7,9 @@ import { KeyboardController } from "../../data/controller/keyboardController";
 const makeViewport = (worldW = 4000, worldH = 2000, screenW = 1280, screenH = 720) => {
   return new Viewport(screenW, screenH, worldW, worldH, 1);
 };
+
+const fakeViewport = () =>
+  ({ worldWidth: 1000, worldHeight: 1000 } as unknown as Viewport);
 
 const stubController = (mouseX = 0, mouseY = 0) => {
   // A bare-bones stand-in: the camera tick only calls isLocalKeyDown,
@@ -44,6 +47,38 @@ beforeEach(() => {
 
 afterEach(() => {
   setGameContext(null);
+});
+
+describe("CameraTarget pan mode", () => {
+  it("starts focused and attached", () => {
+    const camera = new CameraTarget(fakeViewport());
+    expect(camera.currentPanMode).toBe(PanMode.Focused);
+    expect(camera.isDetached).toBe(false);
+  });
+
+  it("cycles Focused -> Panning -> Frozen -> Focused", () => {
+    const camera = new CameraTarget(fakeViewport());
+
+    expect(camera.cyclePanMode()).toBe(PanMode.Panning);
+    expect(camera.isDetached).toBe(true);
+
+    expect(camera.cyclePanMode()).toBe(PanMode.Frozen);
+    expect(camera.isDetached).toBe(true);
+
+    expect(camera.cyclePanMode()).toBe(PanMode.Focused);
+    expect(camera.isDetached).toBe(false);
+  });
+
+  it("recenter() resets pan mode to Focused", () => {
+    const camera = new CameraTarget(fakeViewport());
+    camera.cyclePanMode();
+    camera.cyclePanMode();
+    expect(camera.currentPanMode).toBe(PanMode.Frozen);
+
+    camera.recenter();
+    expect(camera.currentPanMode).toBe(PanMode.Focused);
+    expect(camera.isDetached).toBe(false);
+  });
 });
 
 describe("CameraTarget", () => {

--- a/src/graphics/__spec__/cameraTarget.spec.ts
+++ b/src/graphics/__spec__/cameraTarget.spec.ts
@@ -19,6 +19,7 @@ const stubController = (mouseX = 0, mouseY = 0) => {
     getLocalMouse: () => [mouseX, mouseY] as [number, number],
     mouseMove: () => {},
     addScrollListener: () => {},
+    addPinchListener: () => () => {},
   };
   return stub as KeyboardController;
 };

--- a/src/graphics/cameraTarget.ts
+++ b/src/graphics/cameraTarget.ts
@@ -8,6 +8,12 @@ import { Viewport } from "../data/map/viewport";
 export type AttachListener = (detached: boolean) => void;
 export type ZoomListener = (scale: number) => void;
 
+export enum PanMode {
+  Focused,
+  Panning,
+  Frozen,
+}
+
 export class CameraTarget {
   private static maxScale = 4;
 
@@ -40,6 +46,7 @@ export class CameraTarget {
   private zoomListeners: ZoomListener[] = [];
   private oldCDown = false;
   private oldMouseDown = false;
+  private panMode = PanMode.Focused;
 
   private get attached() {
     return this._attached;
@@ -117,6 +124,7 @@ export class CameraTarget {
       getManager().self?.activeCharacter?.body.velocity !== 0
     ) {
       this.attached = true;
+      this.panMode = PanMode.Focused;
 
       if (this.target !== getManager().self?.activeCharacter) {
         this.target = getManager().self?.activeCharacter;
@@ -129,7 +137,13 @@ export class CameraTarget {
       this.lastTargetPosition = position;
     }
 
-    if (
+    if (this.panMode === PanMode.Panning) {
+      position = this.controller.getLocalMouse();
+      this.attached = false;
+    } else if (this.panMode === PanMode.Frozen) {
+      position = this.position;
+      this.attached = false;
+    } else if (
       this.controller.isLocalKeyDown(Key.Control) ||
       this.controller.isLocalKeyDown(Key.M3)
     ) {
@@ -250,6 +264,29 @@ export class CameraTarget {
   recenter() {
     this.attached = true;
     this.speed = 0;
+    this.panMode = PanMode.Focused;
+  }
+
+  get currentPanMode(): PanMode {
+    return this.panMode;
+  }
+
+  cyclePanMode(): PanMode {
+    switch (this.panMode) {
+      case PanMode.Focused:
+        this.panMode = PanMode.Panning;
+        this.attached = false;
+        break;
+      case PanMode.Panning:
+        this.panMode = PanMode.Frozen;
+        this.speed = 0;
+        break;
+      default:
+        this.recenter();
+        break;
+    }
+
+    return this.panMode;
   }
 
   setTarget(target: Spawnable, callback?: () => void) {

--- a/src/graphics/cameraTarget.ts
+++ b/src/graphics/cameraTarget.ts
@@ -18,6 +18,7 @@ export class CameraTarget {
   private static maxScale = 4;
 
   private static zoomSpeed = 0.01;
+  private static pinchSpeed = 0.01;
   private static maxZoomScale = 10;
   private static highlightDelay = 90;
   private static continueDelay = 120;
@@ -358,6 +359,10 @@ export class CameraTarget {
           : Math.max(-CameraTarget.maxZoomScale, event.deltaY);
 
       zoom(this.scale - zoomDelta * CameraTarget.zoomSpeed);
+    });
+
+    controller.addPinchListener((delta) => {
+      zoom(this.scale + delta * CameraTarget.pinchSpeed);
     });
 
     zoom(this.scale);

--- a/src/util/__spec__/useTouchDevice.spec.ts
+++ b/src/util/__spec__/useTouchDevice.spec.ts
@@ -1,0 +1,37 @@
+import { createTouchDeviceState } from "../useTouchDevice";
+
+describe("createTouchDeviceState", () => {
+  it("defaults to false in a non-touch (jsdom) environment", () => {
+    const { showTouchControls } = createTouchDeviceState();
+    expect(showTouchControls.value).toBe(false);
+  });
+
+  it("shows on a touch pointer and hides on keyboard input", () => {
+    const { showTouchControls, onPointerDown, onKeyDown } =
+      createTouchDeviceState();
+
+    onPointerDown({ pointerType: "touch" } as PointerEvent);
+    expect(showTouchControls.value).toBe(true);
+
+    onKeyDown();
+    expect(showTouchControls.value).toBe(false);
+  });
+
+  it("re-shows on the next touch after a keyboard hide", () => {
+    const { showTouchControls, onPointerDown, onKeyDown } =
+      createTouchDeviceState();
+
+    onPointerDown({ pointerType: "touch" } as PointerEvent);
+    onKeyDown();
+    expect(showTouchControls.value).toBe(false);
+
+    onPointerDown({ pointerType: "touch" } as PointerEvent);
+    expect(showTouchControls.value).toBe(true);
+  });
+
+  it("ignores non-touch pointer events", () => {
+    const { showTouchControls, onPointerDown } = createTouchDeviceState();
+    onPointerDown({ pointerType: "mouse" } as PointerEvent);
+    expect(showTouchControls.value).toBe(false);
+  });
+});

--- a/src/util/useTouchDevice.ts
+++ b/src/util/useTouchDevice.ts
@@ -1,7 +1,8 @@
 import { onMounted, onUnmounted, ref, Ref } from "vue";
 
 function detectInitialTouch(): boolean {
-  return false;
+  if (typeof window === "undefined") return false;
+  return navigator.maxTouchPoints > 0;
 }
 
 export function createTouchDeviceState(): {

--- a/src/util/useTouchDevice.ts
+++ b/src/util/useTouchDevice.ts
@@ -1,0 +1,42 @@
+import { onMounted, onUnmounted, ref, Ref } from "vue";
+
+function detectInitialTouch(): boolean {
+  return false;
+}
+
+export function createTouchDeviceState(): {
+  showTouchControls: Ref<boolean>;
+  onPointerDown: (event: PointerEvent) => void;
+  onKeyDown: () => void;
+} {
+  const showTouchControls = ref(detectInitialTouch());
+
+  const onPointerDown = (event: PointerEvent) => {
+    if (event.pointerType === "touch") {
+      showTouchControls.value = true;
+    }
+  };
+
+  const onKeyDown = () => {
+    showTouchControls.value = false;
+  };
+
+  return { showTouchControls, onPointerDown, onKeyDown };
+}
+
+export function useTouchDevice(): { showTouchControls: Ref<boolean> } {
+  const { showTouchControls, onPointerDown, onKeyDown } =
+    createTouchDeviceState();
+
+  onMounted(() => {
+    window.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("keydown", onKeyDown);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener("pointerdown", onPointerDown);
+    window.removeEventListener("keydown", onKeyDown);
+  });
+
+  return { showTouchControls };
+}


### PR DESCRIPTION
### Description

Adds an on-screen touch control overlay for devices without a keyboard. It appears when a touch is detected and hides on physical-keyboard input (re-showing on the next touch). Six controls: a WASD D-pad, a spellbook toggle, and a three-state pan button (focus → free pan → locked). Aiming/casting stays on direct canvas touch, with two-finger pinch-to-zoom reusing the existing clamped zoom path. Casting is suppressed (touch-only) while panning or pinching so a drag never accidentally fires a spell. All controls sit in one bottom-right cluster, clear of the bottom-left HUD and left of the inventory dock.

Implemented across small, isolated units: a `useTouchDevice` composable (show/hide detection), a `Focused/Panning/Frozen` pan-mode state machine on `CameraTarget`, touch-pointer tracking + pinch detection + touch-scoped cast suppression in `KeyboardController`, and the `MobileControls.vue` overlay. Desktop mouse/keyboard behavior is unchanged.

### Manual check

- [ ] On a touch device (or Chrome touch emulation), the overlay appears; pressing a physical key hides it; a later touch brings it back.
- [ ] D-pad moves/jumps the active character; releasing stops it; switching to a keyboard mid-press does not leave a movement key stuck.
- [ ] Spellbook button opens and closes the spell inventory.
- [ ] Pan button cycles focus → pan → lock → focus; dragging the canvas pans while active; moving the character auto-returns to focus.
- [ ] Two-finger pinch zooms in/out; no spell fires while panning or pinching.
- [ ] Desktop mouse + keyboard play is unaffected.